### PR TITLE
feat: add in-page YouTube timestamp seeking

### DIFF
--- a/src/app/(app)/digest/[id]/page.tsx
+++ b/src/app/(app)/digest/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { withAuth } from "@workos-inc/authkit-nextjs";
-import { ChapterGrid } from "@/components/chapter-grid";
+import { DigestViewer } from "@/components/digest-viewer";
 import { DeleteDigestButton } from "@/components/delete-digest-button";
 import { RegenerateDigestButton } from "@/components/regenerate-digest-button";
 import { ShareButton } from "@/components/share-button";
@@ -112,57 +112,45 @@ export default async function DigestPage({ params }: PageProps) {
             </div>
           </div>
 
-          {/* Embedded YouTube Player */}
-          <div className="relative aspect-video rounded-2xl overflow-hidden mb-4 bg-black">
-            <iframe
-              src={`https://www.youtube.com/embed/${digest.videoId}`}
-              title={digest.title}
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-              allowFullScreen
-              className="absolute inset-0 w-full h-full"
-            />
-          </div>
+          {/* Embedded YouTube Player and Chapters */}
+          <DigestViewer
+            videoId={digest.videoId}
+            title={digest.title}
+            sections={digest.sections}
+            hasCreatorChapters={digest.hasCreatorChapters}
+          >
+            {/* Title */}
+            <h1 className="text-xl md:text-2xl font-semibold text-[var(--color-text-primary)] mb-2">
+              {digest.title}
+            </h1>
 
-          {/* Title */}
-          <h1 className="text-xl md:text-2xl font-semibold text-[var(--color-text-primary)] mb-2">
-            {digest.title}
-          </h1>
+            {/* Meta line */}
+            <div className="flex flex-wrap items-center gap-2 text-[var(--color-text-secondary)] mb-4">
+              <span>{digest.channelName}</span>
+              {digest.duration && (
+                <>
+                  <span className="text-[var(--color-text-tertiary)]">•</span>
+                  <span>{formatDuration(digest.duration)}</span>
+                </>
+              )}
+              {publishDate && (
+                <>
+                  <span className="text-[var(--color-text-tertiary)]">•</span>
+                  <span>{publishDate}</span>
+                </>
+              )}
+            </div>
 
-          {/* Meta line */}
-          <div className="flex flex-wrap items-center gap-2 text-[var(--color-text-secondary)] mb-4">
-            <span>{digest.channelName}</span>
-            {digest.duration && (
-              <>
-                <span className="text-[var(--color-text-tertiary)]">•</span>
-                <span>{formatDuration(digest.duration)}</span>
-              </>
-            )}
-            {publishDate && (
-              <>
-                <span className="text-[var(--color-text-tertiary)]">•</span>
-                <span>{publishDate}</span>
-              </>
-            )}
-          </div>
-
-          {/* The Gist */}
-          <section className="mt-6 mb-4">
-            <h2 className="text-lg font-semibold text-[var(--color-text-primary)] mb-1.5 pb-1 border-b border-[var(--color-border)]">
-              The Gist
-            </h2>
-            <p className="text-lg text-[var(--color-text-primary)] leading-relaxed pt-2">
-              {digest.summary}
-            </p>
-          </section>
-
-          {/* Chapters */}
-          <section className="mt-6 mb-4">
-            <ChapterGrid
-              sections={digest.sections}
-              videoId={digest.videoId}
-              hasCreatorChapters={digest.hasCreatorChapters}
-            />
-          </section>
+            {/* The Gist */}
+            <section className="mt-6 mb-4">
+              <h2 className="text-lg font-semibold text-[var(--color-text-primary)] mb-1.5 pb-1 border-b border-[var(--color-border)]">
+                The Gist
+              </h2>
+              <p className="text-lg text-[var(--color-text-primary)] leading-relaxed pt-2">
+                {digest.summary}
+              </p>
+            </section>
+          </DigestViewer>
 
           {/* Links & Resources */}
           {(digest.relatedLinks.length > 0 || digest.otherLinks.length > 0) && (

--- a/src/app/(public)/share/[slug]/page.tsx
+++ b/src/app/(public)/share/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
-import { ChapterGrid } from "@/components/chapter-grid";
+import { DigestViewer } from "@/components/digest-viewer";
 import { Card, CardContent } from "@/components/ui/card";
 import { getSharedDigestBySlug } from "@/lib/db";
 
@@ -88,57 +88,45 @@ export default async function SharedDigestPage({ params }: PageProps) {
   return (
     <main className="flex-1 px-4 py-4">
       <article className="max-w-3xl mx-auto">
-        {/* Embedded YouTube Player */}
-        <div className="relative aspect-video rounded-2xl overflow-hidden mb-4 bg-black">
-          <iframe
-            src={`https://www.youtube.com/embed/${digest.videoId}`}
-            title={digest.title}
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            allowFullScreen
-            className="absolute inset-0 w-full h-full"
-          />
-        </div>
+        {/* Embedded YouTube Player and Chapters */}
+        <DigestViewer
+          videoId={digest.videoId}
+          title={digest.title}
+          sections={digest.sections}
+          hasCreatorChapters={digest.hasCreatorChapters}
+        >
+          {/* Title */}
+          <h1 className="text-xl md:text-2xl font-semibold text-[var(--color-text-primary)] mb-2">
+            {digest.title}
+          </h1>
 
-        {/* Title */}
-        <h1 className="text-xl md:text-2xl font-semibold text-[var(--color-text-primary)] mb-2">
-          {digest.title}
-        </h1>
+          {/* Meta line */}
+          <div className="flex flex-wrap items-center gap-2 text-[var(--color-text-secondary)] mb-4">
+            <span>{digest.channelName}</span>
+            {digest.duration && (
+              <>
+                <span className="text-[var(--color-text-tertiary)]">•</span>
+                <span>{formatDuration(digest.duration)}</span>
+              </>
+            )}
+            {publishDate && (
+              <>
+                <span className="text-[var(--color-text-tertiary)]">•</span>
+                <span>{publishDate}</span>
+              </>
+            )}
+          </div>
 
-        {/* Meta line */}
-        <div className="flex flex-wrap items-center gap-2 text-[var(--color-text-secondary)] mb-4">
-          <span>{digest.channelName}</span>
-          {digest.duration && (
-            <>
-              <span className="text-[var(--color-text-tertiary)]">•</span>
-              <span>{formatDuration(digest.duration)}</span>
-            </>
-          )}
-          {publishDate && (
-            <>
-              <span className="text-[var(--color-text-tertiary)]">•</span>
-              <span>{publishDate}</span>
-            </>
-          )}
-        </div>
-
-        {/* The Gist */}
-        <section className="mt-6 mb-4">
-          <h2 className="text-lg font-semibold text-[var(--color-text-primary)] mb-1.5 pb-1 border-b border-[var(--color-border)]">
-            The Gist
-          </h2>
-          <p className="text-lg text-[var(--color-text-primary)] leading-relaxed pt-2">
-            {digest.summary}
-          </p>
-        </section>
-
-        {/* Chapters */}
-        <section className="mt-6 mb-4">
-          <ChapterGrid
-            sections={digest.sections}
-            videoId={digest.videoId}
-            hasCreatorChapters={digest.hasCreatorChapters}
-          />
-        </section>
+          {/* The Gist */}
+          <section className="mt-6 mb-4">
+            <h2 className="text-lg font-semibold text-[var(--color-text-primary)] mb-1.5 pb-1 border-b border-[var(--color-border)]">
+              The Gist
+            </h2>
+            <p className="text-lg text-[var(--color-text-primary)] leading-relaxed pt-2">
+              {digest.summary}
+            </p>
+          </section>
+        </DigestViewer>
 
         {/* Links & Resources */}
         {(digest.relatedLinks.length > 0 || digest.otherLinks.length > 0) && (

--- a/src/components/chapter-grid.tsx
+++ b/src/components/chapter-grid.tsx
@@ -16,16 +16,48 @@ interface ChapterGridProps {
   sections: ContentSection[];
   videoId: string;
   hasCreatorChapters?: boolean | null;
+  onSeek?: (seconds: number) => void;
 }
 
 function isKeyPointArray(keyPoints: KeyPoint[] | string[]): keyPoints is KeyPoint[] {
   return keyPoints.length > 0 && typeof keyPoints[0] === "object";
 }
 
-function TimestampLink({ time, videoId }: { time: string; videoId: string }) {
+function TimestampLink({
+  time,
+  videoId,
+  onSeek,
+}: {
+  time: string;
+  videoId: string;
+  onSeek?: (seconds: number) => void;
+}) {
   const seconds = parseTimestamp(time);
-  const url = `https://youtube.com/watch?v=${videoId}&t=${seconds}s`;
 
+  if (onSeek) {
+    return (
+      <span
+        role="button"
+        tabIndex={0}
+        onClick={(e) => {
+          e.stopPropagation();
+          onSeek(seconds);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            e.stopPropagation();
+            onSeek(seconds);
+          }
+        }}
+        className="font-mono text-sm text-[var(--color-accent)] hover:text-[var(--color-accent-hover)] transition-colors cursor-pointer"
+      >
+        {time}
+      </span>
+    );
+  }
+
+  const url = `https://youtube.com/watch?v=${videoId}&t=${seconds}s`;
   return (
     <a
       href={url}
@@ -39,7 +71,7 @@ function TimestampLink({ time, videoId }: { time: string; videoId: string }) {
   );
 }
 
-export function ChapterGrid({ sections, videoId, hasCreatorChapters }: ChapterGridProps) {
+export function ChapterGrid({ sections, videoId, hasCreatorChapters, onSeek }: ChapterGridProps) {
   const allSectionValues = sections.map((_, index) => `section-${index}`);
   const [openSections, setOpenSections] = useState<string[]>([]);
 
@@ -97,9 +129,9 @@ export function ChapterGrid({ sections, videoId, hasCreatorChapters }: ChapterGr
             >
               <div className="flex items-center gap-2 flex-1">
                 <ChevronRight className="w-4 h-4 text-[var(--color-text-tertiary)] transition-transform [[data-state=open]_&]:rotate-90 shrink-0" />
-                <span className="text-lg">{section.title}</span>
+                <span className="text-lg font-light">{section.title}</span>
               </div>
-              <TimestampLink time={section.timestampStart} videoId={videoId} />
+              <TimestampLink time={section.timestampStart} videoId={videoId} onSeek={onSeek} />
             </AccordionTrigger>
 
             <AccordionContent className="px-3 py-2">

--- a/src/components/digest-viewer.tsx
+++ b/src/components/digest-viewer.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState, useCallback, type ReactNode } from "react";
+import { YouTubePlayer } from "./youtube-player";
+import { ChapterGrid } from "./chapter-grid";
+import type { ContentSection } from "@/lib/types";
+
+interface DigestViewerProps {
+  videoId: string;
+  title: string;
+  sections: ContentSection[];
+  hasCreatorChapters?: boolean | null;
+  children?: ReactNode;
+}
+
+export function DigestViewer({
+  videoId,
+  title,
+  sections,
+  hasCreatorChapters,
+  children,
+}: DigestViewerProps) {
+  const [seekToFn, setSeekToFn] = useState<((seconds: number) => void) | null>(null);
+
+  const handlePlayerReady = useCallback((seekFn: (seconds: number) => void) => {
+    setSeekToFn(() => seekFn);
+  }, []);
+
+  const handleSeek = useCallback((seconds: number) => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+    seekToFn?.(seconds);
+  }, [seekToFn]);
+
+  return (
+    <>
+      <YouTubePlayer
+        videoId={videoId}
+        title={title}
+        className="mb-4"
+        onReady={handlePlayerReady}
+      />
+      {children}
+      <section className="mt-6 mb-4">
+        <ChapterGrid
+          sections={sections}
+          videoId={videoId}
+          hasCreatorChapters={hasCreatorChapters}
+          onSeek={seekToFn ? handleSeek : undefined}
+        />
+      </section>
+    </>
+  );
+}

--- a/src/components/youtube-player.tsx
+++ b/src/components/youtube-player.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import { cn } from "@/lib/utils";
+
+interface YouTubePlayerProps {
+  videoId: string;
+  title: string;
+  className?: string;
+  onReady?: (seekTo: (seconds: number) => void) => void;
+}
+
+let apiLoadPromise: Promise<void> | null = null;
+
+function loadYouTubeAPI(): Promise<void> {
+  if (apiLoadPromise) return apiLoadPromise;
+
+  apiLoadPromise = new Promise((resolve) => {
+    if (window.YT && window.YT.Player) {
+      resolve();
+      return;
+    }
+
+    const existingCallback = window.onYouTubeIframeAPIReady;
+    window.onYouTubeIframeAPIReady = () => {
+      existingCallback?.();
+      resolve();
+    };
+
+    if (!document.querySelector('script[src*="youtube.com/iframe_api"]')) {
+      const script = document.createElement("script");
+      script.src = "https://www.youtube.com/iframe_api";
+      document.head.appendChild(script);
+    }
+  });
+
+  return apiLoadPromise;
+}
+
+export function YouTubePlayer({ videoId, title, className, onReady }: YouTubePlayerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const playerRef = useRef<YT.Player | null>(null);
+  const onReadyRef = useRef(onReady);
+
+  // Keep callback ref current
+  onReadyRef.current = onReady;
+
+  const seekTo = useCallback((seconds: number) => {
+    if (playerRef.current) {
+      playerRef.current.seekTo(seconds, true);
+    }
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function initPlayer() {
+      if (!containerRef.current) return;
+
+      await loadYouTubeAPI();
+
+      if (!mounted || !containerRef.current) return;
+
+      // Create a unique ID for this player instance
+      const playerId = `youtube-player-${videoId}-${Date.now()}`;
+      containerRef.current.id = playerId;
+
+      playerRef.current = new YT.Player(playerId, {
+        videoId,
+        playerVars: {
+          enablejsapi: 1,
+          rel: 0,
+        },
+        events: {
+          onReady: () => {
+            if (mounted) {
+              onReadyRef.current?.(seekTo);
+            }
+          },
+        },
+      });
+    }
+
+    initPlayer();
+
+    return () => {
+      mounted = false;
+      if (playerRef.current) {
+        playerRef.current.destroy();
+        playerRef.current = null;
+      }
+    };
+  }, [videoId, seekTo]);
+
+  return (
+    <div
+      className={cn(
+        "relative aspect-video rounded-2xl overflow-hidden bg-black",
+        className
+      )}
+    >
+      <div ref={containerRef} className="absolute inset-0 w-full h-full" title={title} />
+    </div>
+  );
+}

--- a/src/types/youtube.d.ts
+++ b/src/types/youtube.d.ts
@@ -1,0 +1,59 @@
+declare namespace YT {
+  class Player {
+    constructor(element: HTMLElement | string, options: PlayerOptions);
+    seekTo(seconds: number, allowSeekAhead: boolean): void;
+    destroy(): void;
+    getPlayerState(): PlayerState;
+    playVideo(): void;
+    pauseVideo(): void;
+  }
+
+  interface PlayerOptions {
+    videoId?: string;
+    width?: number | string;
+    height?: number | string;
+    playerVars?: PlayerVars;
+    events?: PlayerEvents;
+  }
+
+  interface PlayerVars {
+    autoplay?: 0 | 1;
+    controls?: 0 | 1;
+    enablejsapi?: 0 | 1;
+    modestbranding?: 0 | 1;
+    rel?: 0 | 1;
+    origin?: string;
+  }
+
+  interface PlayerEvents {
+    onReady?: (event: PlayerEvent) => void;
+    onStateChange?: (event: OnStateChangeEvent) => void;
+    onError?: (event: OnErrorEvent) => void;
+  }
+
+  interface PlayerEvent {
+    target: Player;
+  }
+
+  interface OnStateChangeEvent extends PlayerEvent {
+    data: PlayerState;
+  }
+
+  interface OnErrorEvent extends PlayerEvent {
+    data: number;
+  }
+
+  enum PlayerState {
+    UNSTARTED = -1,
+    ENDED = 0,
+    PLAYING = 1,
+    PAUSED = 2,
+    BUFFERING = 3,
+    CUED = 5,
+  }
+}
+
+interface Window {
+  YT?: typeof YT;
+  onYouTubeIframeAPIReady?: () => void;
+}


### PR DESCRIPTION
## Summary
- Clicking chapter timestamps now seeks the embedded YouTube player instead of opening a new tab
- Uses YouTube IFrame Player API for JavaScript control of the embedded player
- Scrolls to top of page when seeking from further down

## Changes
- **New:** `YouTubePlayer` component - loads YouTube IFrame API and creates controllable player
- **New:** `DigestViewer` component - coordinates player and chapters, passes `seekTo` function
- **New:** `src/types/youtube.d.ts` - TypeScript declarations for YouTube IFrame API
- **Modified:** `ChapterGrid` - accepts optional `onSeek` prop; timestamps render as clickable spans when seeking is available, falls back to external links otherwise
- **Modified:** Digest detail page and share page - use `DigestViewer` wrapper