### PR TITLE
Add @brief/core package and brief CLI binary

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@brief/cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "brief": "./dist/main.cjs"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsx src/main.ts",
+    "start": "node dist/main.cjs",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@brief/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.19.26",
+    "tsup": "^8.3.5",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.9"
+  }
+}

--- a/apps/cli/src/exit-codes.test.ts
+++ b/apps/cli/src/exit-codes.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { mapExitCode } from "./exit-codes";
+import type { TranscriptResult } from "@brief/core";
+
+describe("mapExitCode", () => {
+  it("returns 0 for ok", () => {
+    const r: TranscriptResult = {
+      kind: "ok",
+      source: "youtube-transcript-plus",
+      entries: [],
+    };
+    expect(mapExitCode(r)).toBe(0);
+  });
+
+  it("returns 2 for pending", () => {
+    const r: TranscriptResult = {
+      kind: "pending",
+      source: "supadata",
+      jobId: "j",
+      retryAfterSeconds: 90,
+      message: "queued",
+    };
+    expect(mapExitCode(r)).toBe(2);
+  });
+
+  it("returns 3 for unavailable", () => {
+    const r: TranscriptResult = {
+      kind: "unavailable",
+      reason: "no-captions",
+      message: "no caps",
+    };
+    expect(mapExitCode(r)).toBe(3);
+  });
+
+  it("returns 4 for transient", () => {
+    const r: TranscriptResult = {
+      kind: "transient",
+      cause: "net",
+      message: "net err",
+    };
+    expect(mapExitCode(r)).toBe(4);
+  });
+});

--- a/apps/cli/src/exit-codes.ts
+++ b/apps/cli/src/exit-codes.ts
@@ -1,0 +1,14 @@
+import type { TranscriptResult } from "@brief/core";
+
+export function mapExitCode(transcript: TranscriptResult): 0 | 2 | 3 | 4 {
+  switch (transcript.kind) {
+    case "ok":
+      return 0;
+    case "pending":
+      return 2;
+    case "unavailable":
+      return 3;
+    case "transient":
+      return 4;
+  }
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,0 +1,162 @@
+import { parseArgs } from "node:util";
+import {
+  fetchMetadata,
+  fetchTranscript,
+  type MetadataResult,
+  type SourceName,
+  type TranscriptResult,
+} from "@brief/core";
+import { mapExitCode } from "./exit-codes";
+import { render, type CombinedResult } from "./renderer";
+
+const USAGE = `Usage: brief <url-or-id> [options]
+
+Fetch a YouTube transcript on stdout.
+
+Options:
+  --json                    Emit machine-readable JSON instead of human output
+  --no-metadata             Skip the YouTube Data API metadata fetch
+  --source=<auto|local|supadata>
+                            Override the cascade. Default: auto.
+  --timeout=<ms>            Overall request budget in milliseconds
+  --supadata-key=<key>      Override SUPADATA_API_KEY env var
+  --youtube-key=<key>       Override YOUTUBE_API_KEY env var
+  --help                    Show this help
+
+Exit codes:
+  0  Transcript retrieved
+  1  Argument or unexpected error
+  2  Async generation queued (jobId in output)
+  3  Permanently unavailable
+  4  Transient failure after retries`;
+
+type Parsed = {
+  values: {
+    json?: boolean;
+    "no-metadata"?: boolean;
+    source?: string;
+    timeout?: string;
+    "supadata-key"?: string;
+    "youtube-key"?: string;
+    help?: boolean;
+  };
+  positionals: string[];
+};
+
+function parse(argv: string[]): Parsed {
+  return parseArgs({
+    args: argv,
+    allowPositionals: true,
+    options: {
+      json: { type: "boolean" },
+      "no-metadata": { type: "boolean" },
+      source: { type: "string" },
+      timeout: { type: "string" },
+      "supadata-key": { type: "string" },
+      "youtube-key": { type: "string" },
+      help: { type: "boolean" },
+    },
+  });
+}
+
+function mapSource(value: string | undefined): SourceName[] | undefined {
+  if (!value || value === "auto") return undefined;
+  if (value === "local") return ["youtube-transcript-plus"];
+  if (value === "supadata") return ["supadata"];
+  throw new Error(`Invalid --source=${value}; expected auto|local|supadata`);
+}
+
+async function main(): Promise<number> {
+  let parsed: Parsed;
+  try {
+    parsed = parse(process.argv.slice(2));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`${msg}\n\n${USAGE}\n`);
+    return 1;
+  }
+
+  if (parsed.values.help) {
+    process.stdout.write(`${USAGE}\n`);
+    return 1;
+  }
+
+  const positional = parsed.positionals[0];
+  if (!positional) {
+    process.stderr.write(`Missing positional argument <url-or-id>\n\n${USAGE}\n`);
+    return 1;
+  }
+
+  let sources: SourceName[] | undefined;
+  try {
+    sources = mapSource(parsed.values.source);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`${msg}\n`);
+    return 1;
+  }
+
+  const supadataKey = parsed.values["supadata-key"] ?? process.env.SUPADATA_API_KEY;
+  const youtubeKey = parsed.values["youtube-key"] ?? process.env.YOUTUBE_API_KEY;
+
+  if (parsed.values.source === "supadata" && !supadataKey) {
+    process.stderr.write(
+      `--source=supadata requires SUPADATA_API_KEY or --supadata-key\n`
+    );
+    return 1;
+  }
+
+  let signal: AbortSignal | undefined;
+  if (parsed.values.timeout) {
+    const ms = Number(parsed.values.timeout);
+    if (!Number.isFinite(ms) || ms <= 0) {
+      process.stderr.write(`--timeout must be a positive number of ms\n`);
+      return 1;
+    }
+    signal = AbortSignal.timeout(ms);
+  }
+
+  const wantMetadata = !parsed.values["no-metadata"] && !!youtubeKey;
+
+  const transcriptPromise: Promise<TranscriptResult> = fetchTranscript(
+    positional,
+    {
+      ...(supadataKey ? { supadataApiKey: supadataKey } : {}),
+      ...(sources ? { sources } : {}),
+      ...(signal ? { signal } : {}),
+    }
+  );
+  const metadataPromise: Promise<MetadataResult | null> = wantMetadata
+    ? fetchMetadata(positional, {
+        youtubeApiKey: youtubeKey!,
+        ...(signal ? { signal } : {}),
+      })
+    : Promise.resolve(null);
+
+  const [transcript, metadata] = await Promise.all([
+    transcriptPromise,
+    metadataPromise,
+  ]);
+
+  const combined: CombinedResult = {
+    videoIdOrUrl: positional,
+    transcript,
+    metadata,
+  };
+
+  const format = parsed.values.json ? "json" : "human";
+  const out = render(combined, format, !!process.stderr.isTTY);
+  if (out.stdout) process.stdout.write(out.stdout);
+  if (out.stderr) process.stderr.write(out.stderr);
+
+  return mapExitCode(transcript);
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Unexpected error: ${msg}\n`);
+    process.exit(1);
+  }
+);

--- a/apps/cli/src/renderer.test.ts
+++ b/apps/cli/src/renderer.test.ts
@@ -12,7 +12,7 @@ const okTranscript: TranscriptResult = {
   lang: "en",
   entries: [
     { offsetSec: 0, durationSec: 2, text: "hello" },
-    { offsetSec: 65, durationSec: 1, text: "world" },
+    { offsetSec: 2, durationSec: 1, text: "world" },
   ],
 };
 
@@ -62,7 +62,7 @@ function combined(
 describe("render — human format", () => {
   it("renders ok with metadata: header on stderr, transcript on stdout", () => {
     const out = render(combined(okTranscript, okMetadata), "human", false);
-    expect(out.stdout).toBe("[00:00] hello\n[01:05] world\n");
+    expect(out.stdout).toBe("hello world\n");
     expect(out.stderr).toContain("Title: Never Gonna Give You Up");
     expect(out.stderr).toContain("Channel: Rick Astley");
     expect(out.stderr).toContain("Duration: PT3M33S");
@@ -71,7 +71,7 @@ describe("render — human format", () => {
 
   it("renders ok without metadata: bare header with just video id and url", () => {
     const out = render(combined(okTranscript, null), "human", false);
-    expect(out.stdout).toBe("[00:00] hello\n[01:05] world\n");
+    expect(out.stdout).toBe("hello world\n");
     expect(out.stderr).toContain("Video ID: dQw4w9WgXcQ");
     expect(out.stderr).not.toContain("Title:");
     expect(out.stderr).not.toContain("Channel:");

--- a/apps/cli/src/renderer.test.ts
+++ b/apps/cli/src/renderer.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { render, type CombinedResult } from "./renderer";
+import type {
+  MetadataResult,
+  TranscriptResult,
+  VideoMetadata,
+} from "@brief/core";
+
+const okTranscript: TranscriptResult = {
+  kind: "ok",
+  source: "youtube-transcript-plus",
+  lang: "en",
+  entries: [
+    { offsetSec: 0, durationSec: 2, text: "hello" },
+    { offsetSec: 65, durationSec: 1, text: "world" },
+  ],
+};
+
+const pendingTranscript: TranscriptResult = {
+  kind: "pending",
+  source: "supadata",
+  jobId: "abc",
+  retryAfterSeconds: 90,
+  message: "queued",
+};
+
+const unavailableTranscript: TranscriptResult = {
+  kind: "unavailable",
+  reason: "no-captions",
+  message: "no captions",
+};
+
+const transientTranscript: TranscriptResult = {
+  kind: "transient",
+  cause: "net",
+  message: "net error",
+};
+
+const metadata: VideoMetadata = {
+  videoId: "dQw4w9WgXcQ",
+  title: "Never Gonna Give You Up",
+  channelTitle: "Rick Astley",
+  channelId: "UC1",
+  duration: "PT3M33S",
+  publishedAt: "2009-10-25T07:57:33Z",
+  description: "x",
+};
+
+const okMetadata: MetadataResult = { kind: "ok", metadata };
+
+function combined(
+  transcript: TranscriptResult,
+  metadataResult: MetadataResult | null
+): CombinedResult {
+  return {
+    videoIdOrUrl: "dQw4w9WgXcQ",
+    transcript,
+    metadata: metadataResult,
+  };
+}
+
+describe("render — human format", () => {
+  it("renders ok with metadata: header on stderr, transcript on stdout", () => {
+    const out = render(combined(okTranscript, okMetadata), "human", false);
+    expect(out.stdout).toBe("[00:00] hello\n[01:05] world\n");
+    expect(out.stderr).toContain("Title: Never Gonna Give You Up");
+    expect(out.stderr).toContain("Channel: Rick Astley");
+    expect(out.stderr).toContain("Duration: PT3M33S");
+    expect(out.stderr).toContain("Video ID: dQw4w9WgXcQ");
+  });
+
+  it("renders ok without metadata: bare header with just video id and url", () => {
+    const out = render(combined(okTranscript, null), "human", false);
+    expect(out.stdout).toBe("[00:00] hello\n[01:05] world\n");
+    expect(out.stderr).toContain("Video ID: dQw4w9WgXcQ");
+    expect(out.stderr).not.toContain("Title:");
+    expect(out.stderr).not.toContain("Channel:");
+  });
+
+  it("renders pending: empty stdout, message on stderr", () => {
+    const out = render(combined(pendingTranscript, null), "human", false);
+    expect(out.stdout).toBe("");
+    expect(out.stderr).toContain("Transcript generation queued");
+    expect(out.stderr).toContain("abc");
+    expect(out.stderr).toContain("90");
+  });
+
+  it("renders unavailable: empty stdout, reason on stderr", () => {
+    const out = render(combined(unavailableTranscript, null), "human", false);
+    expect(out.stdout).toBe("");
+    expect(out.stderr).toContain("Unavailable");
+    expect(out.stderr).toContain("no-captions");
+  });
+
+  it("renders transient: empty stdout, cause on stderr", () => {
+    const out = render(combined(transientTranscript, null), "human", false);
+    expect(out.stdout).toBe("");
+    expect(out.stderr).toContain("Transient");
+    expect(out.stderr).toContain("net");
+  });
+
+  it("does not emit ANSI when isTTY is false", () => {
+    const out = render(combined(okTranscript, okMetadata), "human", false);
+    // eslint-disable-next-line no-control-regex
+    expect(out.stderr).not.toMatch(/\x1b\[/);
+  });
+
+  it("never emits ANSI on stdout even when isTTY is true", () => {
+    const out = render(combined(okTranscript, okMetadata), "human", true);
+    // eslint-disable-next-line no-control-regex
+    expect(out.stdout).not.toMatch(/\x1b\[/);
+  });
+});
+
+describe("render — json format", () => {
+  it("emits a JSON object on stdout, empty stderr", () => {
+    const out = render(combined(okTranscript, okMetadata), "json", false);
+    expect(out.stderr).toBe("");
+    const parsed = JSON.parse(out.stdout);
+    expect(parsed.schemaVersion).toBe("1.0.0");
+    expect(parsed.status).toBe("ok");
+  });
+
+  it("enriches the video object with metadata fields when metadata is ok", () => {
+    const out = render(combined(okTranscript, okMetadata), "json", false);
+    const parsed = JSON.parse(out.stdout);
+    expect(parsed.video).toEqual({
+      id: "dQw4w9WgXcQ",
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      title: "Never Gonna Give You Up",
+      channel: "Rick Astley",
+      duration: "PT3M33S",
+      publishedAt: "2009-10-25T07:57:33Z",
+    });
+  });
+
+  it("emits a minimal video object when metadata is null", () => {
+    const out = render(combined(okTranscript, null), "json", false);
+    const parsed = JSON.parse(out.stdout);
+    expect(parsed.video).toEqual({
+      id: "dQw4w9WgXcQ",
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+  });
+
+  it("renders pending status with job and source", () => {
+    const out = render(combined(pendingTranscript, null), "json", false);
+    const parsed = JSON.parse(out.stdout);
+    expect(parsed.status).toBe("pending");
+    expect(parsed.source).toBe("supadata");
+    expect(parsed.job).toEqual({ id: "abc", retryAfterSeconds: 90 });
+  });
+
+  it("renders unavailable with reason", () => {
+    const out = render(combined(unavailableTranscript, null), "json", false);
+    const parsed = JSON.parse(out.stdout);
+    expect(parsed.status).toBe("unavailable");
+    expect(parsed.reason).toBe("no-captions");
+  });
+
+  it("uses videoIdOrUrl as the URL when input is already a URL", () => {
+    const c = {
+      videoIdOrUrl: "https://youtu.be/dQw4w9WgXcQ",
+      transcript: okTranscript,
+      metadata: null,
+    };
+    const out = render(c, "json", false);
+    const parsed = JSON.parse(out.stdout);
+    expect(parsed.video.url).toBe("https://youtu.be/dQw4w9WgXcQ");
+    expect(parsed.video.id).toBe("dQw4w9WgXcQ");
+  });
+});

--- a/apps/cli/src/renderer.ts
+++ b/apps/cli/src/renderer.ts
@@ -1,0 +1,101 @@
+import {
+  formatTranscript,
+  type MetadataResult,
+  type TranscriptResult,
+  type VideoMetadata,
+} from "@brief/core";
+
+export type CombinedResult = {
+  videoIdOrUrl: string;
+  transcript: TranscriptResult;
+  metadata: MetadataResult | null;
+};
+
+export type RenderFormat = "human" | "json";
+
+export type Rendered = { stdout: string; stderr: string };
+
+const DIM = "\x1b[2m";
+const RESET = "\x1b[0m";
+
+export function render(
+  combined: CombinedResult,
+  format: RenderFormat,
+  isTTY: boolean
+): Rendered {
+  return format === "json"
+    ? renderJson(combined)
+    : renderHuman(combined, isTTY);
+}
+
+function renderHuman(combined: CombinedResult, isTTY: boolean): Rendered {
+  const { transcript, metadata, videoIdOrUrl } = combined;
+  const headerLines = buildHeader(videoIdOrUrl, metadata, isTTY);
+  const stderrLines = [...headerLines];
+
+  let stdout = "";
+  if (transcript.kind === "ok") {
+    stdout = formatTranscript(transcript, "text") + "\n";
+  } else {
+    stderrLines.push("");
+    stderrLines.push(formatTranscript(transcript, "text"));
+  }
+
+  return { stdout, stderr: stderrLines.join("\n") + "\n" };
+}
+
+function buildHeader(
+  videoIdOrUrl: string,
+  metadata: MetadataResult | null,
+  isTTY: boolean
+): string[] {
+  const dim = (s: string): string => (isTTY ? `${DIM}${s}${RESET}` : s);
+  const lines: string[] = [];
+  const id = extractIdFromInput(videoIdOrUrl);
+
+  if (metadata?.kind === "ok") {
+    lines.push(`Title: ${metadata.metadata.title}`);
+    lines.push(`Channel: ${metadata.metadata.channelTitle}`);
+    lines.push(`Duration: ${metadata.metadata.duration}`);
+  }
+  lines.push(`Video ID: ${id}`);
+  lines.push(`URL: ${videoIdOrUrl}`);
+
+  return lines.map(dim);
+}
+
+function renderJson(combined: CombinedResult): Rendered {
+  const baseStr = formatTranscript(combined.transcript, "json");
+  const base = JSON.parse(baseStr) as Record<string, unknown>;
+
+  const id = extractIdFromInput(combined.videoIdOrUrl);
+  const url = isUrl(combined.videoIdOrUrl)
+    ? combined.videoIdOrUrl
+    : `https://www.youtube.com/watch?v=${id}`;
+
+  const video: Record<string, unknown> = { id, url };
+  if (combined.metadata?.kind === "ok") {
+    const m: VideoMetadata = combined.metadata.metadata;
+    video.title = m.title;
+    video.channel = m.channelTitle;
+    video.duration = m.duration;
+    video.publishedAt = m.publishedAt;
+  }
+  base.video = video;
+
+  return { stdout: JSON.stringify(base, null, 2) + "\n", stderr: "" };
+}
+
+function isUrl(input: string): boolean {
+  return /^https?:\/\//i.test(input);
+}
+
+function extractIdFromInput(input: string): string {
+  const ID = /^[a-zA-Z0-9_-]{11}$/;
+  if (ID.test(input)) return input;
+  const match =
+    input.match(/[?&]v=([a-zA-Z0-9_-]{11})/) ||
+    input.match(/youtu\.be\/([a-zA-Z0-9_-]{11})/) ||
+    input.match(/embed\/([a-zA-Z0-9_-]{11})/);
+  return match?.[1] ?? input;
+}

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -9,6 +9,15 @@ export default defineConfig({
   shims: false,
   splitting: false,
   noExternal: ["@brief/core"],
-  banner: { js: "#!/usr/bin/env node" },
+  banner: {
+    js: [
+      "#!/usr/bin/env node",
+      "process.removeAllListeners('warning');",
+      "process.on('warning', (w) => {",
+      "  if (w.code === 'DEP0040') return;",
+      "  process.stderr.write('(node:' + process.pid + ') ' + w.name + ': ' + w.message + '\\n');",
+      "});",
+    ].join("\n"),
+  },
   outExtension: () => ({ js: ".cjs" }),
 });

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/main.ts"],
+  format: ["cjs"],
+  target: "node20",
+  outDir: "dist",
+  clean: true,
+  shims: false,
+  splitting: false,
+  noExternal: ["@brief/core"],
+  banner: { js: "#!/usr/bin/env node" },
+  outExtension: () => ({ js: ".cjs" }),
+});

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    passWithNoTests: true,
+  },
+});

