### PR TITLE
feat: add user-scoped digests with generation caching

### DIFF
--- a/migrations/002_add_user_id.sql
+++ b/migrations/002_add_user_id.sql
@@ -1,0 +1,12 @@
+-- Add user_id column to digests table
+ALTER TABLE digests ADD COLUMN user_id TEXT;
+
+-- Backfill existing digests with a special marker (keeps them as cache sources, not visible to users)
+UPDATE digests SET user_id = '__migrated__' WHERE user_id IS NULL;
+
+-- Make NOT NULL after backfill
+ALTER TABLE digests ALTER COLUMN user_id SET NOT NULL;
+
+-- Create indexes for efficient user-scoped queries
+CREATE INDEX IF NOT EXISTS idx_digests_user_id ON digests(user_id);
+CREATE INDEX IF NOT EXISTS idx_digests_user_video ON digests(user_id, video_id);

--- a/src/app/(app)/digest/[id]/page.tsx
+++ b/src/app/(app)/digest/[id]/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
 import { ExternalLink, ArrowLeft } from "lucide-react";
+import { withAuth } from "@workos-inc/authkit-nextjs";
 import { SectionAccordion } from "@/components/section-accordion";
 import { Timestamp } from "@/components/timestamp";
 import { DeleteDigestButton } from "@/components/delete-digest-button";
