### PR TITLE
fix: invalidate client Router Cache after tag mutations

### DIFF
--- a/src/components/tag-input.tsx
+++ b/src/components/tag-input.tsx
@@ -25,6 +25,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { TagBadge } from "@/components/tag-badge";
+import { revalidateLibrary } from "@/lib/actions";
 import type { Tag } from "@/lib/types";
 
 interface TagInputProps {
@@ -98,6 +99,7 @@ export function TagInput({ digestId, initialTags }: TagInputProps) {
         setTags((prev) =>
           prev.map((t) => (t.id === tempId ? { ...newTag, isPending: false } : t))
         );
+        revalidateLibrary();
       } else {
         // Remove optimistic tag on failure
         setTags((prev) => prev.filter((t) => t.id !== tempId));
@@ -119,7 +121,9 @@ export function TagInput({ digestId, initialTags }: TagInputProps) {
         method: "DELETE",
       });
 
-      if (!res.ok && removedTag) {
+      if (res.ok) {
+        revalidateLibrary();
+      } else if (removedTag) {
         // Revert on failure
         setTags((prev) => [...prev, removedTag]);
       }
@@ -151,7 +155,9 @@ export function TagInput({ digestId, initialTags }: TagInputProps) {
         method: "DELETE",
       });
 
-      if (!res.ok) {
+      if (res.ok) {
+        revalidateLibrary();
+      } else {
         // Revert on failure - refetch tags
         fetch("/api/tags")
           .then((res) => res.json())

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+export async function revalidateLibrary() {
+  revalidatePath("/");
+}


### PR DESCRIPTION
## Summary

- Tags added/removed on a digest page weren't reflected when navigating back to the library
- Root cause: tag mutations use API Route Handlers, which can only invalidate the server-side cache — the client-side Next.js Router Cache remained stale
- Added a `revalidateLibrary()` Server Action that calls `revalidatePath("/")` — Server Action responses include headers that tell the Next.js router to invalidate its client-side cache
- Called after all three tag mutation paths: add tag, remove tag from digest, delete tag entirely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data synchronization for tag management operations, ensuring that tag additions, removals, and vocabulary deletions properly refresh to reflect the latest state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->