### PR TITLE
fix: refresh server data when library page is restored from bfcache

### DIFF
--- a/src/components/layout/library-shell.tsx
+++ b/src/components/layout/library-shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { type ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { LibrarySidebar } from "./library-sidebar";
 import { LibraryToolbar } from "./library-toolbar";
 import { ActiveFilters } from "@/components/filters";
@@ -17,6 +18,18 @@ interface LibraryShellProps {
 }
 
 export function LibraryShell({ children, availableTags = [] }: LibraryShellProps) {
+  const router = useRouter();
+
+  // Refresh server data when the page is restored from bfcache (browser back/forward).
+  // This ensures tags and other mutations made on detail pages are reflected.
+  useEffect(() => {
+    const handlePageShow = (e: PageTransitionEvent) => {
+      if (e.persisted) router.refresh();
+    };
+    window.addEventListener("pageshow", handlePageShow);
+    return () => window.removeEventListener("pageshow", handlePageShow);
+  }, [router]);
+
   return (
     <ContentPendingProvider>
       <div className="flex flex-1">


### PR DESCRIPTION
## Summary

- Browser bfcache restores the library page from frozen memory on back/forward navigation, bypassing Next.js entirely
- This meant tag changes made on digest detail pages weren't visible when navigating back
- Added a `pageshow` event listener in `LibraryShell` that calls `router.refresh()` when `event.persisted` is true (bfcache restore)
- `router.refresh()` silently reconciles server data in the background — no skeleton flash, no layout shift
- Complements PR #54's Server Action approach (which handles the Next.js Router Cache but not bfcache)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures data is refreshed when navigating back to previously visited pages using browser navigation controls, keeping information current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->