### PR TITLE
feat: add digest tagging system with searchable vocabulary

### DIFF
--- a/docs/decisions/search.md
+++ b/docs/decisions/search.md
@@ -1,0 +1,225 @@
+# Comprehensive Search Plan for YouTube Digest
+
+## Current State
+
+### What's Being Searched
+- **Title** (video title) - via `ILIKE`
+- **Channel Name** - via `ILIKE`
+
+### What's NOT Being Searched (but should be)
+- Summary ("At a Glance")
+- Section titles and key points
+- Tangent titles and summaries
+- Link titles and descriptions
+- **Transcript** (not stored - fetched dynamically and discarded)
+
+### Current Implementation
+```sql
+WHERE user_id = ${userId}
+  AND (title ILIKE ${searchPattern} OR channel_name ILIKE ${searchPattern})
+```
+This is a simple substring match with no indexing support for the wildcards.
+
+---
+
+## Recommended Approach: PostgreSQL Full-Text Search (FTS)
+
+### Why PostgreSQL FTS?
+1. **No additional infrastructure** - works with your existing Vercel Postgres
+2. **Weighted search** - title matches rank higher than summary matches
+3. **Language-aware** - handles stemming ("running" matches "run")
+4. **Fast** - GIN indexes provide sub-second searches on large datasets
+5. **Proven** - companies like GitLab started with PG FTS before moving to Elasticsearch at massive scale
+
+### Alternative Considered: External Search (Algolia, Meilisearch, Typesense)
+- **Pros**: More features, typo tolerance, faceted search
+- **Cons**: Additional cost ($$$), data sync complexity, added latency
+- **Verdict**: Overkill for this use case. PG FTS handles 100k+ digests easily.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Add Searchable Content Column
+
+Create a computed `tsvector` column that combines all searchable text with weights:
+
+```sql
+-- Add the search vector column
+ALTER TABLE digests ADD COLUMN search_vector tsvector;
+
+-- Create GIN index for fast searching
+CREATE INDEX idx_digests_search ON digests USING gin(search_vector);
+```
+
+### Phase 2: Populate Search Vector with Weighted Fields
+
+**Weight hierarchy (A = highest, D = lowest):**
+- **A**: Title, Channel Name (most important)
+- **B**: Summary, Section Titles
+- **C**: Key Points, Tangent Titles/Summaries
+- **D**: Link Titles/Descriptions
+
+```sql
+-- Trigger function to auto-update search_vector
+CREATE OR REPLACE FUNCTION digests_search_vector_update() RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector :=
+    setweight(to_tsvector('english', coalesce(NEW.title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(NEW.channel_name, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(NEW.search_text, '')), 'B');
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger
+CREATE TRIGGER digests_search_vector_trigger
+  BEFORE INSERT OR UPDATE ON digests
+  FOR EACH ROW EXECUTE FUNCTION digests_search_vector_update();
+
+-- Backfill existing records
+UPDATE digests SET updated_at = updated_at; -- Triggers the function
+```
+
+### Phase 3: Update Search Query in Application
+
+```typescript
+// In src/lib/db.ts - updated getDigests function
+function buildTsQuery(search: string): string {
+  return search
+    .trim()
+    .toLowerCase()
+    .replace(/[&|!():*<>'"\\]/g, " ")
+    .split(/\s+/)
+    .filter((term) => term.length > 0)
+    .map((term) => `${term}:*`) // Prefix matching
+    .join(" & ");
+}
+
+// Query with ranking
+const result = await sql`
+  SELECT *, ts_rank(search_vector, to_tsquery('english', ${tsQuery})) AS rank
+  FROM digests
+  WHERE user_id = ${userId}
+    AND search_vector @@ to_tsquery('english', ${tsQuery})
+  ORDER BY rank DESC, created_at DESC
+  LIMIT 50
+`;
+```
+
+---
+
+## Decision: Should We Store Transcripts?
+
+### Option A: Don't Store Transcripts (Recommended)
+- **Pros**: Smaller database, faster backups, lower costs
+- **Cons**: Can't search within original transcript text
+- **Storage impact**: None
+- **Search coverage**: Summary + sections + key points (AI-distilled content)
+
+### Option B: Store Full Transcripts
+- **Pros**: Can search exact phrases from video
+- **Cons**: ~50-200KB per digest, significant storage growth
+- **Storage impact**: For 1000 digests → ~50-200MB additional
+- **Vercel Postgres limits**: Hobby = 256MB, Pro = 512MB
+
+### Option C: Store Condensed Transcript (Hybrid)
+- Store first 5000 characters or key excerpts
+- Provides some searchability without full storage cost
+
+**Recommendation**: Start with **Option A** (no transcript storage). The AI-generated summary, sections, and key points already capture the searchable essence of the content. If users frequently can't find content they expect, revisit Option C.
+
+---
+
+## Optional Enhancement: Fuzzy Search with pg_trgm
+
+For typo tolerance (e.g., "javascrpt" → "javascript"):
+
+```sql
+-- Enable extension (one-time)
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Add trigram index on title for fuzzy matching
+CREATE INDEX idx_digests_title_trgm ON digests USING gin(title gin_trgm_ops);
+
+-- Fuzzy search query
+SELECT * FROM digests
+WHERE title % 'javascrpt'  -- similarity match
+   OR search_vector @@ to_tsquery('english', 'javascript:*')
+ORDER BY similarity(title, 'javascrpt') DESC;
+```
+
+**Recommendation**: Add this in a future iteration if users report issues finding content due to typos.
+
+---
+
+## Migration Steps
+
+1. **Create migration file** for schema changes
+2. **Add search_text column** (populated by the application)
+3. **Add search_vector column** (auto-generated via trigger)
+4. **Create GIN index**
+5. **Create trigger function** for auto-updates
+6. **Backfill existing records**
+7. **Update application query** in `src/lib/db.ts`
+8. **Test thoroughly** with various search terms
+
+---
+
+## Expected Performance
+
+| Dataset Size | Current (ILIKE) | With FTS + GIN |
+|--------------|-----------------|----------------|
+| 100 digests  | ~10ms           | ~2ms           |
+| 1,000 digests| ~50ms           | ~5ms           |
+| 10,000 digests| ~500ms+        | ~10ms          |
+
+The GIN index makes FTS queries nearly constant time regardless of table size.
+
+---
+
+## Summary
+
+| Aspect | Current | Proposed |
+|--------|---------|----------|
+| Fields searched | 2 (title, channel) | 8+ (all text content) |
+| Search type | Substring (ILIKE) | Full-text with ranking |
+| Index support | None for wildcards | GIN index |
+| Relevance ranking | None | Weighted by field importance |
+| Stemming | No | Yes (run→running) |
+| Transcript | Not stored | Not stored (recommend keeping this way) |
+
+---
+
+## Implementation Status: ✅ COMPLETE
+
+The following files were created/modified:
+
+- `migrations/004_add_full_text_search.sql` - Database migration
+- `src/lib/db.ts` - Updated with full-text search
+- `scripts/backfill-search.ts` - Backfill script for existing records
+- `package.json` - Added `backfill-search` script
+
+### Deployment Commands
+
+```bash
+# 1. Run migration (local)
+pnpm migrate 004_add_full_text_search.sql
+
+# 2. Backfill existing records (local)
+pnpm backfill-search
+
+# 3. Run migration (production)
+pnpm migrate 004_add_full_text_search.sql --prod
+
+# 4. Backfill existing records (production)
+pnpm backfill-search --prod
+```
+
+---
+
+## Addendum: Tags (Issue #29)
+
+Tags are **not** included in full-text search. They serve as a separate filtering/faceting mechanism rather than searchable content. Filtering by tag can be combined with full-text search queries.
+
+See [tags-performance.md](./tags-performance.md) for schema design and query patterns.

