### PR TITLE
docs: restructure README with CLI and web app sub-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,35 @@
-# YouTube Video Digest CLI
+# YouTube Digest
 
-Generate AI-powered summaries from YouTube videos. Transform long-form content into scannable, timestamped markdown documents.
+AI-powered summaries from YouTube videos. Available as a CLI tool or web application. BYOK (bring your own API keys).
 
 ## Features
 
 - **Structured Summaries** - AI-generated topic sections with timestamp ranges and key takeaways
-- **Smart Link Categorization** - Extracts URLs from descriptions/comments and sorts them into "Related" (resources, docs, tools) vs "Other" (social, sponsors)
-- **Tangent Detection** - Off-topic segments (rants, extended sponsor reads) are separated so you know what's there without cluttering the main content
-- **Organized Output** - Files saved to `outputs/{channel}/{title}.md`
+- **Smart Link Categorization** - Extracts URLs from descriptions and sorts them into "Related" (resources, docs, tools) vs "Other" (social, sponsors)
+- **Tangent Detection** - Off-topic segments are separated so you know what's there without cluttering the main content
+- **Clickable Timestamps** - Jump directly to any section in the video
 
-## Setup
+## Getting Started
 
-### 1. Install Dependencies
+### CLI
 
-```bash
-pnpm install
-```
-
-### 2. Configure API Keys
-
-```bash
-cp .env.example .env
-```
-
-Add your keys to `.env`:
-
-- **Anthropic API Key**: https://console.anthropic.com/
-- **YouTube Data API v3 Key**: Enable at https://console.cloud.google.com/ → APIs & Services → YouTube Data API v3
-
-## Usage
+Quick command-line tool for generating digests from any YouTube video. The CLI was the original proof-of-concept for this project and may lag behind the web app in shared functionality.
 
 ```bash
 pnpm digest <youtube-url>
 ```
 
-Supports standard, short, and mobile YouTube URLs.
+[CLI Documentation](docs/CLI.md)
 
-## Output
+### Web Application
 
-Digests are saved to `outputs/{channel-slug}/{title-slug}.md`
+Full-featured web app with user accounts and saved digests.
 
-Each digest includes:
-- Video metadata and a 2-3 sentence "At a Glance" summary
-- Sections table with clickable timestamps
-- Key points for each section (2-4 bullets synthesizing the content)
-- Tangents section (if any off-topic segments detected)
-- Categorized links from the video description
+```bash
+pnpm dev
+```
+
+[Web App Documentation](docs/WEBAPP.md)
 
 ## Requirements
 
@@ -53,19 +37,6 @@ Each digest includes:
 - Anthropic API key
 - YouTube Data API v3 key
 - Videos must have captions enabled
-
-## Roadmap
-
-### Next: Web Application
-- Interactive UI with video embed and clickable timestamps
-- User accounts and saved digests
-- Real-time processing with streaming updates
-- Export options (PDF, Notion, Markdown)
-
-### Future Enhancements
-- Whisper API fallback for videos without captions
-- Batch processing and playlist support
-- Browser extension for one-click processing
 
 ## License
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,51 @@
+# CLI Documentation
+
+Command-line tool for generating YouTube video digests.
+
+## Installation
+
+```bash
+pnpm install
+```
+
+## Configuration
+
+Copy the example environment file and add your API keys:
+
+```bash
+cp .env.example .env
+```
+
+### Required API Keys
+
+| Variable | Description | Get it at |
+|----------|-------------|-----------|
+| `ANTHROPIC_API_KEY` | For AI-powered summarization | [console.anthropic.com](https://console.anthropic.com/) |
+| `YOUTUBE_API_KEY` | For fetching video metadata | [Google Cloud Console](https://console.cloud.google.com/) (enable YouTube Data API v3) |
+
+## Usage
+
+```bash
+pnpm digest <youtube-url>
+```
+
+Supports standard, short, and mobile YouTube URLs:
+- `https://www.youtube.com/watch?v=VIDEO_ID`
+- `https://youtu.be/VIDEO_ID`
+- `https://m.youtube.com/watch?v=VIDEO_ID`
+
+## Output
+
+Digests are saved to `outputs/{channel-slug}/{title-slug}.md`
+
+Each digest includes:
+- Video metadata and a 2-3 sentence "At a Glance" summary
+- Sections table with clickable timestamps
+- Key points for each section (2-4 bullets synthesizing the content)
+- Tangents section (if any off-topic segments detected)
+- Categorized links from the video description
+
+## Requirements
+
+- Node.js 18+
+- Videos must have captions enabled (auto-generated or manual)

--- a/docs/WEBAPP.md
+++ b/docs/WEBAPP.md
@@ -1,0 +1,61 @@
+# Web Application Documentation
+
+Full-featured web app with user accounts and saved digests.
+
+## Quick Start
+
+```bash
+pnpm install
+pnpm dev
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `ANTHROPIC_API_KEY` | For AI-powered summarization |
+| `YOUTUBE_API_KEY` | For fetching video metadata |
+| `DATABASE_URL` | PostgreSQL connection string |
+| `WORKOS_API_KEY` | WorkOS API key |
+| `WORKOS_CLIENT_ID` | WorkOS client ID |
+| `WORKOS_COOKIE_PASSWORD` | 32+ character secret for session encryption |
+| `NEXT_PUBLIC_WORKOS_REDIRECT_URI` | OAuth callback URL (e.g., `http://localhost:3000/callback`) |
+| `SUPADATA_API_KEY` | For transcript fetching in cloud deployments (optional locally) |
+
+### Local Development
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...
+YOUTUBE_API_KEY=AIza...
+DATABASE_URL=postgresql://user:password@localhost:5432/youtube_digest
+WORKOS_API_KEY=sk_test_...
+WORKOS_CLIENT_ID=client_...
+WORKOS_COOKIE_PASSWORD=your-32-character-secret-here...
+NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/callback
+# SUPADATA_API_KEY not needed - uses youtube-transcript-plus locally
+```
+
+### Cloud Deployment
+
+```bash
+# Same as above, plus:
+SUPADATA_API_KEY=sd_...  # Required - YouTube blocks direct requests from cloud IPs
+```
+
+## Transcript Fetching
+
+The app uses different transcript sources based on environment:
+
+- **Local** (no `SUPADATA_API_KEY`): Uses [`youtube-transcript-plus`](https://www.npmjs.com/package/youtube-transcript-plus) - free, no API key needed
+- **Cloud** (with `SUPADATA_API_KEY`): Uses [Supadata API](https://supadata.ai/) - required because YouTube blocks direct requests from cloud IPs
+
+## Features
+
+- **User Accounts** - Save and organize your digests
+- **Digest Caching** - Re-generating a digest for the same video is instant
+- **Clickable Timestamps** - Jump to any point in the video on YouTube
+- **Regenerate** - Re-process any digest with updated AI
+
+## Database Setup
+
+The app uses PostgreSQL. For local development, you can use a local PostgreSQL instance or a service like [Neon](https://neon.tech/) or [Supabase](https://supabase.com/).


### PR DESCRIPTION
## Summary
- Restructures documentation to reflect that YouTube Digest is both a CLI and web app
- Creates `docs/CLI.md` with CLI-specific documentation
- Creates `docs/WEBAPP.md` with web app setup (including local vs cloud transcript fetching)
- Rewrites main README as a concise overview with links to sub-docs
- Adds BYOK note and CLI proof-of-concept disclaimer