### PR TITLE
Add privacy policy page for CWS publishing

### DIFF
--- a/apps/web/src/app/(public)/layout.tsx
+++ b/apps/web/src/app/(public)/layout.tsx
@@ -1,12 +1,21 @@
 import Link from "next/link";
 import { Youtube } from "lucide-react";
+import { withAuth, signOut } from "@workos-inc/authkit-nextjs";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { UserMenu } from "@/components/user-menu";
 
-export default function PublicLayout({
+async function signOutAction() {
+  "use server";
+  await signOut();
+}
+
+export default async function PublicLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const { user } = await withAuth({ ensureSignedIn: false });
+
   return (
     <>
       <header className="sticky top-0 z-50 border-b border-[var(--color-border)] bg-[var(--color-bg-primary)]/95 backdrop-blur supports-[backdrop-filter]:bg-[var(--color-bg-primary)]/80">
@@ -20,13 +29,25 @@ export default function PublicLayout({
           </Link>
 
           <div className="flex items-center gap-4">
-            <Link
-              href="/auth"
-              prefetch={false}
-              className="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
-            >
-              Sign In
-            </Link>
+            {user ? (
+              <UserMenu
+                user={{
+                  email: user.email ?? "",
+                  firstName: user.firstName,
+                  lastName: user.lastName,
+                  profilePictureUrl: user.profilePictureUrl,
+                }}
+                signOutAction={signOutAction}
+              />
+            ) : (
+              <Link
+                href="/auth"
+                prefetch={false}
+                className="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+              >
+                Sign In
+              </Link>
+            )}
             <ThemeToggle />
           </div>
         </div>

--- a/apps/web/src/app/(public)/privacy/page.tsx
+++ b/apps/web/src/app/(public)/privacy/page.tsx
@@ -1,0 +1,295 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | Brief",
+  description:
+    "Privacy policy for Brief — the web app and Chrome extension for AI-powered YouTube video summaries.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="flex-1 px-4 py-8">
+      <article className="max-w-3xl mx-auto space-y-8">
+        <header>
+          <h1 className="text-2xl md:text-3xl font-semibold text-[var(--color-text-primary)] mb-2">
+            Privacy Policy
+          </h1>
+          <p className="text-[var(--color-text-secondary)]">
+            Effective date: February 19, 2026
+          </p>
+        </header>
+
+        {/* 1. Introduction */}
+        <Section title="Introduction">
+          <p>
+            Brief (&ldquo;we&rdquo;, &ldquo;us&rdquo;, or &ldquo;our&rdquo;)
+            provides an AI-powered YouTube video summarization service available
+            as a web application at{" "}
+            <a
+              href="https://brief.niftymonkey.dev"
+              className="text-[var(--color-accent)] hover:text-[var(--color-accent-hover)] transition-colors"
+            >
+              brief.niftymonkey.dev
+            </a>{" "}
+            and as a Chrome browser extension. This privacy policy explains what
+            information we collect, how we use it, and the choices you have.
+          </p>
+        </Section>
+
+        {/* 2. Information We Collect */}
+        <Section title="Information We Collect">
+          <h3 className="font-medium text-[var(--color-text-primary)] mt-4 mb-2">
+            Account information
+          </h3>
+          <p>
+            When you sign in, we receive basic identity information from our
+            authentication provider (WorkOS), such as your name, email address,
+            and profile picture. We use this solely to identify your account and
+            display your profile in the app.
+          </p>
+
+          <h3 className="font-medium text-[var(--color-text-primary)] mt-4 mb-2">
+            YouTube video data
+          </h3>
+          <p>
+            When you create a brief, we receive the YouTube video URL you
+            submit. We use a third-party transcript service (Supadata) to fetch
+            the video transcript, and an AI model (Anthropic Claude) to generate
+            a summary. The resulting brief&mdash;including the video title,
+            channel name, duration, summary, timestamped sections, and extracted
+            links&mdash;is stored on our servers and associated with your
+            account.
+          </p>
+
+          <h3 className="font-medium text-[var(--color-text-primary)] mt-4 mb-2">
+            Chrome extension local data
+          </h3>
+          <p>
+            The Brief Chrome extension stores a small amount of data locally on
+            your device using{" "}
+            <code className="text-sm bg-[var(--color-bg-secondary)] px-1.5 py-0.5 rounded">
+              chrome.storage.local
+            </code>
+            . This includes the URLs and titles of your five most recent video
+            submissions, along with their processing status. This data never
+            leaves your device and is automatically removed when you uninstall
+            the extension.
+          </p>
+        </Section>
+
+        {/* 3. How We Use Your Information */}
+        <Section title="How We Use Your Information">
+          <ul className="list-disc pl-5 space-y-2">
+            <li>
+              <strong>Summarization:</strong> We process YouTube video
+              transcripts to generate AI-powered summaries, timestamps, and
+              extracted links.
+            </li>
+            <li>
+              <strong>Authentication:</strong> We use your account information to
+              manage access and display your profile.
+            </li>
+            <li>
+              <strong>Notifications:</strong> The Chrome extension may show
+              browser notifications when a brief finishes processing. You can
+              disable notifications in your browser settings at any time.
+            </li>
+          </ul>
+          <p className="mt-3">
+            We do not use your data for advertising, analytics profiling, or any
+            purpose other than providing the Brief service.
+          </p>
+        </Section>
+
+        {/* 4. Third-Party Services */}
+        <Section title="Third-Party Services">
+          <p className="mb-3">
+            Brief relies on the following third-party services to operate. Each
+            service has its own privacy policy governing how it handles data:
+          </p>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>
+              <ExtLink href="https://workos.com/privacy">WorkOS</ExtLink>{" "}
+              &mdash; authentication and user identity
+            </li>
+            <li>
+              <ExtLink href="https://supadata.ai/privacy-policy">
+                Supadata
+              </ExtLink>{" "}
+              &mdash; YouTube transcript retrieval
+            </li>
+            <li>
+              <ExtLink href="https://www.anthropic.com/privacy">
+                Anthropic
+              </ExtLink>{" "}
+              &mdash; AI summarization (Claude)
+            </li>
+            <li>
+              <ExtLink href="https://vercel.com/legal/privacy-policy">
+                Vercel
+              </ExtLink>{" "}
+              &mdash; hosting and deployment
+            </li>
+          </ul>
+        </Section>
+
+        {/* 5. Chrome Extension Permissions */}
+        <Section title="Chrome Extension Permissions Explained">
+          <p className="mb-3">
+            The Brief Chrome extension requests the following permissions:
+          </p>
+          <dl className="space-y-3">
+            <PermissionItem term="activeTab">
+              Allows the extension to read the URL and title of the current tab
+              when you click the extension icon&mdash;used to detect YouTube
+              videos and pre-fill the submission form.
+            </PermissionItem>
+            <PermissionItem term="storage">
+              Used to store your five most recent brief submissions locally on
+              your device. No data is synced to other devices.
+            </PermissionItem>
+            <PermissionItem term="notifications">
+              Allows the extension to show a browser notification when a brief
+              finishes processing in the background.
+            </PermissionItem>
+            <PermissionItem term="cookies">
+              Used to read the authentication session cookie so the extension can
+              make authenticated requests to the Brief API on your behalf.
+            </PermissionItem>
+            <PermissionItem term="host_permissions">
+              The extension communicates with{" "}
+              <code className="text-sm bg-[var(--color-bg-secondary)] px-1.5 py-0.5 rounded">
+                brief.niftymonkey.dev
+              </code>{" "}
+              (the Brief API) and reads tab URLs on{" "}
+              <code className="text-sm bg-[var(--color-bg-secondary)] px-1.5 py-0.5 rounded">
+                youtube.com
+              </code>{" "}
+              to detect video pages.
+            </PermissionItem>
+          </dl>
+        </Section>
+
+        {/* 6. Data Sharing */}
+        <Section title="Data Sharing">
+          <p>
+            We do not sell, rent, or share your personal information with third
+            parties for advertising or marketing purposes. Data is only shared
+            with the third-party services listed above as necessary to provide
+            the Brief service.
+          </p>
+        </Section>
+
+        {/* 7. Data Retention */}
+        <Section title="Data Retention">
+          <ul className="list-disc pl-5 space-y-2">
+            <li>
+              <strong>Server-side data:</strong> Your briefs and account
+              information are retained as long as your account exists. You can
+              delete individual briefs at any time from the Brief library.
+            </li>
+            <li>
+              <strong>Extension local data:</strong> Data stored by the Chrome
+              extension is automatically cleared when you uninstall the
+              extension.
+            </li>
+          </ul>
+        </Section>
+
+        {/* 8. Cookies */}
+        <Section title="Cookies">
+          <p>
+            Brief uses a single session cookie (
+            <code className="text-sm bg-[var(--color-bg-secondary)] px-1.5 py-0.5 rounded">
+              wos-session
+            </code>
+            ) to maintain your authentication state. We do not use tracking
+            cookies, analytics cookies, or any third-party cookie-based
+            tracking.
+          </p>
+        </Section>
+
+        {/* 9. Contact */}
+        <Section title="Contact">
+          <p>
+            If you have questions about this privacy policy or your data, you
+            can reach us at{" "}
+            <a
+              href="mailto:mark.d.lozano+brief.privacy@gmail.com"
+              className="text-[var(--color-accent)] hover:text-[var(--color-accent-hover)] transition-colors"
+            >
+              mark.d.lozano+brief.privacy@gmail.com
+            </a>
+            .
+          </p>
+        </Section>
+
+        {/* 10. Changes to This Policy */}
+        <Section title="Changes to This Policy">
+          <p>
+            We may update this privacy policy from time to time. When we do, we
+            will revise the effective date at the top of this page. Continued use
+            of Brief after changes constitutes acceptance of the updated policy.
+          </p>
+        </Section>
+      </article>
+    </main>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <h2 className="text-lg font-semibold text-[var(--color-text-primary)] mb-1.5 pb-1 border-b border-[var(--color-border)]">
+        {title}
+      </h2>
+      <div className="text-[var(--color-text-secondary)] leading-relaxed pt-2 space-y-2">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function ExtLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-[var(--color-accent)] hover:text-[var(--color-accent-hover)] transition-colors"
+    >
+      {children}
+    </a>
+  );
+}
+
+function PermissionItem({
+  term,
+  children,
+}: {
+  term: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <dt className="font-medium text-[var(--color-text-primary)]">
+        <code className="text-sm bg-[var(--color-bg-secondary)] px-1.5 py-0.5 rounded">
+          {term}
+        </code>
+      </dt>
+      <dd className="mt-1 ml-4">{children}</dd>
+    </div>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -60,6 +60,15 @@ function LandingPage() {
           </div>
         </section>
       </main>
+      <footer className="px-4 py-6 text-center">
+        <Link
+          href="/privacy"
+          target="_blank"
+          className="text-sm text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)] transition-colors"
+        >
+          Privacy Policy
+        </Link>
+      </footer>
     </>
   );
 }

--- a/apps/web/src/components/user-menu.tsx
+++ b/apps/web/src/components/user-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { LogOut } from "lucide-react";
+import Link from "next/link";
+import { LogOut, Shield } from "lucide-react";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import {
   DropdownMenu,
@@ -57,7 +58,7 @@ export function UserMenu({ user, signOutAction }: UserMenuProps) {
   const displayName = getDisplayName(user.firstName, user.lastName, user.email);
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <button className="flex items-center gap-2 rounded-full p-0.5 hover:bg-[var(--color-bg-secondary)] transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]">
           <Avatar className="size-7">
@@ -79,6 +80,13 @@ export function UserMenu({ user, signOutAction }: UserMenuProps) {
             </p>
           </div>
         </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href="/privacy" target="_blank" className="cursor-pointer">
+            <Shield className="mr-2 h-4 w-4" />
+            Privacy Policy
+          </Link>
+        </DropdownMenuItem>
         <DropdownMenuSeparator />
         <form action={signOutAction}>
           <DropdownMenuItem asChild>

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -3,7 +3,7 @@ import { authkitMiddleware } from '@workos-inc/authkit-nextjs';
 export const proxy = authkitMiddleware({
   middlewareAuth: {
     enabled: true,
-    unauthenticatedPaths: ['/', '/auth', '/callback', '/api/:path*', '/share/:path*'],
+    unauthenticatedPaths: ['/', '/auth', '/callback', '/api/:path*', '/share/:path*', '/privacy'],
   },
 });
 


### PR DESCRIPTION
## Summary
- Add `/privacy` page (server component, no client JS) with full privacy policy covering web app and Chrome extension
- Add `/privacy` to `unauthenticatedPaths` in `proxy.ts` so the page is publicly accessible
- Add privacy policy link to landing page footer and user dropdown menu (opens in new tab)
- Make public layout auth-aware — logged-in users see their avatar instead of "Sign In" on public pages
- Fix scrollbar shift when opening user menu dropdown (`modal={false}`)

Closes #67 (partial — privacy policy is the repo-side requirement for CWS submission)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated Privacy Policy page accessible via the website
  * Added Privacy Policy link to user menu and footer
  * User menu now displays when signed in; sign-in option appears when not authenticated

* **Refactor**
  * Improved authentication state handling for better server-side integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->