--- a/docs/decisions/tags-performance.md
+++ b/docs/decisions/tags-performance.md
@@ -1,0 +1,100 @@
+# Tags Performance Decision
+
+## Context
+
+Issue #29 adds a tagging system for digests. This document explains the schema design choices and their performance implications.
+
+## Why Normalized Schema Over JSONB
+
+We chose a normalized approach (separate `tags` and `digest_tags` tables) over storing tags as a JSONB array on the digests table.
+
+### Advantages of Normalized Schema
+
+1. **Efficient filtering**: When filtering digests by tag (issue #30), we can use indexed joins rather than scanning JSONB arrays
+2. **Auto-suggest performance**: Fetching a user's tag vocabulary is a simple indexed query on `tags(user_id)`
+3. **Tag management**: Future features like renaming tags or merging duplicates are straightforward UPDATE operations
+4. **Referential integrity**: Foreign keys ensure orphaned references can't exist
+5. **Storage efficiency**: Tag names stored once, referenced by UUID (vs. duplicated strings in JSONB)
+
+### Trade-offs
+
+- **Write complexity**: Adding a tag requires INSERT into both tables (mitigated by ON CONFLICT handling)
+- **Read complexity**: Requires JOIN to fetch tags with digests (mitigated by batch queries)
+
+## Index Strategy
+
+```sql
+-- Find all tags for a user (auto-suggest)
+CREATE INDEX idx_tags_user_id ON tags(user_id);
+
+-- Look up tag by name for a user (add tag operation)
+CREATE INDEX idx_tags_user_name ON tags(user_id, name);
+
+-- Find tags for a digest
+CREATE INDEX idx_digest_tags_digest_id ON digest_tags(digest_id);
+
+-- Find digests with a tag (future filtering)
+CREATE INDEX idx_digest_tags_tag_id ON digest_tags(tag_id);
+```
+
+## Query Patterns
+
+### Adding a Tag
+```sql
+-- 1. Upsert tag into vocabulary
+INSERT INTO tags (user_id, name) VALUES ($1, $2)
+ON CONFLICT (user_id, name) DO UPDATE SET name = EXCLUDED.name
+RETURNING id, name;
+
+-- 2. Link to digest
+INSERT INTO digest_tags (digest_id, tag_id) VALUES ($1, $2)
+ON CONFLICT DO NOTHING;
+```
+
+### Fetching Digests with Tags (Batch)
+```sql
+-- After fetching digests, batch-load their tags
+SELECT dt.digest_id, t.id, t.name
+FROM tags t
+JOIN digest_tags dt ON t.id = dt.tag_id
+WHERE dt.digest_id IN ($1, $2, ...)
+ORDER BY t.name;
+```
+
+### Future: Filtering by Tag (Issue #30)
+```sql
+-- Find digests with specific tag
+SELECT d.*
+FROM digests d
+JOIN digest_tags dt ON d.id = dt.digest_id
+JOIN tags t ON dt.tag_id = t.id
+WHERE d.user_id = $1 AND t.name = $2
+ORDER BY d.created_at DESC;
+
+-- Combine with full-text search
+SELECT d.*
+FROM digests d
+JOIN digest_tags dt ON d.id = dt.digest_id
+JOIN tags t ON dt.tag_id = t.id
+WHERE d.user_id = $1
+  AND t.name = $2
+  AND d.search_vector @@ to_tsquery('english', $3)
+ORDER BY ts_rank(d.search_vector, to_tsquery('english', $3)) DESC;
+```
+
+## Performance Characteristics
+
+| Operation | Complexity | Notes |
+|-----------|------------|-------|
+| Add tag | O(1) | Two indexed inserts |
+| Remove tag | O(1) | Single indexed delete |
+| Get digest tags | O(n) | n = number of tags on digest |
+| Get user vocabulary | O(n) | n = unique tags user has created |
+| Batch load tags | O(n) | n = total tags across requested digests |
+| Filter by tag | O(log n) | Indexed join, very fast |
+
+## Limits
+
+- **20 tags per digest**: Soft limit enforced in application layer
+- **50 char tag name**: Database constraint prevents abuse
+- **Case-insensitive**: Tags normalized to lowercase on insert

--- a/migrations/007_add_tags.sql
+++ b/migrations/007_add_tags.sql
@@ -1,0 +1,25 @@
+-- Add tags functionality to digests
+-- Tags are per-user, case-insensitive, stored in normalized form (lowercase)
+
+-- Step 1: Create tags table (user's tag vocabulary)
+CREATE TABLE IF NOT EXISTS tags (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id TEXT NOT NULL,
+  name VARCHAR(50) NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW(),
+  UNIQUE(user_id, name)
+);
+
+-- Step 2: Create digest_tags junction table
+CREATE TABLE IF NOT EXISTS digest_tags (
+  digest_id UUID REFERENCES digests(id) ON DELETE CASCADE,
+  tag_id UUID REFERENCES tags(id) ON DELETE CASCADE,
+  created_at TIMESTAMP DEFAULT NOW(),
+  PRIMARY KEY (digest_id, tag_id)
+);
+
+-- Step 3: Create indexes for efficient querying
+CREATE INDEX IF NOT EXISTS idx_tags_user_id ON tags(user_id);
+CREATE INDEX IF NOT EXISTS idx_tags_user_name ON tags(user_id, name);
+CREATE INDEX IF NOT EXISTS idx_digest_tags_digest_id ON digest_tags(digest_id);
+CREATE INDEX IF NOT EXISTS idx_digest_tags_tag_id ON digest_tags(tag_id);

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ai": "^6.0.39",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "dotenv": "^17.2.3",
     "geist": "^1.5.1",
     "get-youtube-chapters": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
@@ -1713,6 +1716,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -4725,6 +4734,18 @@ snapshots:
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   color-convert@2.0.1:
     dependencies:

--- a/src/app/(app)/digest/[id]/page.tsx
+++ b/src/app/(app)/digest/[id]/page.tsx
@@ -7,6 +7,7 @@ import { DigestViewer } from "@/components/digest-viewer";
 import { DeleteDigestButton } from "@/components/delete-digest-button";
 import { RegenerateDigestButton } from "@/components/regenerate-digest-button";
 import { ShareButton } from "@/components/share-button";
+import { TagInput } from "@/components/tag-input";
 import { Card, CardContent } from "@/components/ui/card";
 import { getDigestById } from "@/lib/db";
 import { isEmailAllowed } from "@/lib/access";
@@ -125,7 +126,7 @@ export default async function DigestPage({ params }: PageProps) {
             </h1>
 
             {/* Meta line */}
-            <div className="flex flex-wrap items-center gap-2 text-[var(--color-text-secondary)] mb-4">
+            <div className="flex flex-wrap items-center gap-2 text-[var(--color-text-secondary)] mb-3">
               <span>{digest.channelName}</span>
               {digest.duration && (
                 <>
@@ -139,6 +140,11 @@ export default async function DigestPage({ params }: PageProps) {
                   <span>{publishDate}</span>
                 </>
               )}
+            </div>
+
+            {/* Tags */}
+            <div className="mb-4">
+              <TagInput digestId={id} initialTags={digest.tags || []} />
             </div>
 
             {/* The Gist */}

--- a/src/app/api/digest/[id]/tags/[tagId]/route.ts
+++ b/src/app/api/digest/[id]/tags/[tagId]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { removeTagFromDigest } from "@/lib/db";
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; tagId: string }> }
+) {
+  const { user } = await withAuth();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id, tagId } = await params;
+
+  if (!id || !tagId) {
+    return NextResponse.json(
+      { error: "Digest ID and Tag ID are required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const removed = await removeTagFromDigest(user.id, id, tagId);
+
+    if (!removed) {
+      return NextResponse.json({ error: "Tag not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("[REMOVE TAG] Error:", error);
+    return NextResponse.json({ error: "Failed to remove tag" }, { status: 500 });
+  }
+}

--- a/src/app/api/digest/[id]/tags/route.ts
+++ b/src/app/api/digest/[id]/tags/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { addTagToDigest, getDigestTags } from "@/lib/db";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { user } = await withAuth();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  if (!id) {
+    return NextResponse.json({ error: "Digest ID is required" }, { status: 400 });
+  }
+
+  try {
+    const tags = await getDigestTags(id);
+    return NextResponse.json(tags);
+  } catch (error) {
+    console.error("[GET DIGEST TAGS] Error:", error);
+    return NextResponse.json({ error: "Failed to get tags" }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { user } = await withAuth();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  if (!id) {
+    return NextResponse.json({ error: "Digest ID is required" }, { status: 400 });
+  }
+
+  try {
+    const body = await request.json();
+    const { name } = body;
+
+    if (!name || typeof name !== "string") {
+      return NextResponse.json({ error: "Tag name is required" }, { status: 400 });
+    }
+
+    const tag = await addTagToDigest(user.id, id, name);
+    return NextResponse.json(tag);
+  } catch (error) {
+    console.error("[ADD TAG] Error:", error);
+    const message = error instanceof Error ? error.message : "Failed to add tag";
+    const status = message.includes("not found") ? 404 :
+                   message.includes("Maximum") ? 400 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/api/tags/[tagId]/route.ts
+++ b/src/app/api/tags/[tagId]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { deleteTag } from "@/lib/db";
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ tagId: string }> }
+) {
+  const { user } = await withAuth();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { tagId } = await params;
+
+  try {
+    const deleted = await deleteTag(tagId, user.id);
+    if (!deleted) {
+      return NextResponse.json({ error: "Tag not found" }, { status: 404 });
+    }
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("[DELETE TAG] Error:", error);
+    return NextResponse.json({ error: "Failed to delete tag" }, { status: 500 });
+  }
+}

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { getUserTags } from "@/lib/db";
+
+export async function GET() {
+  const { user } = await withAuth();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const tags = await getUserTags(user.id);
+    return NextResponse.json(tags);
+  } catch (error) {
+    console.error("[GET USER TAGS] Error:", error);
+    return NextResponse.json({ error: "Failed to get tags" }, { status: 500 });
+  }
+}

--- a/src/components/digest-card.tsx
+++ b/src/components/digest-card.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import type { DigestSummary } from "@/lib/types";
+import { TagBadge } from "@/components/tag-badge";
 
 interface DigestCardProps {
   digest: DigestSummary;
@@ -16,7 +17,7 @@ export function DigestCard({ digest }: DigestCardProps) {
   return (
     <Link
       href={`/digest/${digest.id}`}
-      className="group block p-4 rounded-xl bg-[var(--color-bg-secondary)] border border-[var(--color-border)] hover:border-[var(--color-border-hover)] hover:shadow-[var(--shadow-md)] transition-all"
+      className="group flex flex-col p-4 rounded-xl bg-[var(--color-bg-secondary)] border border-[var(--color-border)] hover:border-[var(--color-border-hover)] hover:shadow-[var(--shadow-md)] transition-all"
     >
       {/* Thumbnail */}
       <div className="aspect-video rounded-lg bg-[var(--color-bg-tertiary)] mb-3 overflow-hidden relative">
@@ -35,21 +36,38 @@ export function DigestCard({ digest }: DigestCardProps) {
         )}
       </div>
 
-      {/* Title - FIXED HEIGHT for 2 lines */}
-      <div className="h-[2.75rem] mb-2">
+      {/* Title - let it grow naturally, min-height for 1 line */}
+      <div className="flex-1 min-h-[1.375rem]">
         <h3 className="font-medium text-[var(--color-text-primary)] line-clamp-2 leading-snug group-hover:text-[var(--color-accent)] transition-colors">
           {digest.title}
         </h3>
       </div>
 
-      {/* Meta - channel left, date right */}
-      <div className="flex items-center justify-between text-sm border-t border-[var(--color-border)] pt-2 mt-2">
-        <span className="text-[var(--color-text-secondary)] truncate min-w-0">
-          {digest.channelName}
-        </span>
-        <span className="text-[var(--color-text-secondary)] shrink-0 ml-2">
-          {createdDate}
-        </span>
+      {/* Footer area - anchored to bottom */}
+      <div className="mt-auto pt-2">
+        {/* Tags row - only if tags exist */}
+        {digest.tags && digest.tags.length > 0 && (
+          <div className="flex items-center gap-1.5 mb-2 overflow-hidden">
+            {digest.tags.slice(0, 3).map((tag) => (
+              <TagBadge key={tag.id} name={tag.name} size="sm" />
+            ))}
+            {digest.tags.length > 3 && (
+              <span className="text-xs text-[var(--color-text-tertiary)] shrink-0">
+                +{digest.tags.length - 3}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Channel + date */}
+        <div className="flex items-center justify-between text-sm border-t border-[var(--color-border)] pt-2">
+          <span className="text-[var(--color-text-secondary)] truncate min-w-0">
+            {digest.channelName}
+          </span>
+          <span className="text-[var(--color-text-secondary)] shrink-0 ml-2">
+            {createdDate}
+          </span>
+        </div>
       </div>
     </Link>
   );

--- a/src/components/tag-badge.tsx
+++ b/src/components/tag-badge.tsx
@@ -1,0 +1,39 @@
+import { Badge } from "@/components/ui/badge";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface TagBadgeProps {
+  name: string;
+  size?: "sm" | "md";
+  onRemove?: () => void;
+  className?: string;
+}
+
+export function TagBadge({ name, size = "md", onRemove, className }: TagBadgeProps) {
+  return (
+    <Badge
+      variant="secondary"
+      className={cn(
+        "bg-[oklch(20%_0.04_25)] text-[oklch(72%_0.10_25)] border-[oklch(30%_0.06_25)] hover:bg-[oklch(24%_0.05_25)]",
+        size === "sm" ? "px-2 py-0 text-xs h-5 max-w-24" : "px-2.5 py-0.5 text-sm h-6",
+        className
+      )}
+    >
+      <span className="truncate">{name}</span>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onRemove();
+          }}
+          className="ml-0.5 rounded-full hover:bg-[oklch(32%_0.07_25)] hover:text-[oklch(85%_0.12_25)] transition-colors p-0.5 -mr-1 shrink-0"
+          aria-label={`Remove ${name} tag`}
+        >
+          <X className={size === "sm" ? "w-3 h-3" : "w-3.5 h-3.5"} />
+        </button>
+      )}
+    </Badge>
+  );
+}

--- a/src/components/tag-input.tsx
+++ b/src/components/tag-input.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Plus, Tag as TagIcon, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { TagBadge } from "@/components/tag-badge";
+import type { Tag } from "@/lib/types";
+
+interface TagInputProps {
+  digestId: string;
+  initialTags: Tag[];
+}
+
+interface OptimisticTag extends Tag {
+  isPending?: boolean;
+}
+
+const MAX_TAGS = 20;
+
+export function TagInput({ digestId, initialTags }: TagInputProps) {
+  const [tags, setTags] = useState<OptimisticTag[]>(initialTags);
+  const [userTags, setUserTags] = useState<Tag[]>([]);
+  const [inputValue, setInputValue] = useState("");
+  const [open, setOpen] = useState(false);
+  const [tagToDelete, setTagToDelete] = useState<Tag | null>(null);
+  const [selectedValue, setSelectedValue] = useState("");
+
+  // Fetch user's tag vocabulary for suggestions
+  useEffect(() => {
+    if (open) {
+      fetch("/api/tags")
+        .then((res) => res.json())
+        .then((data) => {
+          if (Array.isArray(data)) {
+            setUserTags(data);
+          }
+        })
+        .catch(console.error);
+    }
+  }, [open]);
+
+  const addTag = async (tagName: string) => {
+    const normalizedName = tagName.toLowerCase().trim();
+    if (!normalizedName) return;
+
+    // Check if tag already exists on this digest
+    if (tags.some((t) => t.name === normalizedName)) {
+      setInputValue("");
+      return;
+    }
+
+    // Check tag limit
+    if (tags.length >= MAX_TAGS) {
+      return;
+    }
+
+    // Optimistic update with temporary ID
+    const tempId = `temp-${Date.now()}`;
+    const optimisticTag: OptimisticTag = {
+      id: tempId,
+      name: normalizedName,
+      isPending: true,
+    };
+    setTags((prev) => [...prev, optimisticTag]);
+    setInputValue("");
+
+    try {
+      const res = await fetch(`/api/digest/${digestId}/tags`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: normalizedName }),
+      });
+
+      if (res.ok) {
+        const newTag = await res.json();
+        // Replace temp tag with real tag
+        setTags((prev) =>
+          prev.map((t) => (t.id === tempId ? { ...newTag, isPending: false } : t))
+        );
+      } else {
+        // Remove optimistic tag on failure
+        setTags((prev) => prev.filter((t) => t.id !== tempId));
+      }
+    } catch (error) {
+      console.error("Failed to add tag:", error);
+      // Remove optimistic tag on error
+      setTags((prev) => prev.filter((t) => t.id !== tempId));
+    }
+  };
+
+  const removeTag = async (tagId: string) => {
+    // Optimistic update
+    const removedTag = tags.find((t) => t.id === tagId);
+    setTags((prev) => prev.filter((t) => t.id !== tagId));
+
+    try {
+      const res = await fetch(`/api/digest/${digestId}/tags/${tagId}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok && removedTag) {
+        // Revert on failure
+        setTags((prev) => [...prev, removedTag]);
+      }
+    } catch (error) {
+      console.error("Failed to remove tag:", error);
+      if (removedTag) {
+        setTags((prev) => [...prev, removedTag]);
+      }
+    }
+  };
+
+  const confirmDeleteTag = async () => {
+    if (!tagToDelete) return;
+
+    const tagId = tagToDelete.id;
+
+    // Optimistic update - remove from suggestions
+    setUserTags((prev) => prev.filter((t) => t.id !== tagId));
+
+    // Also remove from current digest if applied
+    if (tags.some((t) => t.id === tagId)) {
+      setTags((prev) => prev.filter((t) => t.id !== tagId));
+    }
+
+    setTagToDelete(null);
+
+    try {
+      const res = await fetch(`/api/tags/${tagId}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        // Revert on failure - refetch tags
+        fetch("/api/tags")
+          .then((res) => res.json())
+          .then((data) => {
+            if (Array.isArray(data)) {
+              setUserTags(data);
+            }
+          });
+      }
+    } catch (error) {
+      console.error("Failed to delete tag:", error);
+    }
+  };
+
+  // Filter suggestions to exclude already-applied tags
+  const suggestions = userTags.filter(
+    (ut) => !tags.some((t) => t.name === ut.name)
+  );
+
+  // Check if input matches any existing suggestion exactly
+  const normalizedInput = inputValue.toLowerCase().trim();
+  const exactMatch = suggestions.some((s) => s.name === normalizedInput);
+  const showCreateOption = normalizedInput.length > 0 && !exactMatch;
+
+  const atLimit = tags.length >= MAX_TAGS;
+
+  const handleSelect = (value: string) => {
+    if (value.startsWith("create:")) {
+      addTag(value.replace("create:", ""));
+    } else {
+      addTag(value);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center gap-2">
+        {tags.map((tag) => (
+          <TagBadge
+            key={tag.id}
+            name={tag.name}
+            size="md"
+            onRemove={() => removeTag(tag.id)}
+          />
+        ))}
+
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)]"
+              disabled={atLimit}
+            >
+              <Plus className="w-4 h-4 mr-1" />
+              Add tag
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent
+            className="w-auto min-w-48 max-w-64 sm:max-w-72 p-0"
+            align="start"
+          >
+            <Command
+              shouldFilter={true}
+              loop
+              value={selectedValue}
+              onValueChange={setSelectedValue}
+            >
+              <CommandInput
+                placeholder="Search or create tag..."
+                value={inputValue}
+                onValueChange={setInputValue}
+                maxLength={50}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && selectedValue) {
+                    e.preventDefault();
+                    handleSelect(selectedValue);
+                  }
+                }}
+              />
+              <CommandList>
+                <CommandEmpty>
+                  {normalizedInput.length > 0 ? (
+                    <button
+                      type="button"
+                      onClick={() => addTag(normalizedInput)}
+                      className="w-full px-2 py-1.5 text-sm text-left hover:bg-[var(--color-bg-tertiary)] rounded transition-colors"
+                    >
+                      Create &quot;{normalizedInput}&quot;
+                    </button>
+                  ) : (
+                    <span className="text-[var(--color-text-tertiary)]">
+                      Type to create a new tag
+                    </span>
+                  )}
+                </CommandEmpty>
+
+                {showCreateOption && (
+                  <CommandGroup>
+                    <CommandItem
+                      value={`create:${normalizedInput}`}
+                      onSelect={handleSelect}
+                      className="data-[selected=true]:bg-[oklch(25%_0.03_25)] data-[selected=true]:text-[var(--color-text-primary)]"
+                    >
+                      <Plus className="w-4 h-4 mr-2 text-[var(--color-text-tertiary)]" />
+                      Create &quot;{normalizedInput}&quot;
+                    </CommandItem>
+                  </CommandGroup>
+                )}
+
+                {suggestions.length > 0 && (
+                  <CommandGroup heading="Your tags">
+                    {suggestions.map((tag) => (
+                      <CommandItem
+                        key={tag.id}
+                        value={tag.name}
+                        onSelect={handleSelect}
+                        className="group/item justify-between data-[selected=true]:bg-[oklch(25%_0.03_25)] data-[selected=true]:text-[var(--color-text-primary)]"
+                      >
+                        <span className="flex items-center">
+                          <TagIcon className="w-4 h-4 mr-2 text-[var(--color-text-tertiary)]" />
+                          {tag.name}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setTagToDelete(tag);
+                          }}
+                          className="opacity-0 group-hover/item:opacity-100 p-0.5 rounded hover:bg-red-500/20 text-[var(--color-text-tertiary)] hover:text-red-500 transition-all"
+                          aria-label={`Delete ${tag.name} from vocabulary`}
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )}
+              </CommandList>
+            </Command>
+
+            {atLimit && (
+              <p className="px-3 pb-2 text-xs text-[var(--color-text-tertiary)]">
+                Maximum of {MAX_TAGS} tags reached
+              </p>
+            )}
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      {/* Delete confirmation dialog */}
+      <Dialog open={!!tagToDelete} onOpenChange={(open) => !open && setTagToDelete(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete tag?</DialogTitle>
+            <DialogDescription>
+              This will permanently delete the tag &quot;{tagToDelete?.name}&quot; and remove it from all your digests. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setTagToDelete(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={confirmDeleteTag}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { SearchIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("bg-border -mx-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -62,6 +62,12 @@ export interface DigestResult {
   outputPath?: string;
 }
 
+// Tag types
+export interface Tag {
+  id: string;
+  name: string;
+}
+
 // Database types
 export interface DbDigest {
   id: string;
@@ -82,6 +88,7 @@ export interface DbDigest {
   hasCreatorChapters: boolean | null;
   createdAt: Date;
   updatedAt: Date;
+  tags?: Tag[];
 }
 
 export interface DigestSummary {
@@ -92,4 +99,5 @@ export interface DigestSummary {
   channelName: string;
   thumbnailUrl: string | null;
   createdAt: Date;
+  tags?: Tag[];
 }


### PR DESCRIPTION
Closes #29

## Summary

- Add user-scoped tagging system for organizing digests
- Tags displayed on digest cards (up to 3, with "+N more" overflow)
- Searchable tag input with keyboard navigation (arrow keys + Enter)
- Delete tags from vocabulary with confirmation dialog
- Terracotta-colored tag badges matching app accent

## Changes

**Database**
- New `tags` and `digest_tags` tables with proper indexes
- Tag vocabulary is per-user, stored once and linked to digests

**API Endpoints**
- `GET /api/tags` - Get user's tag vocabulary
- `DELETE /api/tags/[tagId]` - Delete tag from vocabulary (removes from all digests)
- `POST /api/digest/[id]/tags` - Add tag to digest
- `DELETE /api/digest/[id]/tags/[tagId]` - Remove tag from digest

**UI Components**
- `TagBadge` - Styled tag display using shadcn Badge
- `TagInput` - Searchable combobox using shadcn Command with:
  - Type-to-filter existing tags
  - Create new tags inline
  - Keyboard navigation (ArrowUp/Down + Enter)
  - Delete tags from vocabulary (trash icon with confirmation)
- Updated `DigestCard` with tags in footer section