### PR TITLE
fix: prevent tangent-only chapters in auto-generated digests

### DIFF
--- a/src/lib/prompts/system.md
+++ b/src/lib/prompts/system.md
@@ -4,9 +4,12 @@ You are a content summarizer specializing in video transcripts. Your task is to 
 Create a brief 2-3 sentence summary that captures the essence of the video. This should give readers a quick understanding of what the video is about without watching it.
 
 ## Chapters
-Organize the video into chapters - major topic sections that help viewers navigate the content.
+Organize the video into chapters based on **main content topics** - not tangent boundaries.
 
-**Critical: All video time must be accounted for.** Chapter timestamps should be continuous with no gaps - each chapter's end time should match the next chapter's start time.
+**Critical rules:**
+1. **All video time must be accounted for.** Chapter timestamps should be continuous with no gaps - each chapter's end time should match the next chapter's start time.
+2. **Tangents do NOT create chapter boundaries.** A sponsor segment, personal aside, or off-topic rant in the middle of a topic discussion does NOT warrant its own chapter. It's an interruption within the ongoing topic.
+3. **Every chapter must have substantive content.** Each chapter needs at least 2 real takeaways about its topic. If a potential "chapter" would only contain tangent content, it's not a chapter - merge that time into the surrounding topic chapter.
 
 ### When Creator Chapters Are Provided
 If the user message includes "Creator-defined chapters", use those as your chapter structure:
@@ -18,10 +21,13 @@ If the user message includes "Creator-defined chapters", use those as your chapt
 - **Respect numbered titles**: If a chapter title implies a specific count (e.g., "2 Big Takeaways", "3 Key Lessons", "The Main Point"), match your key points count to that number. Don't write 3 points for "2 Big Takeaways" or multiple points for "The Big Takeaway".
 
 ### When No Creator Chapters Exist
-Generate 4-6 major topic chapters that logically divide the video content:
-- Think about the major themes and topic shifts in the video
+Generate 4-6 major topic chapters that follow the **main content flow**:
+- Base chapter boundaries on where the creator shifts between major topics
+- Ignore tangents when determining chapter boundaries - a 30-second sponsor mid-discussion is NOT a chapter break, it's an interruption within the chapter
 - Create descriptive chapter titles that capture each section's topic
 - Aim for chapters that represent meaningful content divisions, not every small topic shift
+
+**Important:** If you're tempted to create a chapter that would ONLY contain tangents, don't. Instead, include that tangent as a key point in the surrounding topic chapter.
 
 ## Key Points Within Chapters
 For each chapter, identify **2-4 substantive key points** that synthesize the most important takeaways:
@@ -32,19 +38,17 @@ For each chapter, identify **2-4 substantive key points** that synthesize the mo
 - Skip filler content (ums, repetition, extended pleasantries)
 
 ### Tangent Flagging
-**Tangents are additional** - they don't count against the 2-4 substantive key points requirement. Every chapter should have at least 2 real takeaways, plus any tangents.
-
-Flag a key point as a tangent (`isTangent: true`) only for **significant digressions** (30+ seconds) that clearly diverge from the chapter's stated topic:
+Tangents are **interruptions within a chapter**, not separate chapters. Flag a key point as a tangent (`isTangent: true`) only for significant digressions (30+ seconds) that interrupt the chapter's main topic:
 - Extended personal rants or unrelated stories
 - Long sponsor reads (not brief mentions)
 - Substantial off-topic discussions
+
+**Tangents are additional** - they don't count against the 2-4 substantive key points requirement. A chapter with 4 key points + 2 tangents is fine. Every chapter should have at least 2 real takeaways, plus any tangents.
 
 **Don't flag as tangents:**
 - Brief asides or quick jokes (under 30 seconds)
 - Related but less central points
 - Context or background that supports the main topic
-
-This is scoped to the chapter level - a point is a tangent if it doesn't fit the chapter's topic, not the video's overall theme.
 
 ## Link Categorization
 You will be provided with URLs found in the video description and comments. Categorize them into:


### PR DESCRIPTION
## Summary

- Updates system prompt to clarify that tangents don't create chapter boundaries - chapters should follow main content topics
- Adds `mergeTangentOnlyChapters()` post-processing function as a safety net to merge any tangent-only chapters into the previous chapter
- Creator-defined chapters are preserved as-is; only auto-generated chapters are post-processed

## Problem

When auto-generating chapters, the LLM sometimes creates chapters that contain only tangent content (e.g., a 30-second sponsor read). This causes:
1. Chapters with no substantive key points
2. Timestamp gaps where content isn't properly covered

## Solution

1. **Prompt improvements**: Make explicit that tangents are interruptions within chapters, not chapter boundaries
2. **Post-processing**: Add a safety net that detects and merges tangent-only chapters into the previous chapter, extending the timestamp range

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved chapter organization: chapters follow main topics, include 2–4 substantive, chronologically ordered key points, and avoid chaptering on tangents.
  * Tangents are now treated as interruptions to merge into adjacent chapters unless they notably interrupt (threshold applied).
  * Auto-generated chapters produce 4–6 topic-focused sections with descriptive titles.

* **Documentation**
  * Clarified rules for honoring creator-provided chapters and for providing contextual link categorization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->