### PR TITLE
feat: mobile optimization and SEO metadata for digest pages

### DIFF
--- a/src/app/digest/[id]/page.tsx
+++ b/src/app/digest/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
@@ -9,6 +10,46 @@ import { getDigestById } from "@/lib/db";
 
 interface PageProps {
   params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  const digest = await getDigestById(id);
+
+  if (!digest) {
+    return {
+      title: "Digest Not Found | YouTube Digest",
+    };
+  }
+
+  const thumbnailUrl = digest.thumbnailUrl || `https://i.ytimg.com/vi/${digest.videoId}/hqdefault.jpg`;
+  const description = digest.summary.length > 160
+    ? digest.summary.slice(0, 157) + "..."
+    : digest.summary;
+
+  return {
+    title: `${digest.title} | YouTube Digest`,
+    description,
+    openGraph: {
+      title: digest.title,
+      description,
+      type: "article",
+      images: [
+        {
+          url: thumbnailUrl,
+          width: 480,
+          height: 360,
+          alt: digest.title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: digest.title,
+      description,
+      images: [thumbnailUrl],
+    },
+  };
 }
 
 function formatDuration(isoDuration: string | null): string {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,7 +26,7 @@ export default function Home() {
   return (
     <div className="flex flex-col min-h-screen">
       <Header />
-      <main className="flex-1 px-4 py-8">
+      <main className="flex-1 px-4 py-4 md:py-8">
         {digestData ? (
           <DigestResult
             metadata={digestData.metadata}

--- a/src/components/digest-result.tsx
+++ b/src/components/digest-result.tsx
@@ -45,7 +45,7 @@ export function DigestResult({ metadata, digest, onReset }: DigestResultProps) {
   return (
     <article className="max-w-3xl mx-auto">
       {/* New Digest button */}
-      <div className="mb-6">
+      <div className="mb-4 md:mb-6">
         <button
           onClick={onReset}
           className="text-[var(--color-accent)] hover:text-[var(--color-accent-hover)] transition-colors text-sm"
@@ -59,7 +59,7 @@ export function DigestResult({ metadata, digest, onReset }: DigestResultProps) {
         href={`https://youtube.com/watch?v=${metadata.videoId}`}
         target="_blank"
         rel="noopener noreferrer"
-        className="block relative aspect-video rounded-2xl overflow-hidden mb-6 group"
+        className="block relative aspect-video rounded-2xl overflow-hidden mb-4 md:mb-6 group"
       >
         <Image
           src={thumbnailUrl}
@@ -81,7 +81,7 @@ export function DigestResult({ metadata, digest, onReset }: DigestResultProps) {
       </h1>
 
       {/* Meta line */}
-      <div className="flex flex-wrap items-center gap-2 text-[var(--color-text-secondary)] mb-8">
+      <div className="flex flex-wrap items-center gap-2 text-[var(--color-text-secondary)] mb-6 md:mb-8">
         <span>{metadata.channelTitle}</span>
         {metadata.duration && (
           <>
@@ -98,7 +98,7 @@ export function DigestResult({ metadata, digest, onReset }: DigestResultProps) {
       </div>
 
       {/* At a Glance */}
-      <section className="mb-10">
+      <section className="mb-6 md:mb-10">
         <h2 className="font-serif text-xl text-[var(--color-text-primary)] mb-3 pb-2 border-b border-[var(--color-border)]">
           At a Glance
         </h2>
@@ -108,7 +108,7 @@ export function DigestResult({ metadata, digest, onReset }: DigestResultProps) {
       </section>
 
       {/* Sections */}
-      <section className="mb-10">
+      <section className="mb-6 md:mb-10">
         <h2 className="font-serif text-xl text-[var(--color-text-primary)] mb-4 pb-2 border-b border-[var(--color-border)]">
           Sections
         </h2>
@@ -120,7 +120,7 @@ export function DigestResult({ metadata, digest, onReset }: DigestResultProps) {
 
       {/* Links & Resources */}
       {(digest.relatedLinks.length > 0 || digest.otherLinks.length > 0) && (
-        <section className="mb-10">
+        <section className="mb-6 md:mb-10">
           <h2 className="font-serif text-xl text-[var(--color-text-primary)] mb-4 pb-2 border-b border-[var(--color-border)]">
             Links & Resources
           </h2>
@@ -185,7 +185,7 @@ export function DigestResult({ metadata, digest, onReset }: DigestResultProps) {
 
       {/* Tangents */}
       {digest.tangents && digest.tangents.length > 0 && (
-        <section className="mb-10">
+        <section className="mb-6 md:mb-10">
           <h2 className="font-serif text-xl text-[var(--color-text-primary)] mb-4 pb-2 border-b border-[var(--color-border)]">
             Tangents
           </h2>

--- a/src/components/section-accordion.tsx
+++ b/src/components/section-accordion.tsx
@@ -12,16 +12,14 @@ interface SectionAccordionProps {
   videoId: string;
 }
 
-function TimestampRange({
-  start,
-  end,
+function TimestampLink({
+  time,
   videoId
 }: {
-  start: string;
-  end: string;
+  time: string;
   videoId: string;
 }) {
-  const seconds = parseTimestamp(start);
+  const seconds = parseTimestamp(time);
   const url = `https://youtube.com/watch?v=${videoId}&t=${seconds}s`;
 
   return (
@@ -36,7 +34,7 @@ function TimestampRange({
         "transition-colors"
       )}
     >
-      {start} – {end}
+      {time}
     </a>
   );
 }
@@ -53,7 +51,7 @@ export function SectionAccordion({ sections, videoId }: SectionAccordionProps) {
           <AccordionPrimitive.Header>
             <AccordionPrimitive.Trigger
               className={cn(
-                "flex items-center justify-between w-full px-4 py-3",
+                "flex items-center justify-between w-full px-3 py-2 md:px-4 md:py-3",
                 "text-left font-medium text-[var(--color-text-primary)]",
                 "hover:bg-[var(--color-bg-tertiary)] transition-colors",
                 "group"
@@ -63,16 +61,15 @@ export function SectionAccordion({ sections, videoId }: SectionAccordionProps) {
                 <ChevronRight className="w-4 h-4 text-[var(--color-text-tertiary)] transition-transform group-data-[state=open]:rotate-90" />
                 <span>{section.title}</span>
               </div>
-              <TimestampRange
-                start={section.timestampStart}
-                end={section.timestampEnd}
+              <TimestampLink
+                time={section.timestampStart}
                 videoId={videoId}
               />
             </AccordionPrimitive.Trigger>
           </AccordionPrimitive.Header>
 
           <AccordionPrimitive.Content className="overflow-hidden data-[state=open]:animate-slideDown data-[state=closed]:animate-slideUp">
-            <div className="px-4 pb-4 pt-2">
+            <div className="px-3 pb-3 pt-1 md:px-4 md:pb-4 md:pt-2">
               <ul className="space-y-2">
                 {section.keyPoints.map((point, pointIndex) => (
                   <li


### PR DESCRIPTION
## Summary
- Reduce mobile padding throughout UI (tighter spacing on mobile, full spacing on desktop)
- Section headers show only clickable start time instead of full range
- Add dynamic SEO metadata to digest pages (openGraph, Twitter cards)