### PR TITLE
Fix toolbar tag filter pushing date filter off-screen

### DIFF
--- a/src/components/filters/inline-tag-filter.tsx
+++ b/src/components/filters/inline-tag-filter.tsx
@@ -19,20 +19,9 @@ import {
 import { cn } from "@/lib/utils";
 import type { Tag } from "@/lib/types";
 
-// Layout constants (in pixels)
-const LAYOUT = {
-  GAP_3: 12, // Tailwind gap-3
-  GAP_1_5: 6, // Tailwind gap-1.5
-  SEPARATOR_WIDTH: 1,
-  SEARCH_MIN_WIDTH: 400,
-  SIDEBAR_TOGGLE_WIDTH: 44,
-  DATE_FILTER_WIDTH_XL: 280, // Full presets visible
-  DATE_FILTER_WIDTH_SMALL: 32, // Just calendar icon
-  OVERFLOW_BUTTON_WIDTH: 50,
-  TOOLBAR_PADDING: 32, // px-4 on both sides
-  XL_BREAKPOINT: 1280,
-  NOWRAP_BREAKPOINT: 900, // Above this, CSS forces single line
-} as const;
+// Only self-referential constants remain (intrinsic to this component's own layout)
+const TAG_GAP = 6; // Matches gap-1.5 (0.375rem)
+const OVERFLOW_BUTTON_WIDTH = 50;
 
 interface InlineTagFilterProps {
   availableTags: Tag[];
@@ -48,61 +37,27 @@ export function InlineTagFilter({ availableTags }: InlineTagFilterProps) {
     })
   );
 
+  const outerRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const measureRef = useRef<HTMLDivElement>(null);
-  // Start with 0 - let calculation determine correct count (avoids chicken-and-egg)
   const [visibleCount, setVisibleCount] = useState(0);
 
   const selected = selectedTags ?? [];
 
