### PR TITLE
feat: add email-based allow list for digest generation

### DIFF
--- a/src/app/(app)/digest/[id]/page.tsx
+++ b/src/app/(app)/digest/[id]/page.tsx
@@ -10,6 +10,7 @@ import { DeleteDigestButton } from "@/components/delete-digest-button";
 import { RegenerateDigestButton } from "@/components/regenerate-digest-button";
 import { ShareButton } from "@/components/share-button";
 import { getDigestById } from "@/lib/db";
+import { isEmailAllowed } from "@/lib/access";
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -79,6 +80,7 @@ export default async function DigestPage({ params }: PageProps) {
 
   const { id } = await params;
   const digest = await getDigestById(id, user.id);
+  const canRegenerate = isEmailAllowed(user.email);
 
   if (!digest) {
     notFound();
@@ -107,7 +109,7 @@ export default async function DigestPage({ params }: PageProps) {
             </Link>
             <div className="flex items-center gap-3">
               <ShareButton digestId={id} isShared={digest.isShared} slug={digest.slug} title={digest.title} />
-              <RegenerateDigestButton digestId={id} videoId={digest.videoId} />
+              {canRegenerate && <RegenerateDigestButton digestId={id} videoId={digest.videoId} />}
               <DeleteDigestButton digestId={id} />
             </div>
           </div>

--- a/src/app/(app)/home/page.tsx
+++ b/src/app/(app)/home/page.tsx
@@ -1,27 +1,15 @@
-"use client";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { isEmailAllowed } from "@/lib/access";
+import { HomeContent } from "@/components/home-content";
+import { AccessRestricted } from "@/components/access-restricted";
 
-import { useRouter } from "next/navigation";
-import { UrlInput } from "@/components/url-input";
-import { RecentDigests } from "@/components/recent-digests";
-
-export default function Home() {
-  const router = useRouter();
-
-  const handleDigestComplete = (digestId: string) => {
-    router.push(`/digest/${digestId}`);
-  };
+export default async function Home() {
+  const { user } = await withAuth();
+  const hasAccess = isEmailAllowed(user?.email);
 
   return (
     <main className="flex-1 px-4 py-4 md:py-8">
-      <div className="max-w-2xl mx-auto text-center space-y-6 py-6 md:py-8">
-        <h1 className="text-4xl md:text-5xl text-[var(--color-text-primary)] font-semibold tracking-tight">
-          Your YouTube, indexed
-        </h1>
-
-        <UrlInput onDigestComplete={handleDigestComplete} />
-      </div>
-
-      <RecentDigests />
+      {hasAccess ? <HomeContent /> : <AccessRestricted />}
     </main>
   );
 }

--- a/src/app/api/digest/[id]/regenerate/route.ts
+++ b/src/app/api/digest/[id]/regenerate/route.ts
@@ -3,6 +3,7 @@ import { withAuth } from "@workos-inc/authkit-nextjs";
 import { fetchTranscript } from "@/lib/transcript";
 import { fetchVideoMetadata } from "@/lib/metadata";
 import { generateDigest } from "@/lib/summarize";
+import { isEmailAllowed } from "@/lib/access";
 import { updateDigest, getDigestById } from "@/lib/db";
 
 type Step = "metadata" | "transcript" | "analyzing" | "saving" | "complete" | "error";
@@ -19,6 +20,16 @@ export async function POST(
 
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!isEmailAllowed(user.email)) {
+    return NextResponse.json(
+      {
+        error: "Access restricted",
+        message: "Digest regeneration is currently limited to approved users.",
+      },
+      { status: 403 }
+    );
   }
 
   const { id } = await params;

--- a/src/app/api/digest/route.ts
+++ b/src/app/api/digest/route.ts
@@ -4,6 +4,7 @@ import { extractVideoId } from "@/lib/parser";
 import { fetchTranscript } from "@/lib/transcript";
 import { fetchVideoMetadata } from "@/lib/metadata";
 import { generateDigest } from "@/lib/summarize";
+import { isEmailAllowed } from "@/lib/access";
 import {
   saveDigest,
   getDigestByVideoId,
@@ -57,6 +58,20 @@ export async function POST(request: NextRequest) {
       status: 401,
       headers: { "Content-Type": "application/json" },
     });
+  }
+
+  if (!isEmailAllowed(user.email)) {
+    return new Response(
+      JSON.stringify({
+        error: "Access restricted",
+        message:
+          "Digest generation is currently limited to approved users. Bring Your Own Key (BYOK) support is coming soon!",
+      }),
+      {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
   }
 
   const userId = user.id;

--- a/src/components/access-restricted.tsx
+++ b/src/components/access-restricted.tsx
@@ -1,0 +1,32 @@
+import { Lock } from "lucide-react";
+
+export function AccessRestricted() {
+  return (
+    <div className="max-w-2xl mx-auto text-center space-y-6 py-6 md:py-8">
+      <h1 className="text-4xl md:text-5xl text-[var(--color-text-primary)] font-semibold tracking-tight">
+        Your YouTube, indexed
+      </h1>
+
+      <div className="mt-8 p-6 rounded-xl bg-[var(--color-bg-secondary)] border border-[var(--color-border)]">
+        <div className="flex justify-center mb-4">
+          <div className="p-3 rounded-full bg-[var(--color-bg-tertiary)]">
+            <Lock className="w-6 h-6 text-[var(--color-text-secondary)]" />
+          </div>
+        </div>
+
+        <h2 className="text-xl font-semibold text-[var(--color-text-primary)] mb-2">
+          Coming Soon
+        </h2>
+
+        <p className="text-[var(--color-text-secondary)] mb-4">
+          Digest generation is currently limited to early access users.
+        </p>
+
+        <p className="text-sm text-[var(--color-text-tertiary)]">
+          We&apos;re working on Bring Your Own Key (BYOK) support, which will
+          let you use your own API keys to generate digests. Stay tuned!
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/home-content.tsx
+++ b/src/components/home-content.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { UrlInput } from "@/components/url-input";
+import { RecentDigests } from "@/components/recent-digests";
+
+export function HomeContent() {
+  const router = useRouter();
+
+  const handleDigestComplete = (digestId: string) => {
+    router.push(`/digest/${digestId}`);
+  };
+
+  return (
+    <>
+      <div className="max-w-2xl mx-auto text-center space-y-6 py-6 md:py-8">
+        <h1 className="text-4xl md:text-5xl text-[var(--color-text-primary)] font-semibold tracking-tight">
+          Your YouTube, indexed
+        </h1>
+
+        <UrlInput onDigestComplete={handleDigestComplete} />
+      </div>
+
+      <RecentDigests />
+    </>
+  );
+}

--- a/src/lib/access.ts
+++ b/src/lib/access.ts
@@ -1,0 +1,42 @@
+/**
+ * Email-based access control for digest generation.
+ * Temporary solution until BYOK is implemented.
+ */
+
+const ALLOWED_EMAILS_ENV = process.env.ALLOWED_EMAILS ?? "";
+
+/**
+ * Parse the comma-delimited ALLOWED_EMAILS env var into a Set for O(1) lookups.
+ * Emails are normalized to lowercase and trimmed.
+ */
+function getAllowedEmails(): Set<string> {
+  if (!ALLOWED_EMAILS_ENV) {
+    return new Set();
+  }
+
+  return new Set(
+    ALLOWED_EMAILS_ENV.split(",")
+      .map((email) => email.trim().toLowerCase())
+      .filter((email) => email.length > 0)
+  );
+}
+
+const allowedEmails = getAllowedEmails();
+
+/**
+ * Check if an email is allowed to generate digests.
+ * Returns true only if the email is explicitly in the allow list.
+ * If ALLOWED_EMAILS is not set or empty, no one can generate digests.
+ */
+export function isEmailAllowed(email: string | undefined | null): boolean {
+  if (!email) {
+    return false;
+  }
+
+  // If no allow list is configured, no one is allowed
+  if (allowedEmails.size === 0) {
+    return false;
+  }
+
+  return allowedEmails.has(email.toLowerCase());
+}


### PR DESCRIPTION
## Summary

- Add `ALLOWED_EMAILS` environment variable to restrict digest generation to specific users
- Non-allowed users see a friendly "Coming Soon" message about BYOK support
- Regenerate button hidden for non-allowed users on existing digests
- API routes return 403 for non-allowed users (defense in depth)

Closes #18