### PR TITLE
fix: replace youtube-transcript-plus with Supadata API for cloud compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-tooltip": "^1.1.6",
+    "@supadata/js": "^1.3.2",
     "@vercel/postgres": "^0.10.0",
     "@workos-inc/authkit-nextjs": "^2.13.0",
     "ai": "^6.0.39",
@@ -44,7 +45,6 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.4.0",
-    "youtube-transcript-plus": "^1.1.2",
     "zod": "^4.3.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.1.6
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@supadata/js':
+        specifier: ^1.3.2
+        version: 1.3.2
       '@vercel/postgres':
         specifier: ^0.10.0
         version: 0.10.0
@@ -71,9 +74,6 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
-      youtube-transcript-plus:
-        specifier: ^1.1.2
-        version: 1.1.2
       zod:
         specifier: ^4.3.5
         version: 4.3.5
@@ -940,6 +940,10 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@supadata/js@1.3.2':
+    resolution: {integrity: sha512-1jKz27pcjYDKys5spim2z6gy9zkZbAktWf3AohKc1m0iIVSRdOA0xOTBwEArwhZUmkSH1QjOsd7IUdj6NcYxHQ==}
+    engines: {node: '>=18'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1495,6 +1499,9 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cross-fetch@4.1.0:
+    resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2865,10 +2872,6 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  youtube-transcript-plus@1.1.2:
-    resolution: {integrity: sha512-bLlqkA6gVVUorZpcc+THuECXyAwOpnHqW2lOav9g6gGovxAP3FCD8s9GBFVjmSl3cWWwwPPXtG/zY1nD+GvQ7A==}
-    engines: {node: '>=18.0.0'}
-
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
 
@@ -3550,6 +3553,12 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@supadata/js@1.3.2':
+    dependencies:
+      cross-fetch: 4.1.0
+    transitivePeerDependencies:
+      - encoding
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -4143,6 +4152,12 @@ snapshots:
   cookie@0.5.0: {}
 
   cookie@0.7.2: {}
+
+  cross-fetch@4.1.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5784,7 +5799,5 @@ snapshots:
       bufferutil: 4.1.0
 
   yocto-queue@0.1.0: {}
-
-  youtube-transcript-plus@1.1.2: {}
 
   zod@4.3.5: {}


### PR DESCRIPTION
## Summary
- Replaces `youtube-transcript-plus` with `@supadata/js` SDK for fetching YouTube transcripts
- Fixes transcript fetching failing on Vercel due to YouTube blocking cloud provider IPs
- Supadata handles residential IP routing internally, enabling reliable transcript fetching from any deployment environment

## Setup Required
Add `SUPADATA_API_KEY` environment variable:
- Local: Add to `.env.local`
- Vercel: Add in Settings → Environment Variables

Get a free API key at https://supadata.ai (100 transcripts/month free tier)