-  // Measure how many tags fit while preserving search bar minimum width
+  // Measure how many tags fit by reading the outer wrapper's actual width
   useLayoutEffect(() => {
-    if (!measureRef.current || availableTags.length === 0) {
+    if (!measureRef.current || !outerRef.current || availableTags.length === 0) {
       setVisibleCount(availableTags.length);
       return;
     }
 
     const calculateVisibleTags = () => {
       const measureContainer = measureRef.current;
-      if (!measureContainer) return;
+      const outer = outerRef.current;
+      if (!measureContainer || !outer) return;
 
-      const toolbar = measureContainer.closest("[data-toolbar]");
-      const filterSection = measureContainer.closest("[data-filter-section]");
-      if (!toolbar || !filterSection) {
-        setVisibleCount(availableTags.length);
-        return;
-      }
-
-      // Detect if layout has wrapped by checking vertical positions
-      const searchContainer = toolbar.querySelector(
-        "[data-search-container]"
-      ) as HTMLElement | null;
-      const isWrapped =
-        searchContainer &&
-        filterSection instanceof HTMLElement &&
-        filterSection.offsetTop > searchContainer.offsetTop;
-
-      const toolbarWidth = (toolbar as HTMLElement).offsetWidth;
-      const separatorWidth = LAYOUT.SEPARATOR_WIDTH + LAYOUT.GAP_3 * 2;
-
-      // Date filter width depends on viewport
-      const isXl = window.innerWidth >= LAYOUT.XL_BREAKPOINT;
-      const dateFilterWidth = isXl
-        ? LAYOUT.DATE_FILTER_WIDTH_XL
-        : LAYOUT.DATE_FILTER_WIDTH_SMALL;
-
-      // Calculate theoretical space for filter section based on toolbar minus fixed elements
-      // This avoids the chicken-and-egg problem where filter section size depends on tag count
-      const sidebarToggle = toolbar.querySelector('[aria-label*="sidebar"]') ? LAYOUT.SIDEBAR_TOGGLE_WIDTH + LAYOUT.GAP_3 : 0;
-      const searchMaxWidth = 600; // Matches max-w-[600px] on search container
-      const theoreticalFilterSpace = toolbarWidth - Math.min(searchMaxWidth, toolbarWidth * 0.5) - sidebarToggle - LAYOUT.TOOLBAR_PADDING;
-
-      // Calculate space available for tags within the filter section
-      // When wrapped: filter section has full toolbar width (search is on its own row)
-      // When single line: use theoretical space (accounts for search bar)
-      const availableForTags = isWrapped
-        ? toolbarWidth - LAYOUT.TOOLBAR_PADDING - dateFilterWidth - LAYOUT.SEPARATOR_WIDTH - LAYOUT.GAP_3 * 2
-        : theoreticalFilterSpace - dateFilterWidth - separatorWidth * 2 - LAYOUT.GAP_3;
+      // The outer wrapper (flex-1 min-w-0) is sized by CSS -- just read it
+      const availableWidth = outer.clientWidth;
 
       // Measure actual tag widths from the hidden measurement container
       const tagElements = measureContainer.querySelectorAll("[data-tag]");
@@ -113,12 +68,12 @@ export function InlineTagFilter({ availableTags }: InlineTagFilterProps) {
 
       // Calculate total width of all tags
       const totalTagsWidth = tagWidths.reduce(
-        (sum, w, i) => sum + w + (i > 0 ? LAYOUT.GAP_1_5 : 0),
+        (sum, w, i) => sum + w + (i > 0 ? TAG_GAP : 0),
         0
       );
 
       // If all tags fit, show all
-      if (totalTagsWidth <= availableForTags) {
+      if (totalTagsWidth <= availableWidth) {
         setVisibleCount(availableTags.length);
         return;
       }
@@ -129,11 +84,10 @@ export function InlineTagFilter({ availableTags }: InlineTagFilterProps) {
 
       for (let i = 0; i < tagWidths.length; i++) {
         const tagWidth = tagWidths[i];
-        const widthNeeded = tagWidth + (count > 0 ? LAYOUT.GAP_1_5 : 0);
-        const reservedForOverflow =
-          LAYOUT.OVERFLOW_BUTTON_WIDTH + LAYOUT.GAP_1_5;
+        const widthNeeded = tagWidth + (count > 0 ? TAG_GAP : 0);
+        const reservedForOverflow = OVERFLOW_BUTTON_WIDTH + TAG_GAP;
 
-        if (usedWidth + widthNeeded + reservedForOverflow <= availableForTags) {
+        if (usedWidth + widthNeeded + reservedForOverflow <= availableWidth) {
           usedWidth += widthNeeded;
           count++;
         } else {
@@ -147,12 +101,9 @@ export function InlineTagFilter({ availableTags }: InlineTagFilterProps) {
     // Initial calculation
     calculateVisibleTags();
 
-    // Recalculate on resize - observe both toolbar and filter section
+    // Recalculate when the outer wrapper resizes (CSS handles the sizing)
     const resizeObserver = new ResizeObserver(calculateVisibleTags);
-    const toolbar = measureRef.current?.closest("[data-toolbar]");
-    const filterSection = measureRef.current?.closest("[data-filter-section]");
-    if (toolbar) resizeObserver.observe(toolbar);
-    if (filterSection) resizeObserver.observe(filterSection);
+    resizeObserver.observe(outerRef.current);
 
     return () => resizeObserver.disconnect();
   }, [availableTags]);
@@ -191,13 +142,23 @@ export function InlineTagFilter({ availableTags }: InlineTagFilterProps) {
         aria-hidden={isMeasure ? true : undefined}
       >
         {tag.name}
+        {tag.usageCount !== undefined && (
+          <span className={cn(
+            "text-[10px] leading-none relative top-px",
+            isSelected
+              ? "text-white/50"
+              : "text-[var(--color-text-tertiary)]/60"
+          )}>
+            {tag.usageCount}
+          </span>
+        )}
         {isSelected && !isMeasure && <X className="w-3 h-3" />}
       </button>
     );
   };
 
   return (
-    <>
+    <div ref={outerRef} className="flex-1 min-w-0 relative">
       {/* Hidden measurement container - positioned at origin to prevent overflow */}
       <div
         ref={measureRef}
@@ -209,11 +170,11 @@ export function InlineTagFilter({ availableTags }: InlineTagFilterProps) {
         ))}
       </div>
 
-      {/* Visible tags - shrink-0 so they don't compress */}
+      {/* Visible tags */}
       <div
         ref={containerRef}
         className={cn(
-          "flex items-center gap-1.5 shrink-0",
+          "flex items-center gap-1.5",
           isPending && "opacity-70"
         )}
       >
@@ -279,6 +240,6 @@ export function InlineTagFilter({ availableTags }: InlineTagFilterProps) {
           </Popover>
         )}
       </div>
-    </>
+    </div>
   );
 }

--- a/src/components/layout/library-toolbar.tsx
+++ b/src/components/layout/library-toolbar.tsx
@@ -72,19 +72,19 @@ export function LibraryToolbar({ availableTags = [] }: LibraryToolbarProps) {
           <DigestSearch />
         </div>
 
-        {/* Filter section - grows to fill remaining space */}
+        {/* Filter section - grows into remaining space, can shrink */}
         <div
           data-filter-section
-          className="flex items-center gap-3 flex-[1_0_auto] min-w-0"
+          className="flex items-center gap-3 flex-[1_1_0%] min-w-0"
         >
           {/* Separator - hide when likely wrapped */}
-          <div className="hidden min-[900px]:block h-5 w-px bg-[var(--color-border)]" />
+          <div className="hidden min-[900px]:block h-5 w-px shrink-0 bg-[var(--color-border)]" />
 
           {/* Inline tag pills */}
           <InlineTagFilter availableTags={availableTags} />
 
-          {/* Separator - ml-auto pushes date filter to the right */}
-          <div className="ml-auto h-5 w-px bg-[var(--color-border)]" />
+          {/* Separator */}
+          <div className="h-5 w-px shrink-0 bg-[var(--color-border)]" />
 
           {/* Date presets */}
           <InlineDateFilter />

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -689,7 +689,7 @@ export async function getUserTags(userId: string): Promise<Tag[]> {
     LEFT JOIN digest_tags dt ON t.id = dt.tag_id
     WHERE t.user_id = ${userId}
     GROUP BY t.id, t.name
-    ORDER BY usagecount DESC, t.name ASC
+    ORDER BY t.name ASC
   `;
   // Map the lowercase column name to camelCase
   return result.rows.map((row) => ({


### PR DESCRIPTION
## Summary

Closes #50

- Replace 11 hardcoded pixel constants in `InlineTagFilter` with direct CSS container measurement (`outer.clientWidth`)
- Change filter section flex from `flex-[1_0_auto]` to `flex-[1_1_0%]` so it shrinks properly instead of overflowing
- Add `shrink-0` to separator divs, remove `ml-auto` hack (tag container's `flex-1` naturally pushes date filter right)
- Simplify ResizeObserver from watching 2 elements to 1 (the outer wrapper)
- Show usage counts on inline tag pills (with accurate measurement sizing)
- Sort tags alphabetically instead of by usage count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tags now display usage count on tag pills

* **Bug Fixes**
  * Improved filter section layout behavior and responsiveness

* **Style**
  * Tag list now sorted alphabetically instead of by usage frequency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->