--- a/docs/architecture/transcript-cli.md
+++ b/docs/architecture/transcript-cli.md
@@ -4,7 +4,9 @@ Design pass for issue [#76](https://github.com/niftymonkey/brief/issues/76) — 
 
 ## Why this design
 
-Two surfaces need YouTube transcript retrieval: the existing web app and a new CLI for unattended use (interactive humans, shell scripts, AI coding agents). Today the web app's fetcher dispatches to one of two upstream sources by env-var presence and discards Supadata's async-generation jobs. The new shared package replaces that with a deterministic cascade, models four distinct outcomes as a discriminated union, and treats the reliability concerns documented in [#75](https://github.com/niftymonkey/brief/issues/75) — retry/backoff, schema validation at the upstream boundary, jobId tracking — as foundational v1 behavior rather than future drop-ins.
+Two surfaces need YouTube transcript retrieval: the existing web app and a new CLI for unattended use (interactive humans, shell scripts, AI coding agents). Today the web app's fetcher dispatches to one of two upstream sources by env-var presence and discards Supadata's async-generation jobs. The new shared package replaces that with a deterministic cascade, models four distinct outcomes as a discriminated union, and treats the reliability concerns documented in [#75](https://github.com/niftymonkey/brief/issues/75) — retry/backoff, runtime Zod schema validation at *both* adapter boundaries, jobId tracking — as foundational v1 behavior rather than future drop-ins.
+
+**Naming note (post-implementation):** during the build pass the package was named `@brief/core` (it owns more than transcripts — also metadata, ID parsing, and the shared serializer) and the binary was named `brief` (single-word convention, matching `npm`/`git`/`gh`). References below to "`packages/transcript`" and "`brief-transcript`" reflect the original architecture sketch; the implementation is `packages/core` and `brief`.
 
 ## Module landscape
 
@@ -150,7 +152,7 @@ This is the part of the orchestrator that earns its keep — duplicating it in t
 
 | Element | Decision |
 |---|---|
-| Binary name | `brief-transcript` |
+| Binary name | `brief` (was `brief-transcript` in the sketch) |
 | Positional | `<url-or-id>` |
 | `--json` | Switch to machine-readable output |
 | `--no-metadata` | Skip YouTube Data API call |
@@ -226,14 +228,14 @@ The package's *external* interface has no port. The TranscriptSource port is pur
 
 ## Test surface
 
-- **`packages/transcript`**: tests cross `fetchTranscript()` with stub TranscriptSources. The cascade rules table is the test matrix. Adapter tests use recorded fixtures or HTTP mocks at the network layer. The Supadata schema validator has its own tests against representative response shapes.
+- **`packages/core`**: tests cross `fetchTranscript()` with stub TranscriptSources. The cascade rules table is the test matrix. Adapter tests use recorded fixtures or module mocks at the SDK layer. **Both** adapters' Zod schema validators have their own tests against representative response shapes (a runtime mismatch maps to `transient` with cause `schema-mismatch`).
 - **`apps/cli`**: Renderer and ExitCodeMapper tested directly with synthesized `CombinedResult` values. Entrypoint tested via integration (spawn the binary, assert on stdout/stderr/exit code). No mocking through the package boundary.
 
 ## Locked decisions
 
 | # | Decision |
 |---|---|
-| 1 | CLI bin name: `brief-transcript` |
+| 1 | CLI bin name: `brief` (originally `brief-transcript`; renamed during implementation for the single-word `npm`/`git`/`gh` convention) |
 | 2 | No Supadata key → silent skip; CLI runs zero-config on local-only |
 | 3 | Metadata: best-effort with key, skip without; never affects exit code |
 | 4 | Arg parser: `node:util` `parseArgs` (no dep) |
@@ -245,4 +247,4 @@ The package's *external* interface has no port. The TranscriptSource port is pur
 
 - **#76** — this design pass; deliverable is the package + CLI.
 - **#75** — narrowed to "the web app's existing local fetcher." Closes by inheritance when the web-app migration ticket lands.
-- **Web-app migration ticket** — drafted as a follow-up to #76. Swaps `apps/web` to consume `packages/transcript`, retires `apps/web/src/lib/transcript.ts`, closes #75.
+- **Web-app migration ticket(s)** — follow-ups to #76. One ticket swaps `apps/web` to consume `packages/core` for `extractVideoId` + `fetchMetadata` and retires `apps/web/src/cli.ts`. A separate ticket (#77) swaps `apps/web/src/lib/transcript.ts` for `fetchTranscript`, which closes #75 by inheritance.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "pnpm --filter @brief/web start",
     "lint": "pnpm --filter @brief/web lint",
     "brief": "pnpm --filter @brief/web brief",
+    "cli": "node apps/cli/dist/main.cjs",
     "migrate": "pnpm --filter @brief/web migrate",
     "backfill-search": "pnpm --filter @brief/web backfill-search",
     "security": "pnpm --filter @brief/web security",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@brief/core",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@googleapis/youtube": "^18.0.0",
+    "@supadata/js": "^1.3.2",
+    "youtube-transcript-plus": "^1.1.2",
+    "zod": "^4.3.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.19.26",
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.9"
+  }
+}

--- a/packages/core/src/fetcher.test.ts
+++ b/packages/core/src/fetcher.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchTranscript } from "./fetcher";
+import type { SourceOutcome, TranscriptSource } from "./sources/types";
+import type {
+  SourceName,
+  TranscriptCache,
+  TranscriptResult,
+} from "./types";
+
+vi.mock("./sources/local", () => ({
+  LocalSource: class {
+    readonly name = "youtube-transcript-plus" as const;
+    fetch = localFetch;
+  },
+}));
+vi.mock("./sources/supadata", () => ({
+  SupadataSource: class {
+    constructor(_key: string) {
+      void _key;
+    }
+    readonly name = "supadata" as const;
+    fetch = supadataFetch;
+  },
+}));
+
+const localFetch = vi.fn<(...args: unknown[]) => Promise<SourceOutcome>>();
+const supadataFetch = vi.fn<(...args: unknown[]) => Promise<SourceOutcome>>();
+
+function reset() {
+  localFetch.mockReset();
+  supadataFetch.mockReset();
+}
+
+const noRetry = { maxAttempts: 1, initialDelayMs: 0, backoffMultiplier: 1 };
+
+const VID = "dQw4w9WgXcQ";
+
+describe("fetchTranscript cascade", () => {
+  it("returns ok from src1 immediately, not calling src2", async () => {
+    reset();
+    localFetch.mockResolvedValue({ kind: "ok", entries: [], lang: "en" });
+    supadataFetch.mockResolvedValue({ kind: "ok", entries: [] });
+
+    const result = await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      retryPolicy: noRetry,
+    });
+
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.source).toBe("youtube-transcript-plus");
+    }
+    expect(localFetch).toHaveBeenCalledTimes(1);
+    expect(supadataFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns pending from src1 immediately (short-circuits)", async () => {
+    reset();
+    localFetch.mockResolvedValue({
+      kind: "pending",
+      jobId: "j",
+      retryAfterSeconds: 90,
+    } as SourceOutcome);
+    supadataFetch.mockResolvedValue({ kind: "ok", entries: [] });
+
+    const result = await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      retryPolicy: noRetry,
+    });
+
+    expect(result.kind).toBe("pending");
+    expect(supadataFetch).not.toHaveBeenCalled();
+  });
+
+  it("falls through unavailable→ok and returns src2", async () => {
+    reset();
+    localFetch.mockResolvedValue({ kind: "unavailable", reason: "no-captions" });
+    supadataFetch.mockResolvedValue({ kind: "ok", entries: [], lang: "en" });
+
+    const result = await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      retryPolicy: noRetry,
+    });
+
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") expect(result.source).toBe("supadata");
+  });
+
+  it("falls through transient→ok and returns src2", async () => {
+    reset();
+    localFetch.mockResolvedValue({ kind: "transient", cause: "net" });
+    supadataFetch.mockResolvedValue({ kind: "ok", entries: [], lang: "en" });
+
+    const result = await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      retryPolicy: noRetry,
+    });
+
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") expect(result.source).toBe("supadata");
+  });
+
+  it("prefers later unavailable over earlier transient (more informative)", async () => {
+    reset();
+    localFetch.mockResolvedValue({ kind: "transient", cause: "net" });
+    supadataFetch.mockResolvedValue({
+      kind: "unavailable",
+      reason: "no-captions",
+    });
+
+    const result = await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      retryPolicy: noRetry,
+    });
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") expect(result.reason).toBe("no-captions");
+  });
+
+  it("keeps earlier unavailable when later returns transient", async () => {
+    reset();
+    localFetch.mockResolvedValue({
+      kind: "unavailable",
+      reason: "no-captions",
+    });
+    supadataFetch.mockResolvedValue({ kind: "transient", cause: "net" });
+
+    const result = await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      retryPolicy: noRetry,
+    });
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") expect(result.reason).toBe("no-captions");
+  });
+
+  it("returns transient when only transient outcomes seen", async () => {
+    reset();
+    localFetch.mockResolvedValue({ kind: "transient", cause: "n1" });
+    supadataFetch.mockResolvedValue({ kind: "transient", cause: "n2" });
+
+    const result = await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      retryPolicy: noRetry,
+    });
+
+    expect(result.kind).toBe("transient");
+  });
+
+  it("returns last unavailable when both are unavailable", async () => {
+    reset();
+    localFetch.mockResolvedValue({ kind: "unavailable", reason: "no-captions" });
+    supadataFetch.mockResolvedValue({
+      kind: "unavailable",
+      reason: "video-removed",
+    });
+
+    const result = await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      retryPolicy: noRetry,
+    });
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") {
+      expect(result.reason).toBe("video-removed");
+    }
+  });
+
+  it("returns invalid-id when input does not parse, no source called", async () => {
+    reset();
+    const result = await fetchTranscript("not-a-video!!", {
+      supadataApiKey: "key",
+      retryPolicy: noRetry,
+    });
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") expect(result.reason).toBe("invalid-id");
+    expect(localFetch).not.toHaveBeenCalled();
+    expect(supadataFetch).not.toHaveBeenCalled();
+  });
+
+  it("skips Supadata when no apiKey is provided", async () => {
+    reset();
+    localFetch.mockResolvedValue({ kind: "transient", cause: "net" });
+
+    const result = await fetchTranscript(VID, { retryPolicy: noRetry });
+
+    expect(supadataFetch).not.toHaveBeenCalled();
+    expect(result.kind).toBe("transient");
+  });
+
+  it("honors opts.sources override: only local", async () => {
+    reset();
+    localFetch.mockResolvedValue({ kind: "ok", entries: [] });
+
+    await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      sources: ["youtube-transcript-plus"],
+      retryPolicy: noRetry,
+    });
+
+    expect(localFetch).toHaveBeenCalled();
+    expect(supadataFetch).not.toHaveBeenCalled();
+  });
+
+  it("honors opts.sources override: only supadata", async () => {
+    reset();
+    supadataFetch.mockResolvedValue({ kind: "ok", entries: [] });
+
+    await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      sources: ["supadata"],
+      retryPolicy: noRetry,
+    });
+
+    expect(supadataFetch).toHaveBeenCalled();
+    expect(localFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns transient: no-sources when sources resolve to empty (e.g. supadata-only without key)", async () => {
+    reset();
+    const result = await fetchTranscript(VID, {
+      sources: ["supadata"] as SourceName[],
+      retryPolicy: noRetry,
+    });
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") {
+      expect(result.cause).toBe("no-sources");
+    }
+  });
+
+  it("checks cache.get before cascade and returns cached result", async () => {
+    reset();
+    const cached: TranscriptResult = {
+      kind: "ok",
+      source: "youtube-transcript-plus",
+      entries: [],
+      lang: "en",
+    };
+    const cache: TranscriptCache = {
+      get: vi.fn().mockResolvedValue(cached),
+      set: vi.fn(),
+    };
+
+    const result = await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      cache,
+      retryPolicy: noRetry,
+    });
+
+    expect(result).toBe(cached);
+    expect(cache.get).toHaveBeenCalledWith(VID);
+    expect(localFetch).not.toHaveBeenCalled();
+  });
+
+  it("writes ok results to cache.set", async () => {
+    reset();
+    localFetch.mockResolvedValue({ kind: "ok", entries: [], lang: "en" });
+    const cache: TranscriptCache = {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      cache,
+      retryPolicy: noRetry,
+    });
+
+    expect(cache.set).toHaveBeenCalledTimes(1);
+    expect(cache.set).toHaveBeenCalledWith(VID, result);
+  });
+
+  it("does not call cache.set on non-ok outcomes", async () => {
+    reset();
+    localFetch.mockResolvedValue({ kind: "transient", cause: "net" });
+    supadataFetch.mockResolvedValue({ kind: "transient", cause: "net" });
+    const cache: TranscriptCache = {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      cache,
+      retryPolicy: noRetry,
+    });
+
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it("swallows cache.set errors and still returns the ok result", async () => {
+    reset();
+    localFetch.mockResolvedValue({ kind: "ok", entries: [], lang: "en" });
+    const cache: TranscriptCache = {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockRejectedValue(new Error("disk full")),
+    };
+
+    const result = await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      cache,
+      retryPolicy: noRetry,
+    });
+
+    expect(result.kind).toBe("ok");
+  });
+
+  it("returns transient: aborted when signal is already aborted", async () => {
+    reset();
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      signal: controller.signal,
+      retryPolicy: noRetry,
+    });
+
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") expect(result.cause).toBe("aborted");
+    expect(localFetch).not.toHaveBeenCalled();
+  });
+
+  it("decorates ok with the source that succeeded", async () => {
+    reset();
+    localFetch.mockResolvedValue({
+      kind: "ok",
+      entries: [{ offsetSec: 1, durationSec: 1, text: "hi" }],
+      lang: "en",
+    });
+
+    const result = await fetchTranscript(VID, { retryPolicy: noRetry });
+
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.source).toBe("youtube-transcript-plus");
+      expect(result.entries).toHaveLength(1);
+      expect(result.lang).toBe("en");
+    }
+  });
+
+  it("decorates pending with the source that returned it", async () => {
+    reset();
+    localFetch.mockResolvedValue({ kind: "unavailable", reason: "no-captions" });
+    supadataFetch.mockResolvedValue({
+      kind: "pending",
+      jobId: "abc",
+      retryAfterSeconds: 60,
+    });
+
+    const result = await fetchTranscript(VID, {
+      supadataApiKey: "key",
+      retryPolicy: noRetry,
+    });
+
+    expect(result.kind).toBe("pending");
+    if (result.kind === "pending") {
+      expect(result.source).toBe("supadata");
+      expect(result.jobId).toBe("abc");
+      expect(result.retryAfterSeconds).toBe(60);
+    }
+  });
+});

