### PR TITLE
feat: add youtube-transcript-plus fallback for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,9 @@ ANTHROPIC_API_KEY=sk-ant-...
 # Get yours at: https://console.cloud.google.com/
 # Enable the YouTube Data API v3 in your project
 YOUTUBE_API_KEY=AIza...
+
+# Supadata API Key (Optional)
+# Required for cloud deployments (Vercel, etc.)
+# Leave unset for local development - uses youtube-transcript-plus instead
+# Get yours at: https://supadata.ai/
+SUPADATA_API_KEY=

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.4.0",
+    "youtube-transcript-plus": "^1.1.2",
     "zod": "^4.3.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
+      youtube-transcript-plus:
+        specifier: ^1.1.2
+        version: 1.1.2
       zod:
         specifier: ^4.3.5
         version: 4.3.5
@@ -2871,6 +2874,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  youtube-transcript-plus@1.1.2:
+    resolution: {integrity: sha512-bLlqkA6gVVUorZpcc+THuECXyAwOpnHqW2lOav9g6gGovxAP3FCD8s9GBFVjmSl3cWWwwPPXtG/zY1nD+GvQ7A==}
+    engines: {node: '>=18.0.0'}
 
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
@@ -5799,5 +5806,7 @@ snapshots:
       bufferutil: 4.1.0
 
   yocto-queue@0.1.0: {}
+
+  youtube-transcript-plus@1.1.2: {}
 
   zod@4.3.5: {}


### PR DESCRIPTION
## Summary
- Adds `youtube-transcript-plus` as a fallback for transcript fetching when `SUPADATA_API_KEY` is not set
- Enables zero-config local development (no Supadata API key required)
- Cloud deployments still use Supadata API when the key is configured

Closes #8