### PR TITLE
fix: add favicon to prevent withAuth errors on 404

### DIFF
--- a/public/favicon.ico
+++ b/public/favicon.ico
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="1.5" y="1.5" width="29" height="29" rx="5" fill="none" stroke="#FF0000" stroke-width="3"/>
+  <polygon points="13,10 13,22 23,16" fill="#FF0000"/>
+</svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="1.5" y="1.5" width="29" height="29" rx="5" fill="none" stroke="#FF0000" stroke-width="3"/>
+  <polygon points="13,10 13,22 23,16" fill="#FF0000"/>
+</svg>

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="1.5" y="1.5" width="29" height="29" rx="5" fill="none" stroke="#FF0000" stroke-width="3"/>
+  <polygon points="13,10 13,22 23,16" fill="#FF0000"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add favicon files to prevent 404 errors that trigger `withAuth` failures
- Browsers requesting `/favicon.ico` were hitting the not-found page, which renders the Header component that calls `withAuth()` - but middleware doesn't run for static file paths, causing the error
- Red outline YouTube play button style (per user request)

## Files Added
- `src/app/icon.svg` - Next.js meta tag icon
- `public/favicon.ico` - Direct `/favicon.ico` request fallback
- `public/favicon.svg` - Additional fallback