--- a/packages/core/src/fetcher.ts
+++ b/packages/core/src/fetcher.ts
@@ -1,0 +1,172 @@
+import { extractVideoId } from "./parser";
+import { LocalSource } from "./sources/local";
+import { DEFAULT_RETRY_POLICY, withRetry } from "./sources/retry";
+import { SupadataSource } from "./sources/supadata";
+import type { SourceOutcome, TranscriptSource } from "./sources/types";
+import type {
+  SourceName,
+  TranscriptOptions,
+  TranscriptResult,
+} from "./types";
+
+const DEFAULT_SOURCES: SourceName[] = ["youtube-transcript-plus", "supadata"];
+
+export async function fetchTranscript(
+  input: string,
+  opts: TranscriptOptions = {}
+): Promise<TranscriptResult> {
+  const videoId = extractVideoId(input);
+  if (!videoId) {
+    return {
+      kind: "unavailable",
+      reason: "invalid-id",
+      message: `Could not extract a YouTube video ID from "${input}"`,
+    };
+  }
+
+  if (opts.signal?.aborted) {
+    return {
+      kind: "transient",
+      cause: "aborted",
+      message: "Request aborted before any source was tried",
+    };
+  }
+
+  if (opts.cache) {
+    const cached = await opts.cache.get(videoId);
+    if (cached) return cached;
+  }
+
+  const sources = buildSources(opts);
+  if (sources.length === 0) {
+    return {
+      kind: "transient",
+      cause: "no-sources",
+      message:
+        "No transcript sources available for this configuration (Supadata key may be missing)",
+    };
+  }
+
+  const policy = opts.retryPolicy ?? DEFAULT_RETRY_POLICY;
+  let bestNonTerminal: TranscriptResult | null = null;
+
+  for (const source of sources) {
+    if (opts.signal?.aborted) {
+      return {
+        kind: "transient",
+        cause: "aborted",
+        message: "Request aborted mid-cascade",
+      };
+    }
+
+    const decorated = withRetry(source, policy);
+    const outcome = await decorated.fetch(videoId, opts.signal);
+    const result = decorate(outcome, source.name);
+
+    if (result.kind === "ok") {
+      await writeCache(opts, videoId, result);
+      return result;
+    }
+
+    if (result.kind === "pending") {
+      return result;
+    }
+
+    if (result.kind === "unavailable") {
+      bestNonTerminal = result;
+      continue;
+    }
+
+    if (!bestNonTerminal || bestNonTerminal.kind !== "unavailable") {
+      bestNonTerminal = result;
+    }
+  }
+
+  return (
+    bestNonTerminal ?? {
+      kind: "transient",
+      cause: "exhausted",
+      message: "All transcript sources exhausted",
+    }
+  );
+}
+
+function buildSources(opts: TranscriptOptions): TranscriptSource[] {
+  const requested = opts.sources ?? DEFAULT_SOURCES;
+  const sources: TranscriptSource[] = [];
+
+  for (const name of requested) {
+    if (name === "youtube-transcript-plus") {
+      sources.push(new LocalSource());
+    } else if (name === "supadata") {
+      if (!opts.supadataApiKey) continue;
+      sources.push(new SupadataSource(opts.supadataApiKey));
+    }
+  }
+
+  return sources;
+}
+
+function decorate(
+  outcome: SourceOutcome,
+  source: SourceName
+): TranscriptResult {
+  switch (outcome.kind) {
+    case "ok":
+      return {
+        kind: "ok",
+        source,
+        ...(outcome.lang ? { lang: outcome.lang } : {}),
+        entries: outcome.entries,
+      };
+    case "pending":
+      return {
+        kind: "pending",
+        source,
+        jobId: outcome.jobId,
+        retryAfterSeconds: outcome.retryAfterSeconds,
+        message: `Transcript generation queued by ${source}`,
+      };
+    case "unavailable":
+      return {
+        kind: "unavailable",
+        reason: outcome.reason,
+        message: messageForUnavailable(outcome.reason),
+      };
+    case "transient":
+      return {
+        kind: "transient",
+        cause: outcome.cause,
+        message: `Transient failure (${outcome.cause}) from ${source}`,
+      };
+  }
+}
+
+function messageForUnavailable(reason: string): string {
+  switch (reason) {
+    case "no-captions":
+      return "No captions or transcript available for this video";
+    case "video-removed":
+      return "Video is unavailable or has been removed";
+    case "video-private":
+      return "Video is private";
+    case "invalid-id":
+      return "Invalid video ID";
+    default:
+      return "Transcript unavailable";
+  }
+}
+
+async function writeCache(
+  opts: TranscriptOptions,
+  videoId: string,
+  result: TranscriptResult
+): Promise<void> {
+  if (!opts.cache) return;
+  try {
+    await opts.cache.set(videoId, result);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[transcript] cache.set failed for ${videoId}: ${msg}`);
+  }
+}

--- a/packages/core/src/format.test.ts
+++ b/packages/core/src/format.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { formatTranscript, SCHEMA_VERSION } from "./format";
+import type { TranscriptResult } from "./types";
+
+const okResult: TranscriptResult = {
+  kind: "ok",
+  source: "youtube-transcript-plus",
+  lang: "en",
+  entries: [
+    { offsetSec: 0, durationSec: 2, text: "hello" },
+    { offsetSec: 65, durationSec: 3, text: "world" },
+    { offsetSec: 3725, durationSec: 4, text: "later" },
+  ],
+};
+
+const pendingResult: TranscriptResult = {
+  kind: "pending",
+  source: "supadata",
+  jobId: "job-123",
+  retryAfterSeconds: 90,
+  message: "Transcript generation queued",
+};
+
+const unavailableResult: TranscriptResult = {
+  kind: "unavailable",
+  reason: "no-captions",
+  message: "No captions available",
+};
+
+const transientResult: TranscriptResult = {
+  kind: "transient",
+  cause: "ECONNRESET",
+  message: "Network error talking to upstream",
+};
+
+describe("formatTranscript text format", () => {
+  it("renders ok entries as [MM:SS] lines", () => {
+    expect(formatTranscript(okResult, "text")).toBe(
+      "[00:00] hello\n[01:05] world\n[1:02:05] later"
+    );
+  });
+
+  it("renders pending as a single informative line", () => {
+    expect(formatTranscript(pendingResult, "text")).toBe(
+      "Transcript generation queued (jobId: job-123, retryAfter: 90s)"
+    );
+  });
+
+  it("renders unavailable as a single line with the reason", () => {
+    expect(formatTranscript(unavailableResult, "text")).toBe(
+      "Unavailable (no-captions): No captions available"
+    );
+  });
+
+  it("renders transient as a single line with the cause", () => {
+    expect(formatTranscript(transientResult, "text")).toBe(
+      "Transient failure (ECONNRESET): Network error talking to upstream"
+    );
+  });
+});
+
+describe("formatTranscript json format", () => {
+  it("uses schemaVersion 1.0.0", () => {
+    const out = JSON.parse(formatTranscript(okResult, "json"));
+    expect(out.schemaVersion).toBe("1.0.0");
+    expect(SCHEMA_VERSION).toBe("1.0.0");
+  });
+
+  it("renders ok with status, source, transcript entries", () => {
+    const out = JSON.parse(formatTranscript(okResult, "json"));
+    expect(out.status).toBe("ok");
+    expect(out.source).toBe("youtube-transcript-plus");
+    expect(out.transcript).toEqual({
+      language: "en",
+      entries: [
+        { offsetSec: 0, durationSec: 2, text: "hello" },
+        { offsetSec: 65, durationSec: 3, text: "world" },
+        { offsetSec: 3725, durationSec: 4, text: "later" },
+      ],
+    });
+    expect(out.job).toBeNull();
+    expect(out.reason).toBeUndefined();
+    expect(out.message).toEqual(expect.any(String));
+  });
+
+  it("renders pending with job and source, transcript null", () => {
+    const out = JSON.parse(formatTranscript(pendingResult, "json"));
+    expect(out.status).toBe("pending");
+    expect(out.source).toBe("supadata");
+    expect(out.transcript).toBeNull();
+    expect(out.job).toEqual({ id: "job-123", retryAfterSeconds: 90 });
+    expect(out.message).toBe("Transcript generation queued");
+  });
+
+  it("renders unavailable with reason, source null, transcript null", () => {
+    const out = JSON.parse(formatTranscript(unavailableResult, "json"));
+    expect(out.status).toBe("unavailable");
+    expect(out.source).toBeNull();
+    expect(out.reason).toBe("no-captions");
+    expect(out.transcript).toBeNull();
+    expect(out.job).toBeNull();
+    expect(out.message).toBe("No captions available");
+  });
+
+  it("renders transient with source null and no reason", () => {
+    const out = JSON.parse(formatTranscript(transientResult, "json"));
+    expect(out.status).toBe("transient");
+    expect(out.source).toBeNull();
+    expect(out.transcript).toBeNull();
+    expect(out.job).toBeNull();
+    expect(out.reason).toBeUndefined();
+    expect(out.message).toBe("Network error talking to upstream");
+  });
+
+  it("includes a `video` object placeholder (id/url empty since serializer has no metadata)", () => {
+    const out = JSON.parse(formatTranscript(okResult, "json"));
+    expect(out.video).toBeDefined();
+    expect(out.video).toEqual({});
+  });
+});

--- a/packages/core/src/format.test.ts
+++ b/packages/core/src/format.test.ts
@@ -8,8 +8,8 @@ const okResult: TranscriptResult = {
   lang: "en",
   entries: [
     { offsetSec: 0, durationSec: 2, text: "hello" },
-    { offsetSec: 65, durationSec: 3, text: "world" },
-    { offsetSec: 3725, durationSec: 4, text: "later" },
+    { offsetSec: 2, durationSec: 2, text: "world" },
+    { offsetSec: 4, durationSec: 2, text: "later" },
   ],
 };
 
@@ -34,9 +34,53 @@ const transientResult: TranscriptResult = {
 };
 
 describe("formatTranscript text format", () => {
-  it("renders ok entries as [MM:SS] lines", () => {
-    expect(formatTranscript(okResult, "text")).toBe(
-      "[00:00] hello\n[01:05] world\n[1:02:05] later"
+  it("renders ok as a single space-separated blob of text", () => {
+    expect(formatTranscript(okResult, "text")).toBe("hello world later");
+  });
+
+  it("normalizes internal soft-wrap newlines within entry text to spaces", () => {
+    const result: TranscriptResult = {
+      kind: "ok",
+      source: "youtube-transcript-plus",
+      entries: [
+        {
+          offsetSec: 0,
+          durationSec: 2,
+          text: "you know the rules\nand so do I",
+        },
+        { offsetSec: 2, durationSec: 1, text: "single line" },
+      ],
+    };
+    expect(formatTranscript(result, "text")).toBe(
+      "you know the rules and so do I single line"
+    );
+  });
+
+  it("preserves entry text containing punctuation without inserting breaks", () => {
+    const result: TranscriptResult = {
+      kind: "ok",
+      source: "youtube-transcript-plus",
+      entries: [
+        { offsetSec: 0, durationSec: 2, text: "first thought." },
+        { offsetSec: 2, durationSec: 2, text: "second thought" },
+      ],
+    };
+    expect(formatTranscript(result, "text")).toBe(
+      "first thought. second thought"
+    );
+  });
+
+  it("ignores wide timestamp gaps (no paragraph break)", () => {
+    const result: TranscriptResult = {
+      kind: "ok",
+      source: "youtube-transcript-plus",
+      entries: [
+        { offsetSec: 0, durationSec: 2, text: "topic A wraps up" },
+        { offsetSec: 30, durationSec: 2, text: "new topic begins" },
+      ],
+    };
+    expect(formatTranscript(result, "text")).toBe(
+      "topic A wraps up new topic begins"
     );
   });
 
@@ -73,20 +117,20 @@ describe("formatTranscript json format", () => {
     expect(out.transcript.language).toBe("en");
     expect(out.transcript.entries).toEqual([
       { offsetSec: 0, durationSec: 2, text: "hello" },
-      { offsetSec: 65, durationSec: 3, text: "world" },
-      { offsetSec: 3725, durationSec: 4, text: "later" },
+      { offsetSec: 2, durationSec: 2, text: "world" },
+      { offsetSec: 4, durationSec: 2, text: "later" },
     ]);
     expect(out.job).toBeNull();
     expect(out.reason).toBeUndefined();
     expect(out.message).toEqual(expect.any(String));
   });
 
-  it("includes a joined `text` field at the transcript level for ok results", () => {
+  it("includes a joined `text` field on ok results (single blob, soft-wraps normalized)", () => {
     const out = JSON.parse(formatTranscript(okResult, "json"));
-    expect(out.transcript.text).toBe("hello\nworld\nlater");
+    expect(out.transcript.text).toBe("hello world later");
   });
 
-  it("normalizes internal newlines in entry text to spaces in joined `text`", () => {
+  it("preserves per-entry `text` verbatim while joined `text` normalizes soft-wraps", () => {
     const result: TranscriptResult = {
       kind: "ok",
       source: "youtube-transcript-plus",
@@ -98,7 +142,7 @@ describe("formatTranscript json format", () => {
     };
     const out = JSON.parse(formatTranscript(result, "json"));
     expect(out.transcript.text).toBe(
-      "you know the rules and so do I\na full commitment's what I'm thinking of"
+      "you know the rules and so do I a full commitment's what I'm thinking of"
     );
     expect(out.transcript.entries[0].text).toBe(
       "you know the rules\nand so do I"

--- a/packages/core/src/format.test.ts
+++ b/packages/core/src/format.test.ts
@@ -70,17 +70,39 @@ describe("formatTranscript json format", () => {
     const out = JSON.parse(formatTranscript(okResult, "json"));
     expect(out.status).toBe("ok");
     expect(out.source).toBe("youtube-transcript-plus");
-    expect(out.transcript).toEqual({
-      language: "en",
-      entries: [
-        { offsetSec: 0, durationSec: 2, text: "hello" },
-        { offsetSec: 65, durationSec: 3, text: "world" },
-        { offsetSec: 3725, durationSec: 4, text: "later" },
-      ],
-    });
+    expect(out.transcript.language).toBe("en");
+    expect(out.transcript.entries).toEqual([
+      { offsetSec: 0, durationSec: 2, text: "hello" },
+      { offsetSec: 65, durationSec: 3, text: "world" },
+      { offsetSec: 3725, durationSec: 4, text: "later" },
+    ]);
     expect(out.job).toBeNull();
     expect(out.reason).toBeUndefined();
     expect(out.message).toEqual(expect.any(String));
+  });
+
+  it("includes a joined `text` field at the transcript level for ok results", () => {
+    const out = JSON.parse(formatTranscript(okResult, "json"));
+    expect(out.transcript.text).toBe("hello\nworld\nlater");
+  });
+
+  it("normalizes internal newlines in entry text to spaces in joined `text`", () => {
+    const result: TranscriptResult = {
+      kind: "ok",
+      source: "youtube-transcript-plus",
+      lang: "en",
+      entries: [
+        { offsetSec: 0, durationSec: 2, text: "you know the rules\nand so do I" },
+        { offsetSec: 2, durationSec: 2, text: "a full commitment's\nwhat I'm thinking of" },
+      ],
+    };
+    const out = JSON.parse(formatTranscript(result, "json"));
+    expect(out.transcript.text).toBe(
+      "you know the rules and so do I\na full commitment's what I'm thinking of"
+    );
+    expect(out.transcript.entries[0].text).toBe(
+      "you know the rules\nand so do I"
+    );
   });
 
   it("renders pending with job and source, transcript null", () => {

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -1,4 +1,4 @@
-import type { TranscriptResult } from "./types";
+import type { TranscriptEntry, TranscriptResult } from "./types";
 
 export const SCHEMA_VERSION = "1.0.0";
 
@@ -14,9 +14,7 @@ export function formatTranscript(
 function renderText(result: TranscriptResult): string {
   switch (result.kind) {
     case "ok":
-      return result.entries
-        .map((e) => `[${formatTimestamp(e.offsetSec)}] ${e.text}`)
-        .join("\n");
+      return joinEntryText(result.entries);
     case "pending":
       return `Transcript generation queued (jobId: ${result.jobId}, retryAfter: ${result.retryAfterSeconds}s)`;
     case "unavailable":
@@ -67,20 +65,9 @@ function defaultMessage(result: TranscriptResult): string {
   }
 }
 
-function joinEntryText(
-  entries: { text: string }[]
-): string {
-  return entries.map((e) => e.text.replace(/\s*\n\s*/g, " ")).join("\n");
-}
-
-function formatTimestamp(totalSec: number): string {
-  const total = Math.floor(totalSec);
-  const seconds = total % 60;
-  const minutes = Math.floor(total / 60) % 60;
-  const hours = Math.floor(total / 3600);
-  const ss = String(seconds).padStart(2, "0");
-  if (hours > 0) {
-    return `${hours}:${String(minutes).padStart(2, "0")}:${ss}`;
-  }
-  return `${String(minutes).padStart(2, "0")}:${ss}`;
+function joinEntryText(entries: TranscriptEntry[]): string {
+  return entries
+    .map((e) => e.text.replace(/\s*\n\s*/g, " ").trim())
+    .filter((t) => t.length > 0)
+    .join(" ");
 }

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -40,6 +40,7 @@ function renderJson(result: TranscriptResult): string {
   if (result.kind === "ok") {
     base.transcript = {
       language: result.lang ?? null,
+      text: joinEntryText(result.entries),
       entries: result.entries.map((e) => ({
         offsetSec: e.offsetSec,
         durationSec: e.durationSec,
@@ -64,6 +65,12 @@ function defaultMessage(result: TranscriptResult): string {
     case "transient":
       return result.message;
   }
+}
+
+function joinEntryText(
+  entries: { text: string }[]
+): string {
+  return entries.map((e) => e.text.replace(/\s*\n\s*/g, " ")).join("\n");
 }
 
 function formatTimestamp(totalSec: number): string {

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -1,0 +1,79 @@
+import type { TranscriptResult } from "./types";
+
+export const SCHEMA_VERSION = "1.0.0";
+
+export type TranscriptFormat = "text" | "json";
+
+export function formatTranscript(
+  result: TranscriptResult,
+  format: TranscriptFormat
+): string {
+  return format === "text" ? renderText(result) : renderJson(result);
+}
+
+function renderText(result: TranscriptResult): string {
+  switch (result.kind) {
+    case "ok":
+      return result.entries
+        .map((e) => `[${formatTimestamp(e.offsetSec)}] ${e.text}`)
+        .join("\n");
+    case "pending":
+      return `Transcript generation queued (jobId: ${result.jobId}, retryAfter: ${result.retryAfterSeconds}s)`;
+    case "unavailable":
+      return `Unavailable (${result.reason}): ${result.message}`;
+    case "transient":
+      return `Transient failure (${result.cause}): ${result.message}`;
+  }
+}
+
+function renderJson(result: TranscriptResult): string {
+  const base: Record<string, unknown> = {
+    schemaVersion: SCHEMA_VERSION,
+    status: result.kind,
+    source: "source" in result ? result.source : null,
+    video: {},
+    transcript: null,
+    job: null,
+    message: defaultMessage(result),
+  };
+
+  if (result.kind === "ok") {
+    base.transcript = {
+      language: result.lang ?? null,
+      entries: result.entries.map((e) => ({
+        offsetSec: e.offsetSec,
+        durationSec: e.durationSec,
+        text: e.text,
+      })),
+    };
+  } else if (result.kind === "pending") {
+    base.job = { id: result.jobId, retryAfterSeconds: result.retryAfterSeconds };
+  } else if (result.kind === "unavailable") {
+    base.reason = result.reason;
+  }
+
+  return JSON.stringify(base, null, 2);
+}
+
+function defaultMessage(result: TranscriptResult): string {
+  switch (result.kind) {
+    case "ok":
+      return `Retrieved ${result.entries.length} transcript entries from ${result.source}`;
+    case "pending":
+    case "unavailable":
+    case "transient":
+      return result.message;
+  }
+}
+
+function formatTimestamp(totalSec: number): string {
+  const total = Math.floor(totalSec);
+  const seconds = total % 60;
+  const minutes = Math.floor(total / 60) % 60;
+  const hours = Math.floor(total / 3600);
+  const ss = String(seconds).padStart(2, "0");
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, "0")}:${ss}`;
+  }
+  return `${String(minutes).padStart(2, "0")}:${ss}`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,18 @@
+export { extractVideoId } from "./parser";
+export { fetchTranscript } from "./fetcher";
+export { fetchMetadata } from "./metadata";
+export { formatTranscript, SCHEMA_VERSION } from "./format";
+export type { TranscriptFormat } from "./format";
+export type {
+  MetadataOptions,
+  MetadataResult,
+  MetadataUnavailableReason,
+  RetryPolicy,
+  SourceName,
+  TranscriptCache,
+  TranscriptEntry,
+  TranscriptOptions,
+  TranscriptResult,
+  UnavailableReason,
+  VideoMetadata,
+} from "./types";

--- a/packages/core/src/metadata.test.ts
+++ b/packages/core/src/metadata.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchMetadata } from "./metadata";
+
+const videosListMock = vi.fn();
+const commentThreadsListMock = vi.fn();
+
+vi.mock("@googleapis/youtube", () => ({
+  youtube: () => ({
+    videos: { list: videosListMock },
+    commentThreads: { list: commentThreadsListMock },
+  }),
+}));
+
+afterEach(() => {
+  videosListMock.mockReset();
+  commentThreadsListMock.mockReset();
+});
+
+const VID = "dQw4w9WgXcQ";
+
+const successPayload = {
+  data: {
+    items: [
+      {
+        snippet: {
+          title: "Never Gonna Give You Up",
+          channelTitle: "Rick Astley",
+          channelId: "UC1",
+          publishedAt: "2009-10-25T07:57:33Z",
+          description: "Music video",
+        },
+        contentDetails: { duration: "PT3M33S" },
+      },
+    ],
+  },
+};
+
+describe("fetchMetadata", () => {
+  it("returns ok with full metadata on success", async () => {
+    videosListMock.mockResolvedValue(successPayload);
+    commentThreadsListMock.mockResolvedValue({
+      data: {
+        items: [
+          {
+            snippet: {
+              topLevelComment: {
+                snippet: { textOriginal: "Pinned comment text" },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await fetchMetadata(VID, { youtubeApiKey: "key" });
+
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.metadata).toEqual({
+        videoId: VID,
+        title: "Never Gonna Give You Up",
+        channelTitle: "Rick Astley",
+        channelId: "UC1",
+        duration: "PT3M33S",
+        publishedAt: "2009-10-25T07:57:33Z",
+        description: "Music video",
+        pinnedComment: "Pinned comment text",
+      });
+    }
+  });
+
+  it("returns ok with pinnedComment undefined when comment fetch fails", async () => {
+    videosListMock.mockResolvedValue(successPayload);
+    commentThreadsListMock.mockRejectedValue(new Error("comments disabled"));
+
+    const result = await fetchMetadata(VID, { youtubeApiKey: "key" });
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.metadata.pinnedComment).toBeUndefined();
+    }
+  });
+
+  it("returns ok with pinnedComment undefined when no items returned", async () => {
+    videosListMock.mockResolvedValue(successPayload);
+    commentThreadsListMock.mockResolvedValue({ data: { items: [] } });
+
+    const result = await fetchMetadata(VID, { youtubeApiKey: "key" });
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.metadata.pinnedComment).toBeUndefined();
+    }
+  });
+
+  it("returns unavailable: video-not-found when items empty", async () => {
+    videosListMock.mockResolvedValue({ data: { items: [] } });
+
+    const result = await fetchMetadata(VID, { youtubeApiKey: "key" });
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") {
+      expect(result.reason).toBe("video-not-found");
+    }
+  });
+
+  it("maps 400 error to invalid-id", async () => {
+    const err = Object.assign(new Error("Bad Request"), { code: 400 });
+    videosListMock.mockRejectedValue(err);
+
+    const result = await fetchMetadata(VID, { youtubeApiKey: "key" });
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") {
+      expect(result.reason).toBe("invalid-id");
+    }
+  });
+
+  it("maps 403 quota error to quota-exceeded", async () => {
+    const err = Object.assign(new Error("quota exceeded"), { code: 403 });
+    videosListMock.mockRejectedValue(err);
+
+    const result = await fetchMetadata(VID, { youtubeApiKey: "key" });
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") {
+      expect(result.reason).toBe("quota-exceeded");
+    }
+  });
+
+  it("maps 403 non-quota error to api-key-invalid", async () => {
+    const err = Object.assign(new Error("Forbidden: bad key"), { code: 403 });
+    videosListMock.mockRejectedValue(err);
+
+    const result = await fetchMetadata(VID, { youtubeApiKey: "key" });
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") {
+      expect(result.reason).toBe("api-key-invalid");
+    }
+  });
+
+  it("maps 404 to video-not-found", async () => {
+    const err = Object.assign(new Error("Not Found"), { code: 404 });
+    videosListMock.mockRejectedValue(err);
+
+    const result = await fetchMetadata(VID, { youtubeApiKey: "key" });
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") {
+      expect(result.reason).toBe("video-not-found");
+    }
+  });
+
+  it("maps unknown thrown error to transient", async () => {
+    videosListMock.mockRejectedValue(new Error("ECONNRESET"));
+
+    const result = await fetchMetadata(VID, { youtubeApiKey: "key" });
+    expect(result.kind).toBe("transient");
+  });
+
+  it("returns invalid-id when input does not parse to a video id", async () => {
+    const result = await fetchMetadata("garbage!!!!", { youtubeApiKey: "key" });
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") {
+      expect(result.reason).toBe("invalid-id");
+    }
+    expect(videosListMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts a YouTube URL and extracts the id", async () => {
+    videosListMock.mockResolvedValue(successPayload);
+    commentThreadsListMock.mockResolvedValue({ data: { items: [] } });
+
+    const result = await fetchMetadata(
+      `https://www.youtube.com/watch?v=${VID}`,
+      { youtubeApiKey: "key" }
+    );
+    expect(result.kind).toBe("ok");
+    expect(videosListMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: [VID] })
+    );
+  });
+});

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -1,0 +1,118 @@
+import { youtube, type youtube_v3 } from "@googleapis/youtube";
+import { extractVideoId } from "./parser";
+import type {
+  MetadataOptions,
+  MetadataResult,
+  MetadataUnavailableReason,
+  VideoMetadata,
+} from "./types";
+
+export async function fetchMetadata(
+  input: string,
+  opts: MetadataOptions
+): Promise<MetadataResult> {
+  const videoId = extractVideoId(input);
+  if (!videoId) {
+    return {
+      kind: "unavailable",
+      reason: "invalid-id",
+      message: `Could not extract a YouTube video ID from "${input}"`,
+    };
+  }
+
+  const client = youtube({ version: "v3", auth: opts.youtubeApiKey });
+
+  let response: { data: { items?: youtube_v3.Schema$Video[] } };
+  try {
+    response = await client.videos.list({
+      id: [videoId],
+      part: ["snippet", "contentDetails"],
+    });
+  } catch (err) {
+    return mapError(err);
+  }
+
+  const video = response.data.items?.[0];
+  if (!video) {
+    return {
+      kind: "unavailable",
+      reason: "video-not-found",
+      message: "Video not found or unavailable",
+    };
+  }
+
+  const snippet = video.snippet;
+  const contentDetails = video.contentDetails;
+
+  const metadata: VideoMetadata = {
+    videoId,
+    title: snippet?.title ?? "Untitled",
+    channelTitle: snippet?.channelTitle ?? "Unknown Channel",
+    channelId: snippet?.channelId ?? "",
+    duration: contentDetails?.duration ?? "PT0S",
+    publishedAt: snippet?.publishedAt ?? new Date().toISOString(),
+    description: snippet?.description ?? "",
+  };
+
+  const pinnedComment = await fetchPinnedComment(client, videoId);
+  if (pinnedComment) metadata.pinnedComment = pinnedComment;
+
+  return { kind: "ok", metadata };
+}
+
+async function fetchPinnedComment(
+  client: youtube_v3.Youtube,
+  videoId: string
+): Promise<string | undefined> {
+  try {
+    const response = await client.commentThreads.list({
+      videoId,
+      part: ["snippet"],
+      maxResults: 20,
+      order: "relevance",
+    });
+    const items = response.data.items ?? [];
+    for (const thread of items) {
+      const text = thread.snippet?.topLevelComment?.snippet?.textOriginal;
+      if (text) return text;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+type WithCode = { code?: number; message?: string };
+
+function mapError(err: unknown): MetadataResult {
+  const e = err as WithCode;
+  const code = e?.code;
+  const message = e?.message ?? "Failed to fetch video metadata";
+
+  if (code === 400) {
+    return mkUnavailable("invalid-id", message);
+  }
+  if (code === 404) {
+    return mkUnavailable("video-not-found", message);
+  }
+  if (code === 403) {
+    if (message.toLowerCase().includes("quota")) {
+      return mkUnavailable("quota-exceeded", message);
+    }
+    return mkUnavailable("api-key-invalid", message);
+  }
+
+  const cause = err instanceof Error ? err.message : "unknown";
+  return {
+    kind: "transient",
+    cause,
+    message: `Transient failure fetching metadata: ${cause}`,
+  };
+}
+
+function mkUnavailable(
+  reason: MetadataUnavailableReason,
+  message: string
+): MetadataResult {
+  return { kind: "unavailable", reason, message };
+}

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { extractVideoId } from "./parser";
+
+describe("extractVideoId", () => {
+  describe("URL formats", () => {
+    it("extracts from a standard youtube.com/watch URL", () => {
+      expect(
+        extractVideoId("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+      ).toBe("dQw4w9WgXcQ");
+    });
+
+    it("extracts from a youtu.be short URL", () => {
+      expect(extractVideoId("https://youtu.be/dQw4w9WgXcQ")).toBe(
+        "dQw4w9WgXcQ"
+      );
+    });
+
+    it("extracts from a mobile m.youtube.com URL", () => {
+      expect(
+        extractVideoId("https://m.youtube.com/watch?v=dQw4w9WgXcQ")
+      ).toBe("dQw4w9WgXcQ");
+    });
+
+    it("extracts from an embed URL", () => {
+      expect(
+        extractVideoId("https://www.youtube.com/embed/dQw4w9WgXcQ")
+      ).toBe("dQw4w9WgXcQ");
+    });
+
+    it("ignores query params after the id (&t=)", () => {
+      expect(
+        extractVideoId(
+          "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=123s"
+        )
+      ).toBe("dQw4w9WgXcQ");
+    });
+
+    it("ignores query params before the id", () => {
+      expect(
+        extractVideoId(
+          "https://www.youtube.com/watch?app=desktop&v=dQw4w9WgXcQ"
+        )
+      ).toBe("dQw4w9WgXcQ");
+    });
+  });
+
+  describe("bare 11-character IDs", () => {
+    it("accepts a bare alphanumeric ID", () => {
+      expect(extractVideoId("dQw4w9WgXcQ")).toBe("dQw4w9WgXcQ");
+    });
+
+    it("accepts an ID containing hyphens", () => {
+      expect(extractVideoId("a-b-c-d-e-f")).toBe("a-b-c-d-e-f");
+    });
+
+    it("accepts an ID containing underscores", () => {
+      expect(extractVideoId("a_b_c_d_e_f")).toBe("a_b_c_d_e_f");
+    });
+  });
+
+  describe("invalid input", () => {
+    it("rejects 10-character strings", () => {
+      expect(extractVideoId("dQw4w9WgXc")).toBeNull();
+    });
+
+    it("rejects 12-character strings", () => {
+      expect(extractVideoId("dQw4w9WgXcQQ")).toBeNull();
+    });
+
+    it("rejects empty string", () => {
+      expect(extractVideoId("")).toBeNull();
+    });
+
+    it("rejects bare strings with illegal chars", () => {
+      expect(extractVideoId("dQw4w9WgX!Q")).toBeNull();
+    });
+
+    it("rejects unrelated URLs", () => {
+      expect(extractVideoId("https://example.com/foo/bar")).toBeNull();
+    });
+
+    it("rejects youtube URLs with malformed video ids", () => {
+      expect(
+        extractVideoId("https://www.youtube.com/watch?v=tooshort")
+      ).toBeNull();
+    });
+  });
+});

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -1,0 +1,23 @@
+const VIDEO_ID = /^[a-zA-Z0-9_-]{11}$/;
+
+const URL_PATTERNS: RegExp[] = [
+  /(?:youtube\.com\/watch\?(?:[^#]*&)?v=)([^&\n?#]+)/,
+  /(?:youtu\.be\/)([^&\n?#]+)/,
+  /(?:m\.youtube\.com\/watch\?(?:[^#]*&)?v=)([^&\n?#]+)/,
+  /(?:youtube\.com\/embed\/)([^&\n?#]+)/,
+];
+
+export function extractVideoId(input: string): string | null {
+  if (!input) return null;
+
+  if (VIDEO_ID.test(input)) return input;
+
+  for (const pattern of URL_PATTERNS) {
+    const match = input.match(pattern);
+    if (match?.[1] && VIDEO_ID.test(match[1])) {
+      return match[1];
+    }
+  }
+
+  return null;
+}

--- a/packages/core/src/sources/local.test.ts
+++ b/packages/core/src/sources/local.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocalSource } from "./local";
+
+const fetchTranscriptMock = vi.fn();
+
+vi.mock("youtube-transcript-plus", () => {
+  class YoutubeTranscriptDisabledError extends Error {}
+  class YoutubeTranscriptNotAvailableError extends Error {}
+  class YoutubeTranscriptNotAvailableLanguageError extends Error {}
+  class YoutubeTranscriptVideoUnavailableError extends Error {}
+  class YoutubeTranscriptInvalidVideoIdError extends Error {}
+  class YoutubeTranscriptTooManyRequestError extends Error {}
+  return {
+    fetchTranscript: (...args: unknown[]) => fetchTranscriptMock(...args),
+    YoutubeTranscriptDisabledError,
+    YoutubeTranscriptNotAvailableError,
+    YoutubeTranscriptNotAvailableLanguageError,
+    YoutubeTranscriptVideoUnavailableError,
+    YoutubeTranscriptInvalidVideoIdError,
+    YoutubeTranscriptTooManyRequestError,
+  };
+});
+
+import * as ytp from "youtube-transcript-plus";
+
+describe("LocalSource", () => {
+  afterEach(() => {
+    fetchTranscriptMock.mockReset();
+  });
+
+  it("identifies as youtube-transcript-plus", () => {
+    expect(new LocalSource().name).toBe("youtube-transcript-plus");
+  });
+
+  it("returns ok with entries already in seconds", async () => {
+    fetchTranscriptMock.mockResolvedValue([
+      { text: "hello", offset: 0, duration: 2, lang: "en" },
+      { text: "world", offset: 2, duration: 1.5, lang: "en" },
+    ]);
+    const result = await new LocalSource().fetch("vid");
+    expect(result).toEqual({
+      kind: "ok",
+      lang: "en",
+      entries: [
+        { text: "hello", offsetSec: 0, durationSec: 2, lang: "en" },
+        { text: "world", offsetSec: 2, durationSec: 1.5, lang: "en" },
+      ],
+    });
+  });
+
+  it("returns ok without lang when entries have no lang", async () => {
+    fetchTranscriptMock.mockResolvedValue([
+      { text: "hi", offset: 0, duration: 1 },
+    ]);
+    const result = await new LocalSource().fetch("vid");
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.lang).toBeUndefined();
+    }
+  });
+
+  it("maps disabled error to unavailable: no-captions", async () => {
+    fetchTranscriptMock.mockRejectedValue(
+      new ytp.YoutubeTranscriptDisabledError("vid")
+    );
+    expect(await new LocalSource().fetch("vid")).toEqual({
+      kind: "unavailable",
+      reason: "no-captions",
+    });
+  });
+
+  it("maps not-available error to unavailable: no-captions", async () => {
+    fetchTranscriptMock.mockRejectedValue(
+      new ytp.YoutubeTranscriptNotAvailableError("vid")
+    );
+    expect(await new LocalSource().fetch("vid")).toEqual({
+      kind: "unavailable",
+      reason: "no-captions",
+    });
+  });
+
+  it("maps not-available-language to unavailable: no-captions", async () => {
+    fetchTranscriptMock.mockRejectedValue(
+      new ytp.YoutubeTranscriptNotAvailableLanguageError("xx", [], "vid")
+    );
+    expect(await new LocalSource().fetch("vid")).toEqual({
+      kind: "unavailable",
+      reason: "no-captions",
+    });
+  });
+
+  it("maps video-unavailable to unavailable: video-removed", async () => {
+    fetchTranscriptMock.mockRejectedValue(
+      new ytp.YoutubeTranscriptVideoUnavailableError("vid")
+    );
+    expect(await new LocalSource().fetch("vid")).toEqual({
+      kind: "unavailable",
+      reason: "video-removed",
+    });
+  });
+
+  it("maps invalid-video-id to unavailable: invalid-id", async () => {
+    fetchTranscriptMock.mockRejectedValue(
+      new ytp.YoutubeTranscriptInvalidVideoIdError()
+    );
+    expect(await new LocalSource().fetch("vid")).toEqual({
+      kind: "unavailable",
+      reason: "invalid-id",
+    });
+  });
+
+  it("maps too-many-requests to transient", async () => {
+    fetchTranscriptMock.mockRejectedValue(
+      new ytp.YoutubeTranscriptTooManyRequestError()
+    );
+    const result = await new LocalSource().fetch("vid");
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") expect(result.cause).toBe("rate-limit");
+  });
+
+  it("maps unrecognized errors to transient with the error name as cause", async () => {
+    fetchTranscriptMock.mockRejectedValue(new Error("ECONNRESET"));
+    const result = await new LocalSource().fetch("vid");
+    expect(result.kind).toBe("transient");
+  });
+
+  it("maps malformed library response to transient: schema-mismatch", async () => {
+    fetchTranscriptMock.mockResolvedValue([
+      { text: "missing offset", duration: 1 },
+    ]);
+    const result = await new LocalSource().fetch("vid");
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") {
+      expect(result.cause).toBe("schema-mismatch");
+    }
+  });
+
+  it("maps non-array library response to transient: schema-mismatch", async () => {
+    fetchTranscriptMock.mockResolvedValue({ not: "an array" });
+    const result = await new LocalSource().fetch("vid");
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") {
+      expect(result.cause).toBe("schema-mismatch");
+    }
+  });
+});

--- a/packages/core/src/sources/local.test.ts
+++ b/packages/core/src/sources/local.test.ts
@@ -48,6 +48,21 @@ describe("LocalSource", () => {
     });
   });
 
+  it("decodes HTML entities in entry text (including double-encoded)", async () => {
+    fetchTranscriptMock.mockResolvedValue([
+      { text: "we&amp;#39;re no strangers", offset: 0, duration: 2, lang: "en" },
+      { text: "a &lt; b", offset: 2, duration: 1, lang: "en" },
+    ]);
+    const result = await new LocalSource().fetch("vid");
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.entries.map((e) => e.text)).toEqual([
+        "we're no strangers",
+        "a < b",
+      ]);
+    }
+  });
+
   it("returns ok without lang when entries have no lang", async () => {
     fetchTranscriptMock.mockResolvedValue([
       { text: "hi", offset: 0, duration: 1 },

--- a/packages/core/src/sources/local.ts
+++ b/packages/core/src/sources/local.ts
@@ -8,6 +8,7 @@ import {
   YoutubeTranscriptVideoUnavailableError,
 } from "youtube-transcript-plus";
 import { z } from "zod";
+import { decodeHtmlEntities } from "../text";
 import type { SourceOutcome, TranscriptSource } from "./types";
 
 const ResponseSchema = z.array(
@@ -36,7 +37,7 @@ export class LocalSource implements TranscriptSource {
     }
 
     const entries = parsed.data.map((e) => ({
-      text: e.text,
+      text: decodeHtmlEntities(e.text),
       offsetSec: e.offset,
       durationSec: e.duration,
       ...(e.lang ? { lang: e.lang } : {}),

--- a/packages/core/src/sources/local.ts
+++ b/packages/core/src/sources/local.ts
@@ -1,0 +1,69 @@
+import {
+  fetchTranscript,
+  YoutubeTranscriptDisabledError,
+  YoutubeTranscriptInvalidVideoIdError,
+  YoutubeTranscriptNotAvailableError,
+  YoutubeTranscriptNotAvailableLanguageError,
+  YoutubeTranscriptTooManyRequestError,
+  YoutubeTranscriptVideoUnavailableError,
+} from "youtube-transcript-plus";
+import { z } from "zod";
+import type { SourceOutcome, TranscriptSource } from "./types";
+
+const ResponseSchema = z.array(
+  z.object({
+    text: z.string(),
+    offset: z.number(),
+    duration: z.number(),
+    lang: z.string().optional(),
+  })
+);
+
+export class LocalSource implements TranscriptSource {
+  readonly name = "youtube-transcript-plus" as const;
+
+  async fetch(videoId: string): Promise<SourceOutcome> {
+    let raw: unknown;
+    try {
+      raw = await fetchTranscript(videoId);
+    } catch (err) {
+      return mapError(err);
+    }
+
+    const parsed = ResponseSchema.safeParse(raw);
+    if (!parsed.success) {
+      return { kind: "transient", cause: "schema-mismatch" };
+    }
+
+    const entries = parsed.data.map((e) => ({
+      text: e.text,
+      offsetSec: e.offset,
+      durationSec: e.duration,
+      ...(e.lang ? { lang: e.lang } : {}),
+    }));
+    const lang = parsed.data[0]?.lang;
+
+    return { kind: "ok", ...(lang ? { lang } : {}), entries };
+  }
+}
+
+function mapError(err: unknown): SourceOutcome {
+  if (
+    err instanceof YoutubeTranscriptDisabledError ||
+    err instanceof YoutubeTranscriptNotAvailableError ||
+    err instanceof YoutubeTranscriptNotAvailableLanguageError
+  ) {
+    return { kind: "unavailable", reason: "no-captions" };
+  }
+  if (err instanceof YoutubeTranscriptVideoUnavailableError) {
+    return { kind: "unavailable", reason: "video-removed" };
+  }
+  if (err instanceof YoutubeTranscriptInvalidVideoIdError) {
+    return { kind: "unavailable", reason: "invalid-id" };
+  }
+  if (err instanceof YoutubeTranscriptTooManyRequestError) {
+    return { kind: "transient", cause: "rate-limit" };
+  }
+  const cause = err instanceof Error ? err.message : "unknown";
+  return { kind: "transient", cause };
+}

--- a/packages/core/src/sources/retry.test.ts
+++ b/packages/core/src/sources/retry.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_RETRY_POLICY, withRetry } from "./retry";
+import type { TranscriptSource, SourceOutcome } from "./types";
+
+function makeStub(outcomes: SourceOutcome[]): TranscriptSource & {
+  calls: number;
+} {
+  let i = 0;
+  const stub = {
+    name: "youtube-transcript-plus" as const,
+    calls: 0,
+    async fetch(): Promise<SourceOutcome> {
+      stub.calls += 1;
+      const outcome = outcomes[Math.min(i, outcomes.length - 1)];
+      i += 1;
+      return outcome;
+    },
+  };
+  return stub;
+}
+
+describe("withRetry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns ok on first success without retrying", async () => {
+    const stub = makeStub([{ kind: "ok", entries: [] }]);
+    const wrapped = withRetry(stub, DEFAULT_RETRY_POLICY);
+    const promise = wrapped.fetch("vid");
+    await vi.runAllTimersAsync();
+    const result = await promise;
+    expect(result.kind).toBe("ok");
+    expect(stub.calls).toBe(1);
+  });
+
+  it("short-circuits on pending without retrying", async () => {
+    const stub = makeStub([
+      { kind: "pending", jobId: "j", retryAfterSeconds: 90 },
+    ]);
+    const wrapped = withRetry(stub, DEFAULT_RETRY_POLICY);
+    const promise = wrapped.fetch("vid");
+    await vi.runAllTimersAsync();
+    await promise;
+    expect(stub.calls).toBe(1);
+  });
+
+  it("short-circuits on unavailable without retrying", async () => {
+    const stub = makeStub([{ kind: "unavailable", reason: "no-captions" }]);
+    const wrapped = withRetry(stub, DEFAULT_RETRY_POLICY);
+    const promise = wrapped.fetch("vid");
+    await vi.runAllTimersAsync();
+    await promise;
+    expect(stub.calls).toBe(1);
+  });
+
+  it("retries on transient up to maxAttempts", async () => {
+    const stub = makeStub([
+      { kind: "transient", cause: "net" },
+      { kind: "transient", cause: "net" },
+      { kind: "transient", cause: "net" },
+    ]);
+    const wrapped = withRetry(stub, {
+      maxAttempts: 3,
+      initialDelayMs: 10,
+      backoffMultiplier: 2,
+    });
+    const promise = wrapped.fetch("vid");
+    await vi.runAllTimersAsync();
+    const result = await promise;
+    expect(stub.calls).toBe(3);
+    expect(result.kind).toBe("transient");
+  });
+
+  it("returns ok after a transient retry succeeds", async () => {
+    const stub = makeStub([
+      { kind: "transient", cause: "net" },
+      { kind: "ok", entries: [] },
+    ]);
+    const wrapped = withRetry(stub, {
+      maxAttempts: 3,
+      initialDelayMs: 10,
+      backoffMultiplier: 2,
+    });
+    const promise = wrapped.fetch("vid");
+    await vi.runAllTimersAsync();
+    const result = await promise;
+    expect(stub.calls).toBe(2);
+    expect(result.kind).toBe("ok");
+  });
+
+  it("respects an AbortSignal that fires mid-backoff", async () => {
+    const stub = makeStub([
+      { kind: "transient", cause: "net" },
+      { kind: "ok", entries: [] },
+    ]);
+    const wrapped = withRetry(stub, {
+      maxAttempts: 3,
+      initialDelayMs: 1000,
+      backoffMultiplier: 2,
+    });
+    const controller = new AbortController();
+    const promise = wrapped.fetch("vid", controller.signal);
+    await vi.advanceTimersByTimeAsync(100);
+    controller.abort();
+    await vi.runAllTimersAsync();
+    const result = await promise;
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") {
+      expect(result.cause).toBe("aborted");
+    }
+    expect(stub.calls).toBe(1);
+  });
+
+  it("applies exponential backoff between attempts", async () => {
+    const stub = makeStub([
+      { kind: "transient", cause: "net" },
+      { kind: "transient", cause: "net" },
+      { kind: "ok", entries: [] },
+    ]);
+    const wrapped = withRetry(stub, {
+      maxAttempts: 5,
+      initialDelayMs: 100,
+      backoffMultiplier: 3,
+    });
+    const promise = wrapped.fetch("vid");
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(stub.calls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(stub.calls).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(stub.calls).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(150);
+    expect(stub.calls).toBe(3);
+
+    await vi.runAllTimersAsync();
+    await promise;
+  });
+});

--- a/packages/core/src/sources/retry.ts
+++ b/packages/core/src/sources/retry.ts
@@ -1,0 +1,67 @@
+import type { RetryPolicy } from "../types";
+import type { SourceOutcome, TranscriptSource } from "./types";
+
+export const DEFAULT_RETRY_POLICY: RetryPolicy = {
+  maxAttempts: 3,
+  initialDelayMs: 500,
+  backoffMultiplier: 2,
+};
+
+export function withRetry(
+  source: TranscriptSource,
+  policy: RetryPolicy
+): TranscriptSource {
+  return {
+    name: source.name,
+    async fetch(videoId: string, signal?: AbortSignal): Promise<SourceOutcome> {
+      let attempt = 0;
+      let delay = policy.initialDelayMs;
+      let lastTransient: SourceOutcome & { kind: "transient" } = {
+        kind: "transient",
+        cause: "no-attempts",
+      };
+
+      while (attempt < policy.maxAttempts) {
+        if (signal?.aborted) {
+          return { kind: "transient", cause: "aborted" };
+        }
+
+        const outcome = await source.fetch(videoId, signal);
+        if (outcome.kind !== "transient") {
+          return outcome;
+        }
+
+        lastTransient = outcome;
+        attempt += 1;
+
+        if (attempt >= policy.maxAttempts) break;
+
+        const aborted = await sleep(delay, signal);
+        if (aborted) {
+          return { kind: "transient", cause: "aborted" };
+        }
+        delay = Math.floor(delay * policy.backoffMultiplier);
+      }
+
+      return lastTransient;
+    },
+  };
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<boolean> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve(true);
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve(false);
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/packages/core/src/sources/supadata.test.ts
+++ b/packages/core/src/sources/supadata.test.ts
@@ -43,6 +43,30 @@ describe("SupadataSource", () => {
     expect(new SupadataSource("key").name).toBe("supadata");
   });
 
+  it("decodes HTML entities in inline content text", async () => {
+    transcriptMock.mockResolvedValue({
+      content: [
+        {
+          text: "she said &quot;hi&quot;",
+          offset: 0,
+          duration: 1000,
+          lang: "en",
+        },
+        { text: "AT&amp;amp;T", offset: 1000, duration: 500, lang: "en" },
+      ],
+      lang: "en",
+      availableLangs: ["en"],
+    });
+    const result = await new SupadataSource("key").fetch("vid");
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.entries.map((e) => e.text)).toEqual([
+        'she said "hi"',
+        "AT&T",
+      ]);
+    }
+  });
+
   it("converts ms to seconds in inline content", async () => {
     transcriptMock.mockResolvedValue({
       content: [

--- a/packages/core/src/sources/supadata.test.ts
+++ b/packages/core/src/sources/supadata.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SupadataSource } from "./supadata";
+
+const transcriptMock = vi.fn();
+
+vi.mock("@supadata/js", () => {
+  class SupadataError extends Error {
+    error: string;
+    details: string;
+    constructor({
+      error,
+      message,
+      details,
+    }: {
+      error: string;
+      message?: string;
+      details?: string;
+    }) {
+      super(message ?? error);
+      this.error = error;
+      this.details = details ?? "";
+    }
+  }
+  return {
+    Supadata: class {
+      constructor(_config: unknown) {
+        void _config;
+      }
+      transcript = transcriptMock;
+    },
+    SupadataError,
+  };
+});
+
+import { SupadataError } from "@supadata/js";
+
+describe("SupadataSource", () => {
+  afterEach(() => {
+    transcriptMock.mockReset();
+  });
+
+  it("identifies as supadata", () => {
+    expect(new SupadataSource("key").name).toBe("supadata");
+  });
+
+  it("converts ms to seconds in inline content", async () => {
+    transcriptMock.mockResolvedValue({
+      content: [
+        { text: "hello", offset: 0, duration: 2000, lang: "en" },
+        { text: "world", offset: 2000, duration: 1500, lang: "en" },
+      ],
+      lang: "en",
+      availableLangs: ["en"],
+    });
+    const result = await new SupadataSource("key").fetch("vid");
+    expect(result).toEqual({
+      kind: "ok",
+      lang: "en",
+      entries: [
+        { text: "hello", offsetSec: 0, durationSec: 2, lang: "en" },
+        { text: "world", offsetSec: 2, durationSec: 1.5, lang: "en" },
+      ],
+    });
+  });
+
+  it("returns pending with default retryAfter when response has only jobId", async () => {
+    transcriptMock.mockResolvedValue({ jobId: "abc-123" });
+    const result = await new SupadataSource("key").fetch("vid");
+    expect(result).toEqual({
+      kind: "pending",
+      jobId: "abc-123",
+      retryAfterSeconds: 90,
+    });
+  });
+
+  it("maps SupadataError 'transcript-unavailable' to unavailable: no-captions", async () => {
+    transcriptMock.mockRejectedValue(
+      new SupadataError({
+        error: "transcript-unavailable",
+        message: "No captions",
+      })
+    );
+    expect(await new SupadataSource("key").fetch("vid")).toEqual({
+      kind: "unavailable",
+      reason: "no-captions",
+    });
+  });
+
+  it("maps SupadataError 'not-found' to unavailable: video-removed", async () => {
+    transcriptMock.mockRejectedValue(
+      new SupadataError({ error: "not-found", message: "Video not found" })
+    );
+    expect(await new SupadataSource("key").fetch("vid")).toEqual({
+      kind: "unavailable",
+      reason: "video-removed",
+    });
+  });
+
+  it("maps SupadataError 'invalid-request' to unavailable: invalid-id", async () => {
+    transcriptMock.mockRejectedValue(
+      new SupadataError({ error: "invalid-request", message: "Bad URL" })
+    );
+    expect(await new SupadataSource("key").fetch("vid")).toEqual({
+      kind: "unavailable",
+      reason: "invalid-id",
+    });
+  });
+
+  it("maps SupadataError 'limit-exceeded' to transient with cause limit-exceeded", async () => {
+    transcriptMock.mockRejectedValue(
+      new SupadataError({ error: "limit-exceeded", message: "Quota exhausted" })
+    );
+    const result = await new SupadataSource("key").fetch("vid");
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") {
+      expect(result.cause).toBe("limit-exceeded");
+    }
+  });
+
+  it("maps SupadataError 'upgrade-required' to transient", async () => {
+    transcriptMock.mockRejectedValue(
+      new SupadataError({ error: "upgrade-required", message: "" })
+    );
+    const result = await new SupadataSource("key").fetch("vid");
+    expect(result.kind).toBe("transient");
+  });
+
+  it("maps SupadataError 'unauthorized' to transient with cause unauthorized", async () => {
+    transcriptMock.mockRejectedValue(
+      new SupadataError({ error: "unauthorized", message: "Bad key" })
+    );
+    const result = await new SupadataSource("key").fetch("vid");
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") {
+      expect(result.cause).toBe("unauthorized");
+    }
+  });
+
+  it("maps SupadataError 'internal-error' to transient", async () => {
+    transcriptMock.mockRejectedValue(
+      new SupadataError({ error: "internal-error", message: "" })
+    );
+    const result = await new SupadataSource("key").fetch("vid");
+    expect(result.kind).toBe("transient");
+  });
+
+  it("maps generic thrown error to transient", async () => {
+    transcriptMock.mockRejectedValue(new Error("ECONNRESET"));
+    const result = await new SupadataSource("key").fetch("vid");
+    expect(result.kind).toBe("transient");
+  });
+
+  it("maps malformed response (missing lang on success) to transient: schema-mismatch", async () => {
+    transcriptMock.mockResolvedValue({
+      content: [{ text: "x", offset: 0, duration: 1000, lang: "en" }],
+    });
+    const result = await new SupadataSource("key").fetch("vid");
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") {
+      expect(result.cause).toBe("schema-mismatch");
+    }
+  });
+
+  it("maps string content (no timestamps) to transient: schema-mismatch", async () => {
+    transcriptMock.mockResolvedValue({
+      content: "raw string transcript",
+      lang: "en",
+      availableLangs: ["en"],
+    });
+    const result = await new SupadataSource("key").fetch("vid");
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") {
+      expect(result.cause).toBe("schema-mismatch");
+    }
+  });
+
+  it("passes the videoId as a youtube URL to the SDK with mode auto", async () => {
+    transcriptMock.mockResolvedValue({ jobId: "x" });
+    await new SupadataSource("key").fetch("dQw4w9WgXcQ");
+    expect(transcriptMock).toHaveBeenCalledWith({
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      mode: "auto",
+    });
+  });
+});

--- a/packages/core/src/sources/supadata.ts
+++ b/packages/core/src/sources/supadata.ts
@@ -1,0 +1,88 @@
+import { Supadata, SupadataError } from "@supadata/js";
+import { z } from "zod";
+import type { SourceOutcome, TranscriptSource } from "./types";
+
+const ChunkSchema = z.object({
+  text: z.string(),
+  offset: z.number(),
+  duration: z.number(),
+  lang: z.string(),
+});
+
+const InlineTranscriptSchema = z.object({
+  content: z.array(ChunkSchema),
+  lang: z.string(),
+  availableLangs: z.array(z.string()),
+});
+
+const JobIdSchema = z.object({ jobId: z.string() });
+
+const ResponseSchema = z.union([InlineTranscriptSchema, JobIdSchema]);
+
+const DEFAULT_RETRY_AFTER_SECONDS = 90;
+
+export class SupadataSource implements TranscriptSource {
+  readonly name = "supadata" as const;
+  private readonly client: Supadata;
+
+  constructor(apiKey: string) {
+    this.client = new Supadata({ apiKey });
+  }
+
+  async fetch(videoId: string): Promise<SourceOutcome> {
+    let raw: unknown;
+    try {
+      raw = await this.client.transcript({
+        url: `https://www.youtube.com/watch?v=${videoId}`,
+        mode: "auto",
+      });
+    } catch (err) {
+      return mapError(err);
+    }
+
+    const parsed = ResponseSchema.safeParse(raw);
+    if (!parsed.success) {
+      return { kind: "transient", cause: "schema-mismatch" };
+    }
+
+    if ("jobId" in parsed.data) {
+      return {
+        kind: "pending",
+        jobId: parsed.data.jobId,
+        retryAfterSeconds: DEFAULT_RETRY_AFTER_SECONDS,
+      };
+    }
+
+    const entries = parsed.data.content.map((c) => ({
+      text: c.text,
+      offsetSec: c.offset / 1000,
+      durationSec: c.duration / 1000,
+      lang: c.lang,
+    }));
+
+    return { kind: "ok", lang: parsed.data.lang, entries };
+  }
+}
+
+function mapError(err: unknown): SourceOutcome {
+  if (err instanceof SupadataError) {
+    switch (err.error) {
+      case "transcript-unavailable":
+        return { kind: "unavailable", reason: "no-captions" };
+      case "not-found":
+        return { kind: "unavailable", reason: "video-removed" };
+      case "invalid-request":
+        return { kind: "unavailable", reason: "invalid-id" };
+      case "limit-exceeded":
+        return { kind: "transient", cause: "limit-exceeded" };
+      case "upgrade-required":
+        return { kind: "transient", cause: "upgrade-required" };
+      case "unauthorized":
+        return { kind: "transient", cause: "unauthorized" };
+      case "internal-error":
+        return { kind: "transient", cause: "internal-error" };
+    }
+  }
+  const cause = err instanceof Error ? err.message : "unknown";
+  return { kind: "transient", cause };
+}

--- a/packages/core/src/sources/supadata.ts
+++ b/packages/core/src/sources/supadata.ts
@@ -1,5 +1,6 @@
 import { Supadata, SupadataError } from "@supadata/js";
 import { z } from "zod";
+import { decodeHtmlEntities } from "../text";
 import type { SourceOutcome, TranscriptSource } from "./types";
 
 const ChunkSchema = z.object({
@@ -54,7 +55,7 @@ export class SupadataSource implements TranscriptSource {
     }
 
     const entries = parsed.data.content.map((c) => ({
-      text: c.text,
+      text: decodeHtmlEntities(c.text),
       offsetSec: c.offset / 1000,
       durationSec: c.duration / 1000,
       lang: c.lang,

--- a/packages/core/src/sources/types.ts
+++ b/packages/core/src/sources/types.ts
@@ -1,0 +1,12 @@
+import type { SourceName, TranscriptEntry, UnavailableReason } from "../types";
+
+export type SourceOutcome =
+  | { kind: "ok"; lang?: string; entries: TranscriptEntry[] }
+  | { kind: "pending"; jobId: string; retryAfterSeconds: number }
+  | { kind: "unavailable"; reason: UnavailableReason }
+  | { kind: "transient"; cause: string };
+
+export interface TranscriptSource {
+  readonly name: SourceName;
+  fetch(videoId: string, signal?: AbortSignal): Promise<SourceOutcome>;
+}

--- a/packages/core/src/text.test.ts
+++ b/packages/core/src/text.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { decodeHtmlEntities } from "./text";
+
+describe("decodeHtmlEntities", () => {
+  it("decodes named entities", () => {
+    expect(decodeHtmlEntities("&amp;")).toBe("&");
+    expect(decodeHtmlEntities("&lt;")).toBe("<");
+    expect(decodeHtmlEntities("&gt;")).toBe(">");
+    expect(decodeHtmlEntities("&quot;")).toBe('"');
+    expect(decodeHtmlEntities("&apos;")).toBe("'");
+    expect(decodeHtmlEntities("&nbsp;")).toBe(" ");
+  });
+
+  it("decodes numeric entities", () => {
+    expect(decodeHtmlEntities("&#39;")).toBe("'");
+    expect(decodeHtmlEntities("&#34;")).toBe('"');
+    expect(decodeHtmlEntities("&#8217;")).toBe("’");
+  });
+
+  it("decodes hex numeric entities", () => {
+    expect(decodeHtmlEntities("&#x27;")).toBe("'");
+    expect(decodeHtmlEntities("&#x2019;")).toBe("’");
+    expect(decodeHtmlEntities("&#X27;")).toBe("'");
+  });
+
+  it("decodes double-encoded entities", () => {
+    expect(decodeHtmlEntities("&amp;#39;")).toBe("'");
+    expect(decodeHtmlEntities("&amp;amp;")).toBe("&");
+    expect(decodeHtmlEntities("&amp;quot;")).toBe('"');
+  });
+
+  it("decodes entities embedded in real text", () => {
+    expect(
+      decodeHtmlEntities("we&amp;#39;re no strangers")
+    ).toBe("we're no strangers");
+    expect(decodeHtmlEntities("a &lt; b &amp;&amp; c &gt; d")).toBe(
+      "a < b && c > d"
+    );
+  });
+
+  it("leaves text without entities unchanged", () => {
+    expect(decodeHtmlEntities("hello world")).toBe("hello world");
+    expect(decodeHtmlEntities("")).toBe("");
+    expect(decodeHtmlEntities("[♪♪♪]")).toBe("[♪♪♪]");
+  });
+
+  it("leaves stray ampersands alone", () => {
+    expect(decodeHtmlEntities("AT&T")).toBe("AT&T");
+    expect(decodeHtmlEntities("a & b")).toBe("a & b");
+  });
+});

--- a/packages/core/src/text.ts
+++ b/packages/core/src/text.ts
@@ -1,0 +1,27 @@
+const NAMED: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+};
+
+const ENTITY = /&(?:#[xX]([0-9a-fA-F]+)|#(\d+)|([a-zA-Z]+));/g;
+
+export function decodeHtmlEntities(input: string): string {
+  let prev: string;
+  let curr = input;
+  let iterations = 0;
+  do {
+    prev = curr;
+    curr = curr.replace(ENTITY, (match, hex, dec, name) => {
+      if (hex) return String.fromCodePoint(parseInt(hex, 16));
+      if (dec) return String.fromCodePoint(parseInt(dec, 10));
+      const char = NAMED[name as string];
+      return char ?? match;
+    });
+    iterations += 1;
+  } while (curr !== prev && iterations < 5);
+  return curr;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,90 @@
+export type SourceName = "youtube-transcript-plus" | "supadata";
+
+export type UnavailableReason =
+  | "no-captions"
+  | "video-removed"
+  | "video-private"
+  | "invalid-id";
+
+export type TranscriptEntry = {
+  offsetSec: number;
+  durationSec: number;
+  text: string;
+  lang?: string;
+};
+
+export type TranscriptResult =
+  | {
+      kind: "ok";
+      source: SourceName;
+      lang?: string;
+      entries: TranscriptEntry[];
+    }
+  | {
+      kind: "pending";
+      source: SourceName;
+      jobId: string;
+      retryAfterSeconds: number;
+      message: string;
+    }
+  | {
+      kind: "unavailable";
+      reason: UnavailableReason;
+      message: string;
+    }
+  | {
+      kind: "transient";
+      cause: string;
+      message: string;
+    };
+
+export type RetryPolicy = {
+  maxAttempts: number;
+  initialDelayMs: number;
+  backoffMultiplier: number;
+};
+
+export interface TranscriptCache {
+  get(videoId: string): Promise<TranscriptResult | null>;
+  set(videoId: string, result: TranscriptResult): Promise<void>;
+}
+
+export type TranscriptOptions = {
+  supadataApiKey?: string;
+  signal?: AbortSignal;
+  sources?: SourceName[];
+  retryPolicy?: RetryPolicy;
+  cache?: TranscriptCache;
+};
+
+export type MetadataUnavailableReason =
+  | "video-not-found"
+  | "invalid-id"
+  | "quota-exceeded"
+  | "api-key-invalid";
+
+export type VideoMetadata = {
+  videoId: string;
+  title: string;
+  channelTitle: string;
+  channelId: string;
+  duration: string;
+  publishedAt: string;
+  description: string;
+  pinnedComment?: string;
+};
+
+export type MetadataResult =
+  | { kind: "ok"; metadata: VideoMetadata }
+  | {
+      kind: "unavailable";
+      reason: MetadataUnavailableReason;
+      message: string;
+    }
+  | { kind: "transient"; cause: string; message: string };
+
+export type MetadataOptions = {
+  youtubeApiKey: string;
+  signal?: AbortSignal;
+  retryPolicy?: RetryPolicy;
+};

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    passWithNoTests: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,28 @@ importers:
 
   .: {}
 
+  apps/cli:
+    dependencies:
+      '@brief/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+    devDependencies:
+      '@types/node':
+        specifier: ^20.19.26
+        version: 20.19.30
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.19.30)(lightningcss@1.30.2)
+
   apps/extension:
     dependencies:
       '@brief/shared':
@@ -187,6 +209,31 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  packages/core:
+    dependencies:
+      '@googleapis/youtube':
+        specifier: ^18.0.0
+        version: 18.0.0
+      '@supadata/js':
+        specifier: ^1.3.2
+        version: 1.3.2
+      youtube-transcript-plus:
+        specifier: ^1.1.2
+        version: 1.1.2
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^20.19.26
+        version: 20.19.30
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.19.30)(lightningcss@1.30.2)
 
   packages/shared:
     devDependencies:
@@ -373,16 +420,34 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.2':
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.2':
@@ -391,16 +456,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.2':
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.2':
     resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.2':
@@ -409,10 +492,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.2':
     resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.2':
@@ -421,10 +516,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.2':
     resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.2':
@@ -433,10 +540,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.2':
     resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.2':
@@ -445,10 +564,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.2':
     resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.2':
@@ -457,16 +588,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.2':
     resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.2':
     resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.27.2':
@@ -481,6 +630,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.2':
     resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
     engines: {node: '>=18'}
@@ -491,6 +646,12 @@ packages:
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.2':
@@ -505,11 +666,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.27.2':
     resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.27.2':
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
@@ -517,10 +690,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.2':
     resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.2':
@@ -1844,6 +2029,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   '@webext-core/fake-browser@1.3.4':
     resolution: {integrity: sha512-nZcVWr3JpwpS5E6hKpbAwAMBM/AXZShnfW0F76udW8oLd6Kv0nbW6vFS07md4Na/0ntQonk3hFnlQYGYBAlTrA==}
 
@@ -1932,6 +2146,9 @@ packages:
   ansicolors@0.3.2:
     resolution: {integrity: sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1986,6 +2203,10 @@ packages:
   asn1js@3.0.7:
     resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
     engines: {node: '>=12.0.0'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -2082,6 +2303,12 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   c12@3.3.3:
     resolution: {integrity: sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==}
     peerDependencies:
@@ -2121,6 +2348,10 @@ packages:
     resolution: {integrity: sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==}
     hasBin: true
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2132,6 +2363,14 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -2205,6 +2444,10 @@ packages:
   commander@2.9.0:
     resolution: {integrity: sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==}
     engines: {node: '>= 0.6.x'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
 
   commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
@@ -2311,6 +2554,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -2454,6 +2701,9 @@ packages:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
@@ -2475,6 +2725,11 @@ packages:
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
@@ -2628,6 +2883,10 @@ packages:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
@@ -2687,6 +2946,9 @@ packages:
     resolution: {integrity: sha512-aGApEu5bfCNbA4PGUZiRJAIU6jKmghV2UVdklXAofnNtiDjqYw0czLS46W7IfFqVKgKhFB8Ao2YoNGHY4BoIMQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -3188,6 +3450,10 @@ packages:
   jose@5.6.3:
     resolution: {integrity: sha512-1Jh//hEEwMhNYPDDLwXHa2ePWgWiFNNUadVmguAAw2IJ6sj9mNxV5tGXJNqlMkJAybF6Lgw1mISDxTePP/187g==}
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3356,6 +3622,13 @@ packages:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   lines-and-columns@2.0.4:
     resolution: {integrity: sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3372,6 +3645,10 @@ packages:
   listr2@10.1.0:
     resolution: {integrity: sha512-/6t2KgDYIcCjhELwvrRxi1gaJ4xCGLTjNvh6mSjYenBkrZxggek8EwCbwBU33GMUCpyyrOzz2TzylrO5mTiI1w==}
     engines: {node: '>=22.0.0'}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
@@ -3416,6 +3693,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -3490,6 +3770,9 @@ packages:
   multimatch@6.0.0:
     resolution: {integrity: sha512-I7tSVxHGPlmPN/enE3mS1aOSo6bWBfls+3HmuEeCUBCE7gWnm3cBXCBkpurzFjVRwC6Kld8lLaZ1Iv5vOcjvcQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nano-spawn@2.0.0:
     resolution: {integrity: sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==}
@@ -3711,8 +3994,15 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
@@ -3753,6 +4043,10 @@ packages:
     resolution: {integrity: sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==}
     hasBin: true
 
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -3762,6 +4056,24 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -3913,6 +4225,10 @@ packages:
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
@@ -3947,6 +4263,10 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -4077,6 +4397,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4122,6 +4445,12 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stdin-discarder@0.3.1:
     resolution: {integrity: sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==}
@@ -4219,6 +4548,11 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -4241,11 +4575,24 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
@@ -4254,6 +4601,18 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
@@ -4266,17 +4625,43 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -4420,10 +4805,46 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-node@5.3.0:
     resolution: {integrity: sha512-8f20COPYJujc3OKPX6OuyBy3ZIv2det4eRRU4GY1y2MjbeGSUmPjedxg1b72KnTagCofwvZ65ThzjxDW2AtQFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -4463,6 +4884,31 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   watchpack@2.4.4:
@@ -4514,6 +4960,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@5.0.0:
@@ -4869,52 +5320,103 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.27.2':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.27.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.27.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.27.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.27.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.2':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.27.2':
@@ -4923,10 +5425,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.2':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.2':
@@ -4935,13 +5443,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.27.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.27.2':
@@ -6168,6 +6688,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.30)(lightningcss@1.30.2))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.30)(lightningcss@1.30.2)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   '@webext-core/fake-browser@1.3.4':
     dependencies:
       lodash.merge: 4.6.2
@@ -6268,6 +6828,8 @@ snapshots:
 
   ansicolors@0.3.2: {}
 
+  any-promise@1.3.0: {}
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -6352,6 +6914,8 @@ snapshots:
       pvtsutils: 1.3.6
       pvutils: 1.1.5
       tslib: 2.8.1
+
+  assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
 
@@ -6447,6 +7011,11 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  bundle-require@5.1.0(esbuild@0.27.2):
+    dependencies:
+      esbuild: 0.27.2
+      load-tsconfig: 0.2.5
+
   c12@3.3.3(magicast@0.5.2):
     dependencies:
       chokidar: 5.0.0
@@ -6494,6 +7063,14 @@ snapshots:
       ansicolors: 0.3.2
       redeyed: 2.1.1
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -6502,6 +7079,12 @@ snapshots:
   chalk@5.6.2: {}
 
   char-regex@1.0.2: {}
+
+  check-error@2.1.3: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
 
   chokidar@5.0.0:
     dependencies:
@@ -6580,6 +7163,8 @@ snapshots:
   commander@2.9.0:
     dependencies:
       graceful-readlink: 1.0.1
+
+  commander@4.1.1: {}
 
   commander@9.5.0: {}
 
@@ -6677,6 +7262,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -6866,6 +7453,8 @@ snapshots:
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
 
+  es-module-lexer@1.7.0: {}
+
   es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
@@ -6890,6 +7479,32 @@ snapshots:
       is-symbol: 1.1.1
 
   es6-error@4.1.1: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -6933,8 +7548,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.3
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -6956,7 +7571,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6967,22 +7582,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6993,7 +7608,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7036,8 +7651,8 @@ snapshots:
       '@babel/parser': 7.28.6
       eslint: 9.39.2(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.3.5
-      zod-validation-error: 4.0.2(zod@4.3.5)
+      zod: 4.3.6
+      zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -7141,6 +7756,8 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
+  expect-type@1.3.0: {}
+
   exsolve@1.0.8: {}
 
   extend@3.0.2: {}
@@ -7199,6 +7816,12 @@ snapshots:
       ini: 4.1.3
       minimist: 1.2.8
       xml2js: 0.6.2
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
 
   flat-cache@4.0.1:
     dependencies:
@@ -7689,6 +8312,8 @@ snapshots:
 
   jose@5.6.3: {}
 
+  joycon@3.1.1: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -7848,6 +8473,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
 
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
   lines-and-columns@2.0.4: {}
 
   linkedom@0.18.12:
@@ -7866,6 +8495,8 @@ snapshots:
       log-update: 7.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
+
+  load-tsconfig@0.2.5: {}
 
   local-pkg@1.1.2:
     dependencies:
@@ -7909,6 +8540,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -7986,6 +8619,12 @@ snapshots:
       array-differ: 4.0.0
       array-union: 3.0.1
       minimatch: 3.1.2
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nano-spawn@2.0.0: {}
 
@@ -8212,7 +8851,11 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   perfect-debounce@2.1.0: {}
 
@@ -8258,6 +8901,8 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 3.1.0
 
+  pirates@4.0.7: {}
+
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
@@ -8271,6 +8916,14 @@ snapshots:
       pathe: 2.0.3
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.6.1
+      postcss: 8.5.6
+      tsx: 4.21.0
 
   postcss@8.4.31:
     dependencies:
@@ -8420,6 +9073,8 @@ snapshots:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
+  readdirp@4.1.2: {}
+
   readdirp@5.0.0: {}
 
   real-require@0.2.0: {}
@@ -8459,6 +9114,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -8654,6 +9311,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
@@ -8694,6 +9353,10 @@ snapshots:
       through: 2.3.8
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stdin-discarder@0.3.1: {}
 
@@ -8808,6 +9471,16 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.28.6
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -8825,11 +9498,23 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
 
   through@2.3.8: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyexec@1.0.2: {}
 
@@ -8837,6 +9522,12 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   tmp@0.2.5: {}
 
@@ -8846,9 +9537,13 @@ snapshots:
 
   tr46@0.0.3: {}
 
+  tree-kill@1.2.2: {}
+
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-interface-checker@0.1.13: {}
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -8858,6 +9553,34 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.2)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.2
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.6
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tsx@4.21.0:
     dependencies:
@@ -9046,6 +9769,24 @@ snapshots:
 
   uuid@9.0.1: {}
 
+  vite-node@2.1.9(@types/node@20.19.30)(lightningcss@1.30.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@20.19.30)(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@5.3.0(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
@@ -9066,6 +9807,16 @@ snapshots:
       - tsx
       - yaml
 
+  vite@5.4.21(@types/node@20.19.30)(lightningcss@1.30.2):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.57.1
+    optionalDependencies:
+      '@types/node': 20.19.30
+      fsevents: 2.3.3
+      lightningcss: 1.30.2
+
   vite@7.3.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.2
@@ -9080,6 +9831,41 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       tsx: 4.21.0
+
+  vitest@2.1.9(@types/node@20.19.30)(lightningcss@1.30.2):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.30)(lightningcss@1.30.2))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@20.19.30)(lightningcss@1.30.2)
+      vite-node: 2.1.9(@types/node@20.19.30)(lightningcss@1.30.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.30
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   watchpack@2.4.4:
     dependencies:
@@ -9181,6 +9967,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@5.0.0:
     dependencies:
@@ -9312,9 +10103,9 @@ snapshots:
       async: 3.2.6
       jszip: 3.10.1
 
-  zod-validation-error@4.0.2(zod@4.3.5):
+  zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
-      zod: 4.3.5
+      zod: 4.3.6
 
   zod@4.3.5: {}
 


### PR DESCRIPTION
## Summary
- New `@brief/core` package: video ID parsing, transcript fetching with deterministic cascade across `youtube-transcript-plus` and Supadata, retry/backoff, runtime Zod validation at both adapter boundaries, jobId surfaced as a first-class result branch, YouTube Data API metadata fetch (with pinned comment), shared `formatTranscript` serializer.
- New `apps/cli` exposing the `brief` binary. Run via `pnpm cli <url-or-id>` from the repo, or globally as `brief <url-or-id>` after install. Flags: `--json`, `--no-metadata`, `--source=auto|local|supadata`, `--timeout=<ms>`, `--supadata-key`, `--youtube-key`. Stable JSON output schema (schemaVersion 1.0.0).
- 106 vitest tests across both packages covering the cascade rules table, source adapter mappings, retry decorator, video ID parsing, metadata error handling, renderer output, and exit codes.
- Web app migration to consume the new package is deferred to #79.

Closes #76. Web migration tracked in #79.