### PR TITLE
fix: remove year preset from date filters

### DIFF
--- a/src/components/filters/date-filter.tsx
+++ b/src/components/filters/date-filter.tsx
@@ -46,13 +46,6 @@ export function DateFilter() {
     setDateTo(to);
   };
 
-  const setThisYear = () => {
-    const now = new Date();
-    const startOfYear = new Date(now.getFullYear(), 0, 1);
-    setDateFrom(startOfYear);
-    setDateTo(now);
-  };
-
   // Format date for display
   const formatDate = (date: Date) => {
     return date.toLocaleDateString("en-US", {
@@ -120,12 +113,6 @@ export function DateFilter() {
             className="px-2 py-1 text-xs rounded bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
           >
             Last 30 days
-          </button>
-          <button
-            onClick={setThisYear}
-            className="px-2 py-1 text-xs rounded bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
-          >
-            This year
           </button>
         </div>
 

--- a/src/components/filters/inline-date-filter.tsx
+++ b/src/components/filters/inline-date-filter.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
-type PresetKey = "24h" | "2d" | "3d" | "7d" | "30d" | "year";
+type PresetKey = "24h" | "2d" | "3d" | "7d" | "30d";
 
 interface Preset {
   key: PresetKey;
@@ -66,15 +66,6 @@ const presets: Preset[] = [
       const to = new Date();
       const from = new Date();
       from.setDate(from.getDate() - 30);
-      return { from, to };
-    },
-  },
-  {
-    key: "year",
-    label: "Year",
-    getRange: () => {
-      const to = new Date();
-      const from = new Date(to.getFullYear(), 0, 1);
       return { from, to };
     },
   },


### PR DESCRIPTION
## Summary

- Removes the "Year" preset from the inline date filter toolbar
- Removes the "This year" preset from the dropdown date filter component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the "This Year" date filter preset option from date filtering functionality. Date range selection now provides Last 7 days and Last 30 days as the available preset options. This change simplifies the user interface while maintaining access to the most commonly used time period options for filtering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->