@@ -69,8 +70,14 @@ function formatDuration(isoDuration: string | null): string {
 }
 
 export default async function DigestPage({ params }: PageProps) {
+  const { user } = await withAuth();
+
+  if (!user) {
+    redirect("/");
+  }
+
   const { id } = await params;
-  const digest = await getDigestById(id);
+  const digest = await getDigestById(id, user.id);
 
   if (!digest) {
     notFound();

--- a/src/app/(app)/digests/page.tsx
+++ b/src/app/(app)/digests/page.tsx
@@ -1,6 +1,8 @@
 import { Suspense } from "react";
+import { redirect } from "next/navigation";
 import Link from "next/link";
 import { Plus } from "lucide-react";
+import { withAuth } from "@workos-inc/authkit-nextjs";
 import { DigestCard } from "@/components/digest-card";
 import { DigestSearch } from "@/components/digest-search";
 import { getDigests } from "@/lib/db";
@@ -10,8 +12,8 @@ interface PageProps {
   searchParams: Promise<{ search?: string }>;
 }
 
-async function DigestGrid({ search }: { search?: string }) {
-  const { digests, total } = await getDigests({ search, limit: 50 });
+async function DigestGrid({ userId, search }: { userId: string; search?: string }) {
+  const { digests } = await getDigests({ userId, search, limit: 50 });
 
   if (digests.length === 0) {
     return (
@@ -58,8 +60,14 @@ function DigestGridSkeleton() {
 }
 
 export default async function DigestsPage({ searchParams }: PageProps) {
+  const { user } = await withAuth();
+
+  if (!user) {
+    redirect("/");
+  }
+
   const { search } = await searchParams;
-  const { total } = await getDigests({ limit: 1 });
+  const { total } = await getDigests({ userId: user.id, limit: 1 });
 
   return (
     <main className="flex-1 px-4 py-8">
@@ -92,7 +100,7 @@ export default async function DigestsPage({ searchParams }: PageProps) {
 
         {/* Content */}
         <Suspense key={search} fallback={<DigestGridSkeleton />}>
-          <DigestGrid search={search} />
+          <DigestGrid userId={user.id} search={search} />
         </Suspense>
       </div>
     </main>

--- a/src/app/(app)/post-login/page.tsx
+++ b/src/app/(app)/post-login/page.tsx
@@ -1,10 +1,17 @@
 import { redirect } from "next/navigation";
+import { withAuth } from "@workos-inc/authkit-nextjs";
 import { hasDigests } from "@/lib/db";
 
 export const dynamic = "force-dynamic";
 
 export default async function PostLoginPage() {
-  const digestsExist = await hasDigests();
+  const { user } = await withAuth();
+
+  if (!user) {
+    redirect("/");
+  }
+
+  const digestsExist = await hasDigests(user.id);
 
   if (digestsExist) {
     redirect("/digests");

--- a/src/app/api/digest/[id]/regenerate/route.ts
+++ b/src/app/api/digest/[id]/regenerate/route.ts
@@ -40,8 +40,8 @@ export async function POST(
   const stream = new ReadableStream({
     async start(controller) {
       try {
-        // Verify digest exists
-        const existingDigest = await getDigestById(id);
+        // Verify digest exists and belongs to user
+        const existingDigest = await getDigestById(id, user.id);
         if (!existingDigest) {
           controller.enqueue(encoder.encode(createEvent("error", "Digest not found")));
           controller.close();
@@ -67,7 +67,7 @@ export async function POST(
 
         // Step 4: Save
         controller.enqueue(encoder.encode(createEvent("saving", "Saving digest...")));
-        await updateDigest(videoId, metadata, digest);
+        await updateDigest(user.id, id, metadata, digest);
         console.log(`[REGENERATE] Digest updated in database`);
 
         // Complete

--- a/src/app/api/digest/[id]/route.ts
+++ b/src/app/api/digest/[id]/route.ts
@@ -19,7 +19,7 @@ export async function DELETE(
   }
 
   try {
-    const deleted = await deleteDigest(id);
+    const deleted = await deleteDigest(user.id, id);
 
     if (!deleted) {
       return NextResponse.json({ error: "Digest not found" }, { status: 404 });

--- a/src/app/api/digest/route.ts
+++ b/src/app/api/digest/route.ts
@@ -1,9 +1,16 @@
 import { NextRequest } from "next/server";
+import { withAuth } from "@workos-inc/authkit-nextjs";
 import { extractVideoId } from "@/lib/parser";
 import { fetchTranscript } from "@/lib/transcript";
 import { fetchVideoMetadata } from "@/lib/metadata";
 import { generateDigest } from "@/lib/summarize";
-import { saveDigest, getDigestByVideoId, updateDigest } from "@/lib/db";
+import {
+  saveDigest,
+  getDigestByVideoId,
+  updateDigest,
+  findGlobalDigestByVideoId,
+  copyDigestForUser,
+} from "@/lib/db";
 import type { DbDigest } from "@/lib/types";
 
 type Step = "cached" | "metadata" | "transcript" | "analyzing" | "saving" | "complete" | "error";
@@ -21,7 +28,38 @@ function createEvent(step: Step, message: string, data?: unknown) {
   return `data: ${JSON.stringify({ step, message, data })}\n\n`;
 }
 
+function formatDigestResponse(dbDigest: DbDigest) {
+  return {
+    metadata: {
+      videoId: dbDigest.videoId,
+      title: dbDigest.title,
+      channelTitle: dbDigest.channelName,
+      duration: dbDigest.duration,
+      publishedAt: dbDigest.publishedAt,
+      thumbnailUrl: dbDigest.thumbnailUrl,
+    },
+    digest: {
+      summary: dbDigest.summary,
+      sections: dbDigest.sections,
+      tangents: dbDigest.tangents,
+      relatedLinks: dbDigest.relatedLinks,
+      otherLinks: dbDigest.otherLinks,
+    },
+    digestId: dbDigest.id,
+  };
+}
+
 export async function POST(request: NextRequest) {
+  const { user } = await withAuth();
+
+  if (!user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const userId = user.id;
   const encoder = new TextEncoder();
 
   const stream = new ReadableStream({
@@ -42,31 +80,31 @@ export async function POST(request: NextRequest) {
           return;
         }
 
-        // Check for existing cached digest
-        console.log(`[DIGEST] Checking DB for cached digest, videoId: ${videoId}`);
-        const existingDigest = await getDigestByVideoId(videoId);
-        console.log(`[DIGEST] DB result: found=${!!existingDigest}, stale=${existingDigest ? isStale(existingDigest) : 'N/A'}`);
+        // Step 1: Check if user already has this video's digest
+        console.log(`[DIGEST] Checking DB for user's cached digest, userId: ${userId}, videoId: ${videoId}`);
+        const userDigest = await getDigestByVideoId(userId, videoId);
+        console.log(`[DIGEST] User digest result: found=${!!userDigest}, stale=${userDigest ? isStale(userDigest) : 'N/A'}`);
 
-        if (existingDigest && !isStale(existingDigest)) {
-          // Return cached digest immediately
+        if (userDigest && !isStale(userDigest)) {
+          // Return user's cached digest
           controller.enqueue(encoder.encode(createEvent("cached", "Found cached digest")));
-          controller.enqueue(encoder.encode(createEvent("complete", "Done!", {
-            metadata: {
-              videoId: existingDigest.videoId,
-              title: existingDigest.title,
-              channelTitle: existingDigest.channelName,
-              duration: existingDigest.duration,
-              publishedAt: existingDigest.publishedAt,
-              thumbnailUrl: existingDigest.thumbnailUrl,
-            },
-            digest: {
-              summary: existingDigest.summary,
-              sections: existingDigest.sections,
-              tangents: existingDigest.tangents,
-              relatedLinks: existingDigest.relatedLinks,
-              otherLinks: existingDigest.otherLinks,
-            },
-          })));
+          controller.enqueue(encoder.encode(createEvent("complete", "Done!", formatDigestResponse(userDigest))));
+          controller.close();
+          return;
+        }
+
+        // Step 2: Check global cache for any digest of this video
+        console.log(`[DIGEST] Checking global cache for videoId: ${videoId}`);
+        const globalDigest = await findGlobalDigestByVideoId(videoId);
+        console.log(`[DIGEST] Global cache result: found=${!!globalDigest}, stale=${globalDigest ? isStale(globalDigest) : 'N/A'}`);
+
+        if (globalDigest && !isStale(globalDigest)) {
+          // Copy global digest to user
+          controller.enqueue(encoder.encode(createEvent("cached", "Found cached digest")));
+          controller.enqueue(encoder.encode(createEvent("saving", "Adding to your library...")));
+          const copiedDigest = await copyDigestForUser(globalDigest, userId);
+          console.log(`[DIGEST] Copied global digest to user`);
+          controller.enqueue(encoder.encode(createEvent("complete", "Done!", formatDigestResponse(copiedDigest))));
           controller.close();
           return;
         }
@@ -83,43 +121,41 @@ export async function POST(request: NextRequest) {
           return;
         }
 
-        // Step 1: Fetch metadata
+        // Step 3: Fetch metadata
         controller.enqueue(encoder.encode(createEvent("metadata", "Fetching video info...")));
         console.log(`[DIGEST] Fetching metadata for videoId: ${videoId}`);
         const metadata = await fetchVideoMetadata(videoId, youtubeApiKey);
         console.log(`[DIGEST] Metadata fetched successfully: ${metadata.title}`);
 
-        // Step 2: Fetch transcript
+        // Step 4: Fetch transcript
         controller.enqueue(encoder.encode(createEvent("transcript", "Extracting transcript...")));
         console.log(`[DIGEST] Starting transcript fetch for videoId: ${videoId}`);
         const transcript = await fetchTranscript(videoId);
         console.log(`[DIGEST] Transcript fetched successfully: ${transcript.length} entries`);
 
-        // Step 3: Generate digest
+        // Step 5: Generate digest
         controller.enqueue(encoder.encode(createEvent("analyzing", "Analyzing content...")));
         console.log(`[DIGEST] Starting digest generation`);
         const digest = await generateDigest(transcript, metadata, anthropicApiKey);
         console.log(`[DIGEST] Digest generated successfully`);
 
-        // Step 4: Save or update digest
+        // Step 6: Save or update digest
         controller.enqueue(encoder.encode(createEvent("saving", "Saving digest...")));
-        console.log(`[DIGEST] Saving to database, existingDigest: ${!!existingDigest}`);
-        let digestId: string;
-        if (existingDigest) {
+        console.log(`[DIGEST] Saving to database, userDigest: ${!!userDigest}`);
+        let savedDigest: DbDigest;
+        if (userDigest) {
           // Update stale digest
-          const updated = await updateDigest(videoId, metadata, digest);
-          digestId = updated.id;
+          savedDigest = await updateDigest(userId, userDigest.id, metadata, digest);
           console.log(`[DIGEST] Updated existing digest`);
         } else {
           // Save new digest
-          const saved = await saveDigest(metadata, digest);
-          digestId = saved.id;
+          savedDigest = await saveDigest(userId, metadata, digest);
           console.log(`[DIGEST] Saved new digest`);
         }
 
         // Complete
         console.log(`[DIGEST] Process complete!`);
-        controller.enqueue(encoder.encode(createEvent("complete", "Done!", { metadata, digest, digestId })));
+        controller.enqueue(encoder.encode(createEvent("complete", "Done!", formatDigestResponse(savedDigest))));
         controller.close();
       } catch (error) {
         console.error(`[DIGEST] ERROR:`, error);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -63,6 +63,7 @@ export interface DigestResult {
 // Database types
 export interface DbDigest {
   id: string;
+  userId: string;
   videoId: string;
   title: string;
   channelName: string;
@@ -81,6 +82,7 @@ export interface DbDigest {
 
 export interface DigestSummary {
   id: string;
+  userId?: string;
   videoId: string;
   title: string;
   channelName: string;


### PR DESCRIPTION
## Summary
- Add `user_id` column to digests table so each user has their own independent digest library
- Implement generation caching to avoid redundant AI costs when multiple users digest the same video
- Add auth checks to all digest-related API routes and pages

## Changes
- **Migration**: `002_add_user_id.sql` adds user_id column with indexes
- **Database**: Updated all db functions to be user-scoped, added `findGlobalDigestByVideoId` and `copyDigestForUser` for caching
- **API Routes**: Added auth checks and caching flow to digest generation, delete, and regenerate endpoints
- **Pages**: Added auth checks to digests list, digest detail, and post-login pages

## Caching Flow
1. Check if user already has this video's digest -> return cached
2. Check global cache for any user's digest of this video -> copy to user
3. Generate new digest via AI and save with userId

Closes #9