### PR TITLE
Fix: Resolve stuck redirect when creating digest from digest page

### DIFF
--- a/src/components/new-digest-dialog.tsx
+++ b/src/components/new-digest-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
 import { Plus, Youtube } from "lucide-react";
 import { Button, type buttonVariants } from "@/components/ui/button";
 import {
@@ -26,6 +26,16 @@ export function NewDigestDialog({ variant = "default" }: NewDigestDialogProps) {
   const [currentStep, setCurrentStep] = useState<Step | null>(null);
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
+  const pathname = usePathname();
+
+  // Close the progress modal when the route changes after navigation
+  useEffect(() => {
+    if (isLoading && currentStep === "redirecting") {
+      setIsLoading(false);
+      setCurrentStep(null);
+      setError(null);
+    }
+  }, [pathname]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleLoadingStart = () => {
     setOpen(false);
@@ -41,9 +51,9 @@ export function NewDigestDialog({ variant = "default" }: NewDigestDialogProps) {
   };
 
   const handleDigestComplete = (digestId: string) => {
-    // Keep modal open with "redirecting" step - it will unmount when navigation completes
     setCurrentStep("redirecting");
     router.push(`/digest/${digestId}`);
+    router.refresh();
   };
 
   const handleProgressClose = () => {


### PR DESCRIPTION
Closes #48

## Summary

- `NewDigestDialog` lives in the `Header` inside the shared `(app)/layout.tsx`, so it persists across same-layout route transitions and never unmounts
- When navigating from `/digest/oldId` to `/digest/newId`, the progress modal state (`isLoading`, `currentStep`) was never reset, leaving it stuck at "Redirecting"
- Added `usePathname()` watcher to detect route changes and close the modal when navigation completes
- Added `router.refresh()` after `router.push()` to bypass the Next.js router cache for same-pattern dynamic routes (consistent with how `DeleteDigestButton` already handles navigation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loading state initialization during digest creation.
  * Ensured page refreshes after digest creation to display updated content.
  * Improved state reset when navigating between routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->