### PR TITLE
feat: support creator-supplied chapters with AI fallback

### DIFF
--- a/migrations/005_drop_tangents_column.sql
+++ b/migrations/005_drop_tangents_column.sql
@@ -1,0 +1,4 @@
+-- Drop the tangents column from digests table
+-- Tangents are now stored as isTangent flags on individual KeyPoints within sections
+
+ALTER TABLE digests DROP COLUMN IF EXISTS tangents;

--- a/migrations/006_add_creator_chapters_flag.sql
+++ b/migrations/006_add_creator_chapters_flag.sql
@@ -1,0 +1,4 @@
+-- Add flag to track whether chapters came from creator or were AI-generated
+-- NULL for old digests (unknown), true/false for new ones
+
+ALTER TABLE digests ADD COLUMN IF NOT EXISTS has_creator_chapters BOOLEAN;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "clsx": "^2.1.1",
     "dotenv": "^17.2.3",
     "geist": "^1.5.1",
+    "get-youtube-chapters": "^2.0.0",
     "lucide-react": "^0.468.0",
     "marked": "^11.2.0",
     "marked-terminal": "^6.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       geist:
         specifier: ^1.5.1
         version: 1.5.1(next@16.1.3(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      get-youtube-chapters:
+        specifier: ^2.0.0
+        version: 2.0.0
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@19.2.3)
@@ -1955,6 +1958,10 @@ packages:
 
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+
+  get-youtube-chapters@2.0.0:
+    resolution: {integrity: sha512-eLTF7Eg0zihAxya31Zj1vgtV9GbfSNuWwdGqJxCIEpeRDDSYxJEga3Mf8VW1WPrQBgDeG2lYwV0er5tgvtyzyQ==}
+    engines: {node: '>= 6'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -4989,6 +4996,8 @@ snapshots:
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  get-youtube-chapters@2.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:

--- a/src/app/(app)/digest/[id]/page.tsx
+++ b/src/app/(app)/digest/[id]/page.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { ExternalLink, ArrowLeft } from "lucide-react";
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { SectionAccordion } from "@/components/section-accordion";
-import { Timestamp } from "@/components/timestamp";
 import { DeleteDigestButton } from "@/components/delete-digest-button";
 import { RegenerateDigestButton } from "@/components/regenerate-digest-button";
 import { ShareButton } from "@/components/share-button";
@@ -125,6 +124,7 @@ export default async function DigestPage({ params }: PageProps) {
               src={thumbnailUrl}
               alt={digest.title}
               fill
+              sizes="(max-width: 768px) 100vw, 768px"
               className="object-cover"
               priority
             />
@@ -167,15 +167,19 @@ export default async function DigestPage({ params }: PageProps) {
             </p>
           </section>
 
-          {/* Sections */}
+          {/* Chapters */}
           <section className="mb-8">
             <h2 className="text-xl font-semibold text-[var(--color-text-primary)] mb-4 pb-2 border-b border-[var(--color-border)]">
-              Sections
+              Chapters
+              {digest.hasCreatorChapters !== null && (
+                <span className="text-base font-normal text-[var(--color-text-tertiary)]">
+                  {" "}({digest.hasCreatorChapters ? "supplied by content creator" : "AI-generated"})
+                </span>
+              )}
             </h2>
             <SectionAccordion
               sections={digest.sections}
               videoId={digest.videoId}
-              tangents={digest.tangents ?? undefined}
             />
           </section>
 
@@ -244,43 +248,6 @@ export default async function DigestPage({ params }: PageProps) {
             </section>
           )}
 
-          {/* Tangents */}
-          {digest.tangents && digest.tangents.length > 0 && (
-            <section className="mb-8">
-              <h2 className="text-xl font-semibold text-[var(--color-text-primary)] mb-4 pb-2 border-b border-[var(--color-border)]">
-                Tangents
-              </h2>
-              <ul className="space-y-4">
-                {digest.tangents.map((tangent, index) => (
-                  <li
-                    key={index}
-                    id={`tangent-${index}`}
-                    className="p-4 rounded-xl bg-[var(--color-bg-secondary)] border border-[var(--color-border)] scroll-mt-20"
-                  >
-                    <div className="flex items-start justify-between gap-4 mb-2">
-                      <span className="font-medium text-[var(--color-text-primary)]">
-                        {tangent.title}
-                      </span>
-                      <div className="flex items-center gap-2 text-sm shrink-0">
-                        <Timestamp
-                          time={tangent.timestampStart}
-                          videoId={digest.videoId}
-                        />
-                        <span className="text-[var(--color-text-tertiary)]">-</span>
-                        <Timestamp
-                          time={tangent.timestampEnd}
-                          videoId={digest.videoId}
-                        />
-                      </div>
-                    </div>
-                    <p className="text-[var(--color-text-secondary)]">
-                      {tangent.summary}
-                    </p>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          )}
       </article>
     </main>
   );

--- a/src/app/(public)/share/[slug]/page.tsx
+++ b/src/app/(public)/share/[slug]/page.tsx
@@ -4,7 +4,6 @@ import Image from "next/image";
 import Link from "next/link";
 import { ExternalLink, ArrowRight, Youtube } from "lucide-react";
 import { SectionAccordion } from "@/components/section-accordion";
-import { Timestamp } from "@/components/timestamp";
 import { getSharedDigestBySlug } from "@/lib/db";
 
 interface PageProps {
@@ -101,6 +100,7 @@ export default async function SharedDigestPage({ params }: PageProps) {
             src={thumbnailUrl}
             alt={digest.title}
             fill
+            sizes="(max-width: 768px) 100vw, 768px"
             className="object-cover"
             priority
           />
@@ -143,15 +143,19 @@ export default async function SharedDigestPage({ params }: PageProps) {
           </p>
         </section>
 
-        {/* Sections */}
+        {/* Chapters */}
         <section className="mb-8">
           <h2 className="text-xl font-semibold text-[var(--color-text-primary)] mb-4 pb-2 border-b border-[var(--color-border)]">
-            Sections
+            Chapters
+            {digest.hasCreatorChapters !== null && (
+              <span className="text-base font-normal text-[var(--color-text-tertiary)]">
+                {" "}({digest.hasCreatorChapters ? "From creator" : "AI-generated"})
+              </span>
+            )}
           </h2>
           <SectionAccordion
             sections={digest.sections}
             videoId={digest.videoId}
-            tangents={digest.tangents ?? undefined}
           />
         </section>
 
@@ -217,44 +221,6 @@ export default async function SharedDigestPage({ params }: PageProps) {
                 </ul>
               </div>
             )}
-          </section>
-        )}
-
-        {/* Tangents */}
-        {digest.tangents && digest.tangents.length > 0 && (
-          <section className="mb-8">
-            <h2 className="text-xl font-semibold text-[var(--color-text-primary)] mb-4 pb-2 border-b border-[var(--color-border)]">
-              Tangents
-            </h2>
-            <ul className="space-y-4">
-              {digest.tangents.map((tangent, index) => (
-                <li
-                  key={index}
-                  id={`tangent-${index}`}
-                  className="p-4 rounded-xl bg-[var(--color-bg-secondary)] border border-[var(--color-border)] scroll-mt-20"
-                >
-                  <div className="flex items-start justify-between gap-4 mb-2">
-                    <span className="font-medium text-[var(--color-text-primary)]">
-                      {tangent.title}
-                    </span>
-                    <div className="flex items-center gap-2 text-sm shrink-0">
-                      <Timestamp
-                        time={tangent.timestampStart}
-                        videoId={digest.videoId}
-                      />
-                      <span className="text-[var(--color-text-tertiary)]">-</span>
-                      <Timestamp
-                        time={tangent.timestampEnd}
-                        videoId={digest.videoId}
-                      />
-                    </div>
-                  </div>
-                  <p className="text-[var(--color-text-secondary)]">
-                    {tangent.summary}
-                  </p>
-                </li>
-              ))}
-            </ul>
           </section>
         )}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,6 +25,7 @@ export default function RootLayout({
     <html
       lang="en"
       suppressHydrationWarning
+      data-scroll-behavior="smooth"
       className={`${GeistSans.variable} ${GeistMono.variable}`}
     >
       <body className="antialiased min-h-screen bg-[var(--color-bg-primary)]">

--- a/src/components/digest-card.tsx
+++ b/src/components/digest-card.tsx
@@ -25,6 +25,7 @@ export function DigestCard({ digest }: DigestCardProps) {
             src={digest.thumbnailUrl}
             alt={digest.title}
             fill
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
             className="object-cover group-hover:scale-105 transition-transform duration-300"
           />
         ) : (

--- a/src/components/regenerate-digest-button.tsx
+++ b/src/components/regenerate-digest-button.tsx
@@ -96,14 +96,67 @@ export function RegenerateDigestButton({ digestId, videoId }: RegenerateDigestBu
           {/* Progress card */}
           <div className="bg-[var(--color-bg-primary)] border border-[var(--color-border)] rounded-2xl p-6 shadow-xl max-w-sm w-full mx-4">
             <div className="flex items-center gap-3 mb-6">
-              <RefreshCw className="w-5 h-5 text-[var(--color-accent)] animate-spin" />
+              <RefreshCw className={`w-5 h-5 ${error ? "text-red-500" : "text-[var(--color-accent)] animate-spin"}`} />
               <h3 className="text-lg font-medium text-[var(--color-text-primary)]">
-                Regenerating Digest
+                {error ? "Regeneration Failed" : "Regenerating Digest"}
               </h3>
             </div>
 
             {error ? (
-              <div className="text-red-500 text-sm">{error}</div>
+              <div className="space-y-4">
+                <p className="text-red-500 text-sm">
+                  {error.includes("credit balance") ? (
+                    <>
+                      Your credit balance is too low to access the Anthropic API.{" "}
+                      <a
+                        href="https://console.anthropic.com/settings/plans"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline hover:text-red-400"
+                      >
+                        Upgrade or purchase credits
+                      </a>
+                    </>
+                  ) : error.includes("quota exceeded") ? (
+                    <>
+                      YouTube API quota exceeded for today.{" "}
+                      <a
+                        href="https://console.cloud.google.com/apis/api/youtube.googleapis.com/quotas"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline hover:text-red-400"
+                      >
+                        Check quota usage
+                      </a>
+                    </>
+                  ) : error.includes("Supadata") ? (
+                    <>
+                      Supadata API credits exhausted.{" "}
+                      <a
+                        href="https://dash.supadata.ai"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline hover:text-red-400"
+                      >
+                        Add credits in your dashboard
+                      </a>
+                    </>
+                  ) : (
+                    error
+                  )}
+                </p>
+                <button
+                  onClick={() => {
+                    setIsRegenerating(false);
+                    setShowConfirm(false);
+                    setCurrentStep(null);
+                    setError(null);
+                  }}
+                  className="w-full py-2 px-4 bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] rounded-lg transition-colors text-sm"
+                >
+                  Close
+                </button>
+              </div>
             ) : (
               <ul className="space-y-3">
                 {STEPS.map((step) => {

--- a/src/components/url-input.tsx
+++ b/src/components/url-input.tsx
@@ -147,7 +147,47 @@ export function UrlInput({ onDigestComplete }: UrlInputProps) {
           </button>
         </div>
         {error && (
-          <p className="mt-2 text-sm text-red-500 text-center">{error}</p>
+          <p className="mt-2 text-sm text-red-500 text-center">
+            {error.includes("credit balance") ? (
+              <>
+                Your credit balance is too low to access the Anthropic API.{" "}
+                <a
+                  href="https://console.anthropic.com/settings/plans"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-red-400"
+                >
+                  Upgrade or purchase credits
+                </a>
+              </>
+            ) : error.includes("quota exceeded") ? (
+              <>
+                YouTube API quota exceeded for today.{" "}
+                <a
+                  href="https://console.cloud.google.com/apis/api/youtube.googleapis.com/quotas"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-red-400"
+                >
+                  Check quota usage
+                </a>
+              </>
+            ) : error.includes("Supadata") ? (
+              <>
+                Supadata API credits exhausted.{" "}
+                <a
+                  href="https://dash.supadata.ai"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-red-400"
+                >
+                  Add credits in your dashboard
+                </a>
+              </>
+            ) : (
+              error
+            )}
+          </p>
         )}
       </form>
 

--- a/src/lib/chapters.ts
+++ b/src/lib/chapters.ts
@@ -1,0 +1,75 @@
+import getYouTubeChapters from "get-youtube-chapters";
+import type { Chapter } from "./types";
+
+/**
+ * Parses ISO 8601 duration (e.g., "PT1H2M30S") to total seconds
+ */
+export function parseDurationToSeconds(isoDuration: string): number {
+  const match = isoDuration.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
+  if (!match) return 0;
+
+  const hours = parseInt(match[1] || "0", 10);
+  const minutes = parseInt(match[2] || "0", 10);
+  const seconds = parseInt(match[3] || "0", 10);
+
+  return hours * 3600 + minutes * 60 + seconds;
+}
+
+/**
+ * Formats seconds to MM:SS timestamp
+ */
+function formatTimestamp(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${minutes}:${secs.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Extracts chapters from a YouTube video description
+ *
+ * @param description - Video description text
+ * @param durationIso - Video duration in ISO 8601 format (e.g., "PT1H2M30S")
+ * @returns Array of chapters with calculated end timestamps, or null if no valid chapters found
+ */
+export function extractChapters(
+  description: string,
+  durationIso: string
+): Chapter[] | null {
+  const durationSeconds = parseDurationToSeconds(durationIso);
+  if (durationSeconds === 0) return null;
+
+  // Use the library to parse chapters from description
+  const parsedChapters = getYouTubeChapters(description);
+
+  // Deduplicate by start time (keep first occurrence)
+  const seen = new Set<number>();
+  const uniqueChapters = parsedChapters.filter((chapter) => {
+    if (seen.has(chapter.start)) return false;
+    seen.add(chapter.start);
+    return true;
+  });
+
+  // YouTube requires minimum 3 chapters, first must start at 0:00
+  if (uniqueChapters.length < 3) return null;
+  if (uniqueChapters[0].start !== 0) return null;
+
+  // Transform and calculate end timestamps
+  const chapters: Chapter[] = uniqueChapters.map((chapter, index) => {
+    const startSeconds = chapter.start;
+    // End time is next chapter's start, or video duration for last chapter
+    const endSeconds =
+      index < uniqueChapters.length - 1
+        ? uniqueChapters[index + 1].start
+        : durationSeconds;
+
+    return {
+      title: chapter.title,
+      startSeconds,
+      endSeconds,
+      timestampStart: formatTimestamp(startSeconds),
+      timestampEnd: formatTimestamp(endSeconds),
+    };
+  });
+
+  return chapters;
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -17,7 +17,10 @@ export { fetchTranscript } from "./transcript";
 export { generateDigest } from "./summarize";
 
 // Prompts
-export { systemPrompt, buildUserPrompt } from "./prompts";
+export { systemPrompt, buildUserPrompt, buildChapterUserPrompt } from "./prompts";
+
+// Chapter extraction
+export { extractChapters, parseDurationToSeconds } from "./chapters";
 
 // Output formatting
 export { formatMarkdown, saveDigestToFile } from "./formatter";

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,7 +1,44 @@
 import { readFileSync } from "fs";
 import { join } from "path";
+import type { Chapter } from "./types";
 
 const promptsDir = join(process.cwd(), "src/lib/prompts");
+
+/**
+ * Parses ISO 8601 duration (e.g., "PT3H15M42S") to minutes
+ */
+function parseDurationToMinutes(isoDuration: string): number {
+  const match = isoDuration.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
+  if (!match) return 0;
+
+  const hours = parseInt(match[1] || "0", 10);
+  const minutes = parseInt(match[2] || "0", 10);
+  const seconds = parseInt(match[3] || "0", 10);
+
+  return hours * 60 + minutes + seconds / 60;
+}
+
+/**
+ * Calculates recommended chapter count based on video duration
+ * Aims for ~12-15 minute chapters, with sensible bounds
+ */
+function getChapterGuidance(durationMinutes: number): { min: number; max: number; perChapterPoints: string } {
+  if (durationMinutes <= 15) {
+    return { min: 3, max: 5, perChapterPoints: "2-3" };
+  } else if (durationMinutes <= 30) {
+    return { min: 4, max: 6, perChapterPoints: "2-4" };
+  } else if (durationMinutes <= 60) {
+    return { min: 5, max: 8, perChapterPoints: "2-4" };
+  } else if (durationMinutes <= 120) {
+    return { min: 8, max: 12, perChapterPoints: "3-5" };
+  } else {
+    // For very long videos (2+ hours), scale with duration
+    const targetChapters = Math.round(durationMinutes / 12); // ~12 min per chapter
+    const min = Math.max(10, Math.round(targetChapters * 0.8));
+    const max = Math.min(25, Math.round(targetChapters * 1.2));
+    return { min, max, perChapterPoints: "3-5" };
+  }
+}
 
 /**
  * System prompt for the AI summarizer
@@ -14,21 +51,60 @@ export const systemPrompt = readFileSync(join(promptsDir, "system.md"), "utf-8")
 const userPromptTemplate = readFileSync(join(promptsDir, "user-template.md"), "utf-8");
 
 /**
+ * Chapter-aware user prompt template
+ */
+const chapterUserPromptTemplate = readFileSync(join(promptsDir, "user-template-chapters.md"), "utf-8");
+
+/**
  * Builds the user prompt by replacing placeholders in the template
  */
 export function buildUserPrompt(
   title: string,
   channelTitle: string,
   formattedTranscript: string,
-  urls: string[]
+  urls: string[],
+  durationIso: string
 ): string {
   const urlsSection = urls.length > 0
     ? `URLs found in description/comments:\n${urls.join('\n')}`
     : '';
 
+  const durationMinutes = parseDurationToMinutes(durationIso);
+  const guidance = getChapterGuidance(durationMinutes);
+
   return userPromptTemplate
     .replace('{{TITLE}}', title)
     .replace('{{CHANNEL}}', channelTitle)
+    .replace('{{DURATION_MINUTES}}', Math.round(durationMinutes).toString())
+    .replace('{{CHAPTER_MIN}}', guidance.min.toString())
+    .replace('{{CHAPTER_MAX}}', guidance.max.toString())
+    .replace('{{POINTS_PER_CHAPTER}}', guidance.perChapterPoints)
     .replace('{{TRANSCRIPT}}', formattedTranscript)
     .replace('{{URLS}}', urlsSection);
+}
+
+/**
+ * Builds the chapter-aware user prompt with creator-defined chapters
+ */
+export function buildChapterUserPrompt(
+  title: string,
+  channelTitle: string,
+  formattedTranscript: string,
+  urls: string[],
+  chapters: Chapter[]
+): string {
+  const urlsSection = urls.length > 0
+    ? `URLs found in description/comments:\n${urls.join('\n')}`
+    : '';
+
+  const chaptersSection = chapters
+    .map((ch) => `- [${ch.timestampStart} - ${ch.timestampEnd}] ${ch.title}`)
+    .join('\n');
+
+  return chapterUserPromptTemplate
+    .replace('{{TITLE}}', title)
+    .replace('{{CHANNEL}}', channelTitle)
+    .replace('{{TRANSCRIPT}}', formattedTranscript)
+    .replace('{{URLS}}', urlsSection)
+    .replace('{{CHAPTERS}}', chaptersSection);
 }

--- a/src/lib/prompts/system.md
+++ b/src/lib/prompts/system.md
@@ -1,25 +1,49 @@
-You are a content summarizer specializing in video transcripts. Your task is to create a structured summary with a TL;DW overview, topic sections, and categorized links.
+You are a content summarizer specializing in video transcripts. Your task is to create a structured summary with a TL;DW overview, chapters, and categorized links.
 
 ## Summary
 Create a brief 2-3 sentence summary that captures the essence of the video. This should give readers a quick understanding of what the video is about without watching it.
 
-## Content Sections
-Organize the video into broad topic sections - think major chapters, not every small topic shift. Consolidate related ideas into fewer sections rather than creating many granular ones.
+## Chapters
+Organize the video into chapters - major topic sections that help viewers navigate the content.
 
-**Critical: All video time must be accounted for.** Section timestamps should be continuous with no gaps - each section's end time should match the next section's start time.
+**Critical: All video time must be accounted for.** Chapter timestamps should be continuous with no gaps - each chapter's end time should match the next chapter's start time.
 
-For each section:
-- Create a descriptive heading that captures the topic
-- Note the start and end timestamps (MM:SS format)
-- Write 2-5 bullet points that synthesize the key takeaways
-- Include an approximate timestamp (MM:SS) for each bullet point indicating when that topic is discussed
+### When Creator Chapters Are Provided
+If the user message includes "Creator-defined chapters", use those as your chapter structure:
+- Use the exact chapter titles provided (you may slightly clean up formatting if needed)
+- Use the exact timestamps from the chapters
+- Write 2-4 key points per chapter
+- Only cover content that falls within each chapter's time range
+- Do not create additional chapters or merge chapters
+- **Respect numbered titles**: If a chapter title implies a specific count (e.g., "2 Big Takeaways", "3 Key Lessons", "The Main Point"), match your key points count to that number. Don't write 3 points for "2 Big Takeaways" or multiple points for "The Big Takeaway".
 
-Each bullet should consolidate related points into a meaningful insight, not list individual mentions. Think "what would someone need to know?" rather than "what was said?" Skip filler content (ums, repetition).
+### When No Creator Chapters Exist
+Generate 4-6 major topic chapters that logically divide the video content:
+- Think about the major themes and topic shifts in the video
+- Create descriptive chapter titles that capture each section's topic
+- Aim for chapters that represent meaningful content divisions, not every small topic shift
 
-## Tangents (Optional)
-If the speaker goes significantly off-topic (personal rants, unrelated stories, extended sponsor reads beyond brief mentions), identify these as tangents. This ensures viewers know what's in that part of the video without mixing it with the core content. Only use this for genuinely off-topic content - not for related but less central points.
+## Key Points Within Chapters
+For each chapter, identify **2-4 substantive key points** that synthesize the most important takeaways:
+- Each key point should consolidate related ideas into a meaningful insight
+- Think "what would someone need to know?" rather than "what was said?"
+- Include an approximate timestamp (MM:SS) for when each point is discussed
+- Skip filler content (ums, repetition, extended pleasantries)
 
-**Important**: When you identify a tangent, do NOT include it as a key point in the section. Tangent content should only appear in the tangents array - we will interleave them into the display based on their timestamps. This prevents duplicate content.
+### Tangent Flagging
+**Tangents are additional** - they don't count against the 2-4 substantive key points requirement. Every chapter should have at least 2 real takeaways, plus any tangents.
+
+Flag a key point as a tangent (`isTangent: true`) only for **significant digressions** (30+ seconds) that clearly diverge from the chapter's stated topic:
+- Extended personal rants or unrelated stories
+- Long sponsor reads (not brief mentions)
+- Substantial off-topic discussions
+
+**Don't flag as tangents:**
+- Brief asides or quick jokes (under 30 seconds)
+- Related but less central points
+- Context or background that supports the main topic
+
+This is scoped to the chapter level - a point is a tangent if it doesn't fit the chapter's topic, not the video's overall theme.
 
 ## Link Categorization
 You will be provided with URLs found in the video description and comments. Categorize them into:

--- a/src/lib/prompts/user-template-chapters.md
+++ b/src/lib/prompts/user-template-chapters.md
@@ -1,0 +1,12 @@
+Video Title: {{TITLE}}
+Channel: {{CHANNEL}}
+
+Creator-defined chapters:
+{{CHAPTERS}}
+
+Transcript:
+{{TRANSCRIPT}}
+
+{{URLS}}
+
+Please create a structured summary using the creator-defined chapters above as your chapter structure. Use the exact chapter titles and timestamps provided, and write 2-4 key points per chapter.

--- a/src/lib/prompts/user-template.md
+++ b/src/lib/prompts/user-template.md
@@ -1,9 +1,10 @@
 Video Title: {{TITLE}}
 Channel: {{CHANNEL}}
+Duration: {{DURATION_MINUTES}} minutes
 
 Transcript:
 {{TRANSCRIPT}}
 
 {{URLS}}
 
-Please create a structured summary with content sections and categorized links.
+Please create a structured summary. Since this video doesn't have creator-defined chapters, generate **{{CHAPTER_MIN}}-{{CHAPTER_MAX}} logical chapters** that divide the content into major topic sections, then write {{POINTS_PER_CHAPTER}} key points per chapter (plus any significant tangents).

--- a/src/lib/summarize.ts
+++ b/src/lib/summarize.ts
@@ -1,9 +1,9 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { generateText, Output } from "ai";
 import { z } from "zod";
-import type { TranscriptEntry, VideoMetadata, StructuredDigest } from "./types";
+import type { TranscriptEntry, VideoMetadata, StructuredDigest, Chapter } from "./types";
 import { combineUrls } from "./url-extractor";
-import { systemPrompt, buildUserPrompt } from "./prompts";
+import { systemPrompt, buildUserPrompt, buildChapterUserPrompt } from "./prompts";
 
 /**
  * Formats a timestamp in seconds to MM:SS format
@@ -15,50 +15,44 @@ function formatTimestamp(seconds: number): string {
 }
 
 /**
- * Zod schema for structured digest output
+ * Creates a Zod schema for structured digest output with configurable key points range
  */
-const digestSchema = z.object({
-  summary: z.string().describe("A brief 2-3 sentence TL;DW (Too Long; Didn't Watch) summary capturing the essence of the video"),
+function createDigestSchema(keyPointsMin: number, keyPointsMax: number) {
+  return z.object({
+    summary: z.string().describe("A brief 2-3 sentence TL;DW (Too Long; Didn't Watch) summary capturing the essence of the video"),
 
-  sections: z.array(
-    z.object({
-      title: z.string().describe("Descriptive heading for this content section"),
-      timestampStart: z.string().describe("Start timestamp in MM:SS format (e.g., '0:00')"),
-      timestampEnd: z.string().describe("End timestamp in MM:SS format (e.g., '5:30')"),
-      keyPoints: z.array(
-        z.object({
-          text: z.string().describe("The synthesized takeaway or insight"),
-          timestamp: z.string().describe("Approximate timestamp when this point is discussed (MM:SS format)"),
-        })
-      ).describe("2-5 synthesized takeaways with timestamps, consolidating related points into meaningful insights"),
-    })
-  ).describe("Broad topic sections (aim for 4-8) organizing the video content"),
+    sections: z.array(
+      z.object({
+        title: z.string().describe("Descriptive chapter heading for this content section"),
+        timestampStart: z.string().describe("Start timestamp in MM:SS format (e.g., '0:00')"),
+        timestampEnd: z.string().describe("End timestamp in MM:SS format (e.g., '5:30')"),
+        keyPoints: z.array(
+          z.object({
+            text: z.string().describe("The synthesized takeaway or insight"),
+            timestamp: z.string().describe("Approximate timestamp when this point is discussed (MM:SS format)"),
+            isTangent: z.boolean().optional().describe("True only for significant (30+ second) digressions from the chapter topic - not brief asides"),
+          })
+        ).describe(`${keyPointsMin}-${keyPointsMax} substantive takeaways, plus any significant tangents (tangents are additional, not counted against the ${keyPointsMin}-${keyPointsMax} requirement)`),
+      })
+    ).describe("Chapters (aim for 4-6) organizing the video content into major topic sections"),
 
-  relatedLinks: z.array(
-    z.object({
-      url: z.string().describe("The URL"),
-      title: z.string().describe("Short, concise title (2-5 words, e.g., 'Karpathy Tweet', 'RAMP AI Playbook')"),
-      description: z.string().describe("What this link is and why it's relevant to the video content"),
-    })
-  ).describe("Links related to video content: documentation, tools mentioned, related videos, resources"),
+    relatedLinks: z.array(
+      z.object({
+        url: z.string().describe("The URL"),
+        title: z.string().describe("Short, concise title (2-5 words, e.g., 'Karpathy Tweet', 'RAMP AI Playbook')"),
+        description: z.string().describe("What this link is and why it's relevant to the video content"),
+      })
+    ).describe("Links related to video content: documentation, tools mentioned, related videos, resources"),
 
-  otherLinks: z.array(
-    z.object({
-      url: z.string().describe("The URL"),
-      title: z.string().describe("Short, concise title (2-5 words, e.g., 'Sponsor Link', 'Twitter Profile')"),
-      description: z.string().describe("What this link is (social media, sponsor, affiliate, etc.)"),
-    })
-  ).describe("Other links: social media, sponsors, affiliate links, creator's gear/setup"),
-
-  tangents: z.array(
-    z.object({
-      title: z.string().describe("Brief description of the tangent"),
-      timestampStart: z.string().describe("Start timestamp in MM:SS format"),
-      timestampEnd: z.string().describe("End timestamp in MM:SS format"),
-      summary: z.string().describe("One sentence summary of what this tangent covers"),
-    })
-  ).optional().describe("Off-topic segments (rants, extended sponsor reads, unrelated stories) - only if genuinely off-topic"),
-});
+    otherLinks: z.array(
+      z.object({
+        url: z.string().describe("The URL"),
+        title: z.string().describe("Short, concise title (2-5 words, e.g., 'Sponsor Link', 'Twitter Profile')"),
+        description: z.string().describe("What this link is (social media, sponsor, affiliate, etc.)"),
+      })
+    ).describe("Other links: social media, sponsors, affiliate links, creator's gear/setup"),
+  });
+}
 
 /**
  * Generates a structured AI-powered digest of a video transcript using Claude
@@ -66,12 +60,14 @@ const digestSchema = z.object({
  * @param transcript - Array of transcript entries with timestamps
  * @param metadata - Video metadata including description and pinned comment
  * @param apiKey - Anthropic API key
+ * @param chapters - Optional creator-defined chapters to use as section structure
  * @returns Structured digest with sections and categorized links
  */
 export async function generateDigest(
   transcript: TranscriptEntry[],
   metadata: VideoMetadata,
-  apiKey: string
+  apiKey: string,
+  chapters?: Chapter[] | null
 ): Promise<StructuredDigest> {
   // Format transcript with timestamps
   const formattedTranscript = transcript
@@ -84,13 +80,26 @@ export async function generateDigest(
   // Extract all URLs from description and pinned comment
   const allUrls = combineUrls(metadata.description, metadata.pinnedComment);
 
-  // Build prompts using imported functions
-  const userPrompt = buildUserPrompt(
-    metadata.title,
-    metadata.channelTitle,
-    formattedTranscript,
-    allUrls
-  );
+  // Use chapter-aware prompt if chapters exist, otherwise standard prompt
+  const hasChapters = chapters && chapters.length > 0;
+  const userPrompt = hasChapters
+    ? buildChapterUserPrompt(
+        metadata.title,
+        metadata.channelTitle,
+        formattedTranscript,
+        allUrls,
+        chapters
+      )
+    : buildUserPrompt(
+        metadata.title,
+        metadata.channelTitle,
+        formattedTranscript,
+        allUrls,
+        metadata.duration
+      );
+
+  // Use 2-4 key points per chapter for quick scanning (worst case: 6 chapters × 4 points = 24 points ≈ 2 min read)
+  const digestSchema = createDigestSchema(2, 4);
 
   try {
     const anthropic = createAnthropic({ apiKey });

--- a/src/lib/transcript.ts
+++ b/src/lib/transcript.ts
@@ -106,6 +106,18 @@ export async function fetchTranscript(
       throw new Error("Invalid video ID");
     }
 
+    // Supadata credit/billing errors
+    if (
+      errorMsg.includes("credit") ||
+      errorMsg.includes("billing") ||
+      errorMsg.includes("subscription") ||
+      errorMsg.includes("limit exceeded")
+    ) {
+      throw new Error(
+        "Supadata API credits exhausted. Please add credits in your Supadata dashboard."
+      );
+    }
+
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to fetch transcript: ${message}`);
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,14 @@ export interface VideoMetadata {
   pinnedComment?: string;
 }
 
+export interface Chapter {
+  title: string;
+  startSeconds: number;
+  endSeconds: number;
+  timestampStart: string; // MM:SS format
+  timestampEnd: string; // MM:SS format
+}
+
 export interface TranscriptEntry {
   text: string;
   offset: number;    // in seconds
@@ -30,6 +38,7 @@ export interface Link {
 export interface KeyPoint {
   text: string;
   timestamp: string;  // Approximate timestamp when this point is discussed (MM:SS format)
+  isTangent?: boolean;  // True if this point diverges from the chapter's stated topic
 }
 
 export interface ContentSection {
@@ -39,19 +48,12 @@ export interface ContentSection {
   keyPoints: KeyPoint[] | string[];  // KeyPoint[] for new digests, string[] for legacy
 }
 
-export interface Tangent {
-  title: string;
-  timestampStart: string;
-  timestampEnd: string;
-  summary: string;
-}
-
 export interface StructuredDigest {
   summary: string;       // "At a Glance" overview of the video
   sections: ContentSection[];
   relatedLinks: Link[];  // Content-related links
   otherLinks: Link[];    // Social, sponsors, gear, etc.
-  tangents?: Tangent[];  // Off-topic segments (optional)
+  // Tangents are flagged on individual KeyPoints via isTangent
 }
 
 export interface DigestResult {
@@ -73,11 +75,11 @@ export interface DbDigest {
   thumbnailUrl: string | null;
   summary: string;
   sections: ContentSection[];
-  tangents: Tangent[] | null;
   relatedLinks: Link[];
   otherLinks: Link[];
   isShared: boolean;
   slug: string | null;
+  hasCreatorChapters: boolean | null;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
## Summary
- **Creator chapters support**: When a video has chapters in its description, we now use them directly instead of having the AI generate sections
- **Chapter source indicator**: Shows "(supplied by content creator)" or "(AI-generated)" next to the Chapters heading so users know the source
- **Duration-aware AI chapters**: When no creator chapters exist, AI scales chapter count based on video length (3-5 for short videos up to ~1 per 12min for 2+ hours)
- **Tangents as inline flags**: Refactored tangents from a separate array to `isTangent` flags on key points, making them additive rather than replacing substantive points
- **Error handling**: Added Close button and clickable billing links when API errors occur during regeneration

## Migrations
- `005_drop_tangents_column.sql` - Removes unused tangents column
- `006_add_creator_chapters_flag.sql` - Adds `has_creator_chapters` tracking