### PR TITLE
feat: sort key points chronologically within chapters

### DIFF
--- a/src/lib/prompts/system.md
+++ b/src/lib/prompts/system.md
@@ -28,6 +28,7 @@ For each chapter, identify **2-4 substantive key points** that synthesize the mo
 - Each key point should consolidate related ideas into a meaningful insight
 - Think "what would someone need to know?" rather than "what was said?"
 - Include an approximate timestamp (MM:SS) for when each point is discussed
+- **List key points in chronological order** based on when they appear in the chapter
 - Skip filler content (ums, repetition, extended pleasantries)
 
 ### Tangent Flagging


### PR DESCRIPTION
## Summary
- Key points (including tangents) are now sorted by timestamp within each chapter
- Ensures tangents appear in their actual chronological position rather than always at the end
- Helps users skip tangents when watching by knowing exactly where they occur

## Changes
- Added prompt instruction for chronological ordering
- Added `sortKeyPointsByTimestamp()` function as a safety net to enforce ordering in code