### PR TITLE
feat: add public sharing for digests

### DIFF
--- a/migrations/003_add_sharing.sql
+++ b/migrations/003_add_sharing.sql
@@ -1,0 +1,9 @@
+-- Add sharing columns to digests table
+ALTER TABLE digests ADD COLUMN is_shared BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE digests ADD COLUMN slug VARCHAR(255);
+
+-- Unique index on slug (only for non-null slugs)
+CREATE UNIQUE INDEX idx_digests_slug ON digests(slug) WHERE slug IS NOT NULL;
+
+-- Partial index for efficient lookup of shared digests
+CREATE INDEX idx_digests_shared ON digests(id) WHERE is_shared = TRUE;

--- a/src/app/(app)/digest/[id]/page.tsx
+++ b/src/app/(app)/digest/[id]/page.tsx
@@ -8,6 +8,7 @@ import { SectionAccordion } from "@/components/section-accordion";
 import { Timestamp } from "@/components/timestamp";
 import { DeleteDigestButton } from "@/components/delete-digest-button";
 import { RegenerateDigestButton } from "@/components/regenerate-digest-button";
+import { ShareButton } from "@/components/share-button";
 import { getDigestById } from "@/lib/db";
 
 interface PageProps {
@@ -105,6 +106,7 @@ export default async function DigestPage({ params }: PageProps) {
               All digests
             </Link>
             <div className="flex items-center gap-3">
+              <ShareButton digestId={id} isShared={digest.isShared} slug={digest.slug} title={digest.title} />
               <RegenerateDigestButton digestId={id} videoId={digest.videoId} />
               <DeleteDigestButton digestId={id} />
             </div>

--- a/src/app/(public)/not-found.tsx
+++ b/src/app/(public)/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="flex-1 flex items-center justify-center px-4">
+      <div className="text-center">
+        <h1 className="font-serif text-4xl text-[var(--color-text-primary)] mb-4">
+          Page not found
+        </h1>
+        <p className="text-[var(--color-text-secondary)] mb-6">
+          The page you're looking for doesn't exist.
+        </p>
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)] transition-colors"
+        >
+          Go home
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(public)/share/[slug]/page.tsx
+++ b/src/app/(public)/share/[slug]/page.tsx
@@ -1,0 +1,281 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Image from "next/image";
+import Link from "next/link";
+import { ExternalLink, ArrowRight, Youtube } from "lucide-react";
+import { SectionAccordion } from "@/components/section-accordion";
+import { Timestamp } from "@/components/timestamp";
+import { getSharedDigestBySlug } from "@/lib/db";
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const digest = await getSharedDigestBySlug(slug);
+
+  if (!digest) {
+    return {
+      title: "Not Found | YouTube Digest",
+    };
+  }
+
+  const thumbnailUrl = digest.thumbnailUrl || `https://i.ytimg.com/vi/${digest.videoId}/hqdefault.jpg`;
+  const description = digest.summary.length > 160
+    ? digest.summary.slice(0, 157) + "..."
+    : digest.summary;
+
+  return {
+    title: `${digest.title} | YouTube Digest`,
+    description,
+    robots: {
+      index: false,
+      follow: false,
+    },
+    openGraph: {
+      title: digest.title,
+      description,
+      type: "article",
+      images: [
+        {
+          url: thumbnailUrl,
+          width: 480,
+          height: 360,
+          alt: digest.title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: digest.title,
+      description,
+      images: [thumbnailUrl],
+    },
+  };
+}
+
+function formatDuration(isoDuration: string | null): string {
+  if (!isoDuration) return "";
+  const match = isoDuration.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
+  if (!match) return isoDuration;
+
+  const hours = match[1] ? parseInt(match[1]) : 0;
+  const minutes = match[2] ? parseInt(match[2]) : 0;
+  const seconds = match[3] ? parseInt(match[3]) : 0;
+
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+  }
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+export default async function SharedDigestPage({ params }: PageProps) {
+  const { slug } = await params;
+  const digest = await getSharedDigestBySlug(slug);
+
+  if (!digest) {
+    notFound();
+  }
+
+  const thumbnailUrl = digest.thumbnailUrl || `https://i.ytimg.com/vi/${digest.videoId}/hqdefault.jpg`;
+  const publishDate = digest.publishedAt
+    ? new Date(digest.publishedAt).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      })
+    : null;
+
+  return (
+    <main className="flex-1 px-4 py-4">
+      <article className="max-w-3xl mx-auto">
+        {/* Thumbnail */}
+        <a
+          href={`https://youtube.com/watch?v=${digest.videoId}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block relative aspect-video rounded-2xl overflow-hidden mb-6 group"
+        >
+          <Image
+            src={thumbnailUrl}
+            alt={digest.title}
+            fill
+            className="object-cover"
+            priority
+          />
+          <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors flex items-center justify-center">
+            <div className="w-16 h-16 rounded-full bg-black/60 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+              <ExternalLink className="w-6 h-6 text-white" />
+            </div>
+          </div>
+        </a>
+
+        {/* Title */}
+        <h1 className="text-3xl md:text-4xl font-semibold text-[var(--color-text-primary)] mb-3">
+          {digest.title}
+        </h1>
+
+        {/* Meta line */}
+        <div className="flex flex-wrap items-center gap-2 text-[var(--color-text-secondary)] mb-6">
+          <span>{digest.channelName}</span>
+          {digest.duration && (
+            <>
+              <span className="text-[var(--color-text-tertiary)]">•</span>
+              <span>{formatDuration(digest.duration)}</span>
+            </>
+          )}
+          {publishDate && (
+            <>
+              <span className="text-[var(--color-text-tertiary)]">•</span>
+              <span>{publishDate}</span>
+            </>
+          )}
+        </div>
+
+        {/* At a Glance */}
+        <section className="mb-8">
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)] mb-3 pb-2 border-b border-[var(--color-border)]">
+            At a Glance
+          </h2>
+          <p className="text-[var(--color-text-primary)] leading-relaxed">
+            {digest.summary}
+          </p>
+        </section>
+
+        {/* Sections */}
+        <section className="mb-8">
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)] mb-4 pb-2 border-b border-[var(--color-border)]">
+            Sections
+          </h2>
+          <SectionAccordion
+            sections={digest.sections}
+            videoId={digest.videoId}
+            tangents={digest.tangents ?? undefined}
+          />
+        </section>
+
+        {/* Links & Resources */}
+        {(digest.relatedLinks.length > 0 || digest.otherLinks.length > 0) && (
+          <section className="mb-8">
+            <h2 className="text-xl font-semibold text-[var(--color-text-primary)] mb-4 pb-2 border-b border-[var(--color-border)]">
+              Links & Resources
+            </h2>
+
+            {digest.relatedLinks.length > 0 && (
+              <div className="mb-6">
+                <h3 className="font-medium text-[var(--color-text-primary)] mb-3">
+                  From the video
+                </h3>
+                <ul className="space-y-3">
+                  {digest.relatedLinks.map((link, index) => (
+                    <li key={index}>
+                      <a
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group"
+                      >
+                        <span className="font-medium text-[var(--color-accent)] group-hover:text-[var(--color-accent-hover)] transition-colors">
+                          {link.title}
+                        </span>
+                        <span className="text-[var(--color-text-secondary)]">
+                          {" "}
+                          - {link.description}
+                        </span>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {digest.otherLinks.length > 0 && (
+              <div>
+                <h3 className="font-medium text-[var(--color-text-primary)] mb-3">
+                  Other links
+                </h3>
+                <ul className="space-y-3">
+                  {digest.otherLinks.map((link, index) => (
+                    <li key={index}>
+                      <a
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group"
+                      >
+                        <span className="font-medium text-[var(--color-accent)] group-hover:text-[var(--color-accent-hover)] transition-colors">
+                          {link.title}
+                        </span>
+                        <span className="text-[var(--color-text-secondary)]">
+                          {" "}
+                          - {link.description}
+                        </span>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* Tangents */}
+        {digest.tangents && digest.tangents.length > 0 && (
+          <section className="mb-8">
+            <h2 className="text-xl font-semibold text-[var(--color-text-primary)] mb-4 pb-2 border-b border-[var(--color-border)]">
+              Tangents
+            </h2>
+            <ul className="space-y-4">
+              {digest.tangents.map((tangent, index) => (
+                <li
+                  key={index}
+                  id={`tangent-${index}`}
+                  className="p-4 rounded-xl bg-[var(--color-bg-secondary)] border border-[var(--color-border)] scroll-mt-20"
+                >
+                  <div className="flex items-start justify-between gap-4 mb-2">
+                    <span className="font-medium text-[var(--color-text-primary)]">
+                      {tangent.title}
+                    </span>
+                    <div className="flex items-center gap-2 text-sm shrink-0">
+                      <Timestamp
+                        time={tangent.timestampStart}
+                        videoId={digest.videoId}
+                      />
+                      <span className="text-[var(--color-text-tertiary)]">-</span>
+                      <Timestamp
+                        time={tangent.timestampEnd}
+                        videoId={digest.videoId}
+                      />
+                    </div>
+                  </div>
+                  <p className="text-[var(--color-text-secondary)]">
+                    {tangent.summary}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* CTA */}
+        <section className="mt-12 p-6 rounded-2xl bg-[var(--color-bg-secondary)] border border-[var(--color-border)] text-center">
+          <div className="flex items-center justify-center gap-2 mb-3">
+            <Youtube className="w-5 h-5 text-[var(--color-accent)]" />
+            <span className="font-semibold text-[var(--color-text-primary)]">YouTube Digest</span>
+          </div>
+          <p className="text-[var(--color-text-secondary)] mb-4">
+            Create your own AI-powered video digests
+          </p>
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)] transition-colors"
+          >
+            Get Started
+            <ArrowRight className="w-4 h-4" />
+          </Link>
+        </section>
+      </article>
+    </main>
+  );
+}

--- a/src/app/api/digest/[id]/share/route.ts
+++ b/src/app/api/digest/[id]/share/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { toggleDigestSharing } from "@/lib/db";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { user } = await withAuth();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  if (!id) {
+    return NextResponse.json({ error: "Digest ID is required" }, { status: 400 });
+  }
+
+  try {
+    const body = await request.json();
+    const { isShared, title } = body;
+
+    if (typeof isShared !== "boolean") {
+      return NextResponse.json(
+        { error: "isShared must be a boolean" },
+        { status: 400 }
+      );
+    }
+
+    const result = await toggleDigestSharing(user.id, id, isShared, title);
+
+    if (!result) {
+      return NextResponse.json({ error: "Digest not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("[SHARE DIGEST] Error:", error);
+    return NextResponse.json({ error: "Failed to update sharing" }, { status: 500 });
+  }
+}

--- a/src/components/share-button.tsx
+++ b/src/components/share-button.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { Share2, Check, Copy, Link2, Loader2 } from "lucide-react";
+
+interface ShareButtonProps {
+  digestId: string;
+  isShared: boolean;
+  slug: string | null;
+  title: string;
+}
+
+export function ShareButton({ digestId, isShared: initialIsShared, slug: initialSlug, title }: ShareButtonProps) {
+  const [isShared, setIsShared] = useState(initialIsShared);
+  const [slug, setSlug] = useState(initialSlug);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [showPopover, setShowPopover] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const shareUrl = slug ? `${typeof window !== "undefined" ? window.location.origin : ""}/share/${slug}` : "";
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(event.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
+        setShowPopover(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleToggleShare = async () => {
+    setIsUpdating(true);
+    try {
+      const response = await fetch(`/api/digest/${digestId}/share`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ isShared: !isShared, title }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        setIsShared(data.isShared);
+        setSlug(data.slug);
+        if (data.isShared) {
+          setShowPopover(true);
+        }
+      }
+    } catch (error) {
+      console.error("Failed to toggle share:", error);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error("Failed to copy:", error);
+    }
+  };
+
+  const handleButtonClick = () => {
+    if (isShared) {
+      setShowPopover(!showPopover);
+    } else {
+      handleToggleShare();
+    }
+  };
+
+  return (
+    <div className="relative flex items-center">
+      <button
+        ref={buttonRef}
+        onClick={handleButtonClick}
+        disabled={isUpdating}
+        className="inline-flex items-center gap-1 text-[var(--color-text-tertiary)] hover:text-[var(--color-accent)] transition-colors text-sm disabled:opacity-50"
+        title={isShared ? "Manage sharing" : "Share digest"}
+      >
+        {isUpdating ? (
+          <Loader2 className="w-4 h-4 animate-spin" />
+        ) : (
+          <Share2 className={`w-4 h-4 ${isShared ? "text-[var(--color-accent)]" : ""}`} />
+        )}
+      </button>
+
+      {showPopover && isShared && (
+        <div
+          ref={popoverRef}
+          className="absolute right-0 top-full mt-2 w-72 p-3 rounded-xl bg-[var(--color-bg-secondary)] border border-[var(--color-border)] shadow-lg z-10"
+        >
+          <div className="flex items-center gap-2 mb-3">
+            <Link2 className="w-4 h-4 text-[var(--color-accent)]" />
+            <span className="text-sm font-medium text-[var(--color-text-primary)]">
+              Share link
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2 mb-3">
+            <input
+              type="text"
+              readOnly
+              value={shareUrl}
+              className="flex-1 px-3 py-2 text-sm bg-[var(--color-bg-primary)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-primary)] truncate"
+            />
+            <button
+              onClick={handleCopy}
+              className="p-2 rounded-lg bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)] transition-colors shrink-0"
+              title="Copy link"
+            >
+              {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+            </button>
+          </div>
+
+          <button
+            onClick={handleToggleShare}
+            disabled={isUpdating}
+            className="w-full text-sm text-[var(--color-text-secondary)] hover:text-red-500 transition-colors disabled:opacity-50"
+          >
+            {isUpdating ? "Updating..." : "Stop sharing"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -76,6 +76,8 @@ export interface DbDigest {
   tangents: Tangent[] | null;
   relatedLinks: Link[];
   otherLinks: Link[];
+  isShared: boolean;
+  slug: string | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,7 @@ import { authkitMiddleware } from '@workos-inc/authkit-nextjs';
 export default authkitMiddleware({
   middlewareAuth: {
     enabled: true,
-    unauthenticatedPaths: ['/', '/auth', '/callback', '/api/:path*'],
+    unauthenticatedPaths: ['/', '/auth', '/callback', '/api/:path*', '/share/:path*'],
   },
 });
 


### PR DESCRIPTION
## Summary
- Add toggle-based sharing for digests via public URLs (`/share/[slug]`)
- Generate human-readable slugs from digest titles
- Anyone with the link can view shared digests (no auth required)
- Share button in digest action bar with copy-to-clipboard popover

## Changes
- Add `is_shared` and `slug` columns to digests table
- Add share toggle API endpoint (`PATCH /api/digest/[id]/share`)
- Add public share page under `(public)` route group
- Add ShareButton component with popover UI
- Add `/share/:path*` to unauthenticated middleware paths
- Add public not-found page to fix double header issue

Closes #15