### PR TITLE
feat: persist transcripts + metrics, migrate transcript to core

### DIFF
--- a/apps/cli/src/renderer.ts
+++ b/apps/cli/src/renderer.ts
@@ -35,10 +35,10 @@ function renderHuman(combined: CombinedResult, isTTY: boolean): Rendered {
 
   let stdout = "";
   if (transcript.kind === "ok") {
-    stdout = formatTranscript(transcript, "text") + "\n";
+    stdout = formatTranscript(transcript, "prose") + "\n";
   } else {
     stderrLines.push("");
-    stderrLines.push(formatTranscript(transcript, "text"));
+    stderrLines.push(formatTranscript(transcript, "prose"));
   }
 
   return { stdout, stderr: stderrLines.join("\n") + "\n" };

--- a/apps/web/migrations/009_add_transcript_metrics_frames_status.sql
+++ b/apps/web/migrations/009_add_transcript_metrics_frames_status.sql
@@ -1,0 +1,23 @@
+-- Brief schema foundations for downstream LLM consumers (#85).
+--
+-- Three additive columns. Existing rows are unaffected:
+--   - transcript      JSONB     nullable, NULL for legacy rows
+--   - metrics         JSONB     nullable, NULL for legacy rows
+--   - frames_status   enum      NOT NULL, defaults to 'not-requested' (back-fills automatically)
+--
+-- transcript holds the structured per-entry transcript (matches @brief/core's
+-- TranscriptEntry shape: offsetSec/durationSec/text) plus the source. JSONB so
+-- the shape can grow (e.g., visual segments from the video-frames feature #87)
+-- without another migration.
+--
+-- metrics holds per-generation telemetry: { inputTokens, outputTokens, model,
+-- latencyMs }. JSONB to stay extensible.
+--
+-- frames_status captures user intent + pipeline outcome: 'included' |
+-- 'attempted-failed' | 'not-requested'. Only the default 'not-requested' is
+-- written by code shipping in this migration. The frames feature populates the
+-- other values when it lands.
+
+ALTER TABLE digests ADD COLUMN IF NOT EXISTS transcript JSONB;
+ALTER TABLE digests ADD COLUMN IF NOT EXISTS metrics JSONB;
+ALTER TABLE digests ADD COLUMN IF NOT EXISTS frames_status VARCHAR(20) NOT NULL DEFAULT 'not-requested';

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "lint": "next lint",
     "migrate": "tsx scripts/migrate.ts",
     "backfill-search": "tsx scripts/backfill-search.ts",
+    "query": "tsx scripts/query.ts",
     "security": "pnpm security:code && pnpm security:secrets",
     "security:code": "docker run --rm -v \"$(pwd):/src\" semgrep/semgrep semgrep scan --config auto",
     "security:secrets": "docker run --rm -v \"$(pwd):/repo\" trufflesecurity/trufflehog:latest git file:///repo --only-verified --fail"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,7 +42,6 @@
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-tooltip": "^1.1.6",
-    "@supadata/js": "^1.3.2",
     "@vercel/postgres": "^0.10.0",
     "@workos-inc/authkit-nextjs": "^2.13.0",
     "ai": "^6.0.39",
@@ -60,7 +59,6 @@
     "react-dom": "19.2.3",
     "react-hotkeys-hook": "^5.2.3",
     "tailwind-merge": "^3.4.0",
-    "youtube-transcript-plus": "^1.1.2",
     "zod": "^4.3.5"
   },
   "devDependencies": {

--- a/apps/web/scripts/query.ts
+++ b/apps/web/scripts/query.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env tsx
+/**
+ * Local database query helper.
+ *
+ * Usage:
+ *   pnpm query "SELECT id, title FROM digests LIMIT 3"
+ *   pnpm query --pretty "SELECT id, transcript->'source' FROM digests LIMIT 1"
+ *
+ * Local-only by design — reads POSTGRES_URL from apps/web/.env. Does NOT
+ * accept a --prod flag; running ad-hoc queries against production should
+ * happen through the Vercel/Neon dashboard, not from a local shell.
+ */
+
+import { config } from "dotenv";
+import { sql } from "@vercel/postgres";
+import * as path from "path";
+import * as fs from "fs";
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  const pretty = argv.includes("--pretty");
+  const queryParts = argv.filter((a) => !a.startsWith("--"));
+  const query = queryParts.join(" ").trim();
+  return { query, pretty };
+}
+
+async function main() {
+  const { query, pretty } = parseArgs();
+  if (!query) {
+    console.error("Usage: pnpm query \"<SQL>\"  [--pretty]");
+    console.error('Example: pnpm query "SELECT id, title FROM digests LIMIT 3"');
+    process.exit(2);
+  }
+
+  const envPath = path.join(process.cwd(), ".env");
+  if (!fs.existsSync(envPath)) {
+    console.error(`Error: ${envPath} not found.`);
+    process.exit(1);
+  }
+  config({ path: envPath });
+  if (!process.env.POSTGRES_URL) {
+    console.error("Error: POSTGRES_URL not set in .env");
+    process.exit(1);
+  }
+
+  try {
+    const result = await sql.query(query);
+    if (result.rows.length === 0) {
+      console.log("(no rows)");
+      console.log(`Affected: ${result.rowCount ?? 0}`);
+      return;
+    }
+    if (pretty) {
+      for (const row of result.rows) {
+        console.log(JSON.stringify(row, null, 2));
+      }
+    } else {
+      for (const row of result.rows) {
+        console.log(JSON.stringify(row));
+      }
+    }
+    console.log(`(${result.rows.length} row${result.rows.length === 1 ? "" : "s"})`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`Query failed: ${msg}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/apps/web/src/app/api/brief/[id]/regenerate/route.ts
+++ b/apps/web/src/app/api/brief/[id]/regenerate/route.ts
@@ -6,6 +6,7 @@ import { generateBrief } from "@/lib/summarize";
 import { extractChapters } from "@/lib/chapters";
 import { isEmailAllowed } from "@/lib/access";
 import { updateBrief, getBriefById } from "@/lib/db";
+import type { StoredTranscript } from "@/lib/types";
 
 type Step = "metadata" | "transcript" | "analyzing" | "saving" | "complete" | "error";
 
@@ -73,18 +74,29 @@ export async function POST(
 
         // Step 2: Fetch transcript
         controller.enqueue(encoder.encode(createEvent("transcript", "Extracting transcript...")));
-        const transcript = await fetchTranscript(videoId);
+        const { entries: transcript, source: transcriptSource, lang: transcriptLang } = await fetchTranscript(videoId);
         console.log(`[REGENERATE] Transcript fetched: ${transcript.length} entries`);
 
         // Step 3: Generate brief
         controller.enqueue(encoder.encode(createEvent("analyzing", "Analyzing content...")));
-        const brief = await generateBrief(transcript, metadata, openrouterApiKey, chapters);
+        const { brief, metrics } = await generateBrief(transcript, metadata, openrouterApiKey, chapters);
         console.log(`[REGENERATE] Brief generated`);
+
+        const storedTranscript: StoredTranscript = {
+          entries: transcript.map((e) => ({
+            text: e.text,
+            offsetSec: e.offset,
+            durationSec: e.duration,
+            ...(e.lang ? { lang: e.lang } : {}),
+          })),
+          source: transcriptSource,
+          ...(transcriptLang ? { lang: transcriptLang } : {}),
+        };
 
         // Step 4: Save
         controller.enqueue(encoder.encode(createEvent("saving", "Saving brief...")));
         const hasCreatorChapters = chapters !== null && chapters.length > 0;
-        await updateBrief(user.id, id, metadata, brief, hasCreatorChapters);
+        await updateBrief(user.id, id, metadata, brief, hasCreatorChapters, storedTranscript, metrics);
         console.log(`[REGENERATE] Brief updated in database, hasCreatorChapters: ${hasCreatorChapters}`);
 
         // Complete

--- a/apps/web/src/app/api/brief/[id]/regenerate/route.ts
+++ b/apps/web/src/app/api/brief/[id]/regenerate/route.ts
@@ -5,7 +5,7 @@ import { fetchVideoMetadata } from "@/lib/metadata";
 import { generateBrief } from "@/lib/summarize";
 import { extractChapters } from "@/lib/chapters";
 import { isEmailAllowed } from "@/lib/access";
-import { updateBrief, getBriefById } from "@/lib/db";
+import { updateBrief, briefExistsForUser } from "@/lib/db";
 import type { StoredTranscript } from "@/lib/types";
 
 type Step = "metadata" | "transcript" | "analyzing" | "saving" | "complete" | "error";
@@ -53,9 +53,9 @@ export async function POST(
   const stream = new ReadableStream({
     async start(controller) {
       try {
-        // Verify brief exists and belongs to user
-        const existingBrief = await getBriefById(id, user.id);
-        if (!existingBrief) {
+        // Verify brief exists and belongs to user (lightweight — skip JSONB fields)
+        const exists = await briefExistsForUser(id, user.id);
+        if (!exists) {
           controller.enqueue(encoder.encode(createEvent("error", "Brief not found")));
           controller.close();
           return;

--- a/apps/web/src/app/api/brief/route.ts
+++ b/apps/web/src/app/api/brief/route.ts
@@ -13,7 +13,7 @@ import {
   findGlobalBriefByVideoId,
   copyBriefForUser,
 } from "@/lib/db";
-import type { DbBrief } from "@/lib/types";
+import type { DbBrief, StoredTranscript } from "@/lib/types";
 
 type Step = "cached" | "metadata" | "transcript" | "analyzing" | "saving" | "complete" | "error";
 
@@ -148,14 +148,25 @@ export async function POST(request: NextRequest) {
         // Step 4: Fetch transcript
         controller.enqueue(encoder.encode(createEvent("transcript", "Extracting transcript...")));
         console.log(`[BRIEF] Starting transcript fetch for videoId: ${videoId}`);
-        const transcript = await fetchTranscript(videoId);
+        const { entries: transcript, source: transcriptSource, lang: transcriptLang } = await fetchTranscript(videoId);
         console.log(`[BRIEF] Transcript fetched successfully: ${transcript.length} entries`);
 
         // Step 5: Generate brief
         controller.enqueue(encoder.encode(createEvent("analyzing", "Analyzing content...")));
         console.log(`[BRIEF] Starting brief generation`);
-        const brief = await generateBrief(transcript, metadata, openrouterApiKey, chapters);
+        const { brief, metrics } = await generateBrief(transcript, metadata, openrouterApiKey, chapters);
         console.log(`[BRIEF] Brief generated successfully`);
+
+        const storedTranscript: StoredTranscript = {
+          entries: transcript.map((e) => ({
+            text: e.text,
+            offsetSec: e.offset,
+            durationSec: e.duration,
+            ...(e.lang ? { lang: e.lang } : {}),
+          })),
+          source: transcriptSource,
+          ...(transcriptLang ? { lang: transcriptLang } : {}),
+        };
 
         // Step 6: Save or update brief
         controller.enqueue(encoder.encode(createEvent("saving", "Saving brief...")));
@@ -164,11 +175,11 @@ export async function POST(request: NextRequest) {
         let savedBrief: DbBrief;
         if (userBrief) {
           // Update stale brief
-          savedBrief = await updateBrief(userId, userBrief.id, metadata, brief, hasCreatorChapters);
+          savedBrief = await updateBrief(userId, userBrief.id, metadata, brief, hasCreatorChapters, storedTranscript, metrics);
           console.log(`[BRIEF] Updated existing brief`);
         } else {
           // Save new brief
-          savedBrief = await saveBrief(userId, metadata, brief, hasCreatorChapters);
+          savedBrief = await saveBrief(userId, metadata, brief, hasCreatorChapters, storedTranscript, metrics);
           console.log(`[BRIEF] Saved new brief`);
         }
 

--- a/apps/web/src/app/api/briefs/route.ts
+++ b/apps/web/src/app/api/briefs/route.ts
@@ -16,6 +16,7 @@ import {
   updateBriefStatus,
   completePendingBrief,
 } from "@/lib/db";
+import type { StoredTranscript } from "@/lib/types";
 
 export const maxDuration = 120;
 
@@ -105,11 +106,22 @@ export async function POST(request: NextRequest) {
 
       const metadata = await fetchVideoMetadata(videoId, youtubeApiKey);
       const chapters = extractChapters(metadata.description, metadata.duration);
-      const transcript = await fetchTranscript(videoId);
-      const brief = await generateBrief(transcript, metadata, openrouterApiKey, chapters);
+      const { entries: transcript, source: transcriptSource, lang: transcriptLang } = await fetchTranscript(videoId);
+      const { brief, metrics } = await generateBrief(transcript, metadata, openrouterApiKey, chapters);
       const hasCreatorChapters = chapters !== null && chapters.length > 0;
 
-      await completePendingBrief(userId, jobId, metadata, brief, hasCreatorChapters);
+      const storedTranscript: StoredTranscript = {
+        entries: transcript.map((e) => ({
+          text: e.text,
+          offsetSec: e.offset,
+          durationSec: e.duration,
+          ...(e.lang ? { lang: e.lang } : {}),
+        })),
+        source: transcriptSource,
+        ...(transcriptLang ? { lang: transcriptLang } : {}),
+      };
+
+      await completePendingBrief(userId, jobId, metadata, brief, hasCreatorChapters, storedTranscript, metrics);
       console.log(`[BRIEFS] Async brief completed: ${jobId}`);
     } catch (error) {
       console.error(`[BRIEFS] Async brief failed: ${jobId}`, error);

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -301,6 +301,25 @@ export async function getBriefById(
 }
 
 /**
+ * Lightweight ownership check — returns true if the given brief id belongs to
+ * the user. Used by routes that only need to authorize an action (e.g.
+ * regenerate); skipping the heavy `transcript` and `metrics` JSONB columns
+ * matters at scale because brief rows can grow to 100KB+ once transcripts
+ * are populated.
+ */
+export async function briefExistsForUser(
+  id: string,
+  userId: string
+): Promise<boolean> {
+  const result = await sql<{ exists: boolean }>`
+    SELECT EXISTS(
+      SELECT 1 FROM digests WHERE id = ${id} AND user_id = ${userId}
+    ) as exists
+  `;
+  return result.rows[0]?.exists ?? false;
+}
+
+/**
  * Get a brief by video ID for a specific user
  */
 export async function getBriefByVideoId(
@@ -454,7 +473,7 @@ export async function copyBriefForUser(
       ${sourceBrief.hasCreatorChapters},
       ${searchText},
       ${sourceBrief.transcript ? JSON.stringify(sourceBrief.transcript) : null},
-      ${sourceBrief.metrics ? JSON.stringify(sourceBrief.metrics) : null},
+      ${null},
       ${sourceBrief.framesStatus}
     )
     RETURNING

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -1,11 +1,13 @@
 import { sql } from "@vercel/postgres";
 import type {
-  DbBrief,
+  BriefMetrics,
   BriefSummary,
-  VideoMetadata,
-  StructuredBrief,
+  DbBrief,
   Link,
+  StoredTranscript,
+  StructuredBrief,
   Tag,
+  VideoMetadata,
 } from "./types";
 
 /**
@@ -74,7 +76,9 @@ export async function saveBrief(
   userId: string,
   metadata: VideoMetadata,
   brief: StructuredBrief,
-  hasCreatorChapters: boolean
+  hasCreatorChapters: boolean,
+  transcript: StoredTranscript | null,
+  metrics: BriefMetrics | null
 ): Promise<DbBrief> {
   const startTime = Date.now();
   console.log(`[DB] saveBrief called, userId: ${userId}, videoId: ${metadata.videoId}`);
@@ -99,7 +103,9 @@ export async function saveBrief(
       related_links,
       other_links,
       has_creator_chapters,
-      search_text
+      search_text,
+      transcript,
+      metrics
     ) VALUES (
       ${userId},
       ${metadata.videoId},
@@ -114,7 +120,9 @@ export async function saveBrief(
       ${JSON.stringify(brief.relatedLinks)},
       ${JSON.stringify(brief.otherLinks)},
       ${hasCreatorChapters},
-      ${searchText}
+      ${searchText},
+      ${transcript ? JSON.stringify(transcript) : null},
+      ${metrics ? JSON.stringify(metrics) : null}
     )
     RETURNING
       id,
@@ -135,6 +143,9 @@ export async function saveBrief(
       has_creator_chapters as "hasCreatorChapters",
       status,
       error_message as "errorMessage",
+      transcript,
+      metrics,
+      frames_status as "framesStatus",
       created_at as "createdAt",
       updated_at as "updatedAt"
     `;
@@ -155,7 +166,9 @@ export async function updateBrief(
   briefId: string,
   metadata: VideoMetadata,
   brief: StructuredBrief,
-  hasCreatorChapters: boolean
+  hasCreatorChapters: boolean,
+  transcript: StoredTranscript | null,
+  metrics: BriefMetrics | null
 ): Promise<DbBrief> {
   const channelSlug = createSlug(metadata.channelTitle);
   const thumbnailUrl = getThumbnailUrl(metadata.videoId);
@@ -175,6 +188,8 @@ export async function updateBrief(
       other_links = ${JSON.stringify(brief.otherLinks)},
       has_creator_chapters = ${hasCreatorChapters},
       search_text = ${searchText},
+      transcript = ${transcript ? JSON.stringify(transcript) : null},
+      metrics = ${metrics ? JSON.stringify(metrics) : null},
       updated_at = NOW()
     WHERE id = ${briefId} AND user_id = ${userId}
     RETURNING
@@ -196,6 +211,9 @@ export async function updateBrief(
       has_creator_chapters as "hasCreatorChapters",
       status,
       error_message as "errorMessage",
+      transcript,
+      metrics,
+      frames_status as "framesStatus",
       created_at as "createdAt",
       updated_at as "updatedAt"
   `;
@@ -233,6 +251,9 @@ export async function getBriefById(
         has_creator_chapters as "hasCreatorChapters",
         status,
         error_message as "errorMessage",
+        transcript,
+        metrics,
+        frames_status as "framesStatus",
         created_at as "createdAt",
         updated_at as "updatedAt"
       FROM digests
@@ -260,6 +281,9 @@ export async function getBriefById(
         has_creator_chapters as "hasCreatorChapters",
         status,
         error_message as "errorMessage",
+        transcript,
+        metrics,
+        frames_status as "framesStatus",
         created_at as "createdAt",
         updated_at as "updatedAt"
       FROM digests
@@ -307,6 +331,9 @@ export async function getBriefByVideoId(
         has_creator_chapters as "hasCreatorChapters",
         status,
         error_message as "errorMessage",
+        transcript,
+        metrics,
+        frames_status as "framesStatus",
         created_at as "createdAt",
         updated_at as "updatedAt"
       FROM digests
@@ -354,6 +381,9 @@ export async function findGlobalBriefByVideoId(
         has_creator_chapters as "hasCreatorChapters",
         status,
         error_message as "errorMessage",
+        transcript,
+        metrics,
+        frames_status as "framesStatus",
         created_at as "createdAt",
         updated_at as "updatedAt"
       FROM digests
@@ -404,7 +434,10 @@ export async function copyBriefForUser(
       related_links,
       other_links,
       has_creator_chapters,
-      search_text
+      search_text,
+      transcript,
+      metrics,
+      frames_status
     ) VALUES (
       ${userId},
       ${sourceBrief.videoId},
@@ -419,7 +452,10 @@ export async function copyBriefForUser(
       ${JSON.stringify(sourceBrief.relatedLinks)},
       ${JSON.stringify(sourceBrief.otherLinks)},
       ${sourceBrief.hasCreatorChapters},
-      ${searchText}
+      ${searchText},
+      ${sourceBrief.transcript ? JSON.stringify(sourceBrief.transcript) : null},
+      ${sourceBrief.metrics ? JSON.stringify(sourceBrief.metrics) : null},
+      ${sourceBrief.framesStatus}
     )
     RETURNING
       id,
@@ -440,6 +476,9 @@ export async function copyBriefForUser(
       has_creator_chapters as "hasCreatorChapters",
       status,
       error_message as "errorMessage",
+      transcript,
+      metrics,
+      frames_status as "framesStatus",
       created_at as "createdAt",
       updated_at as "updatedAt"
     `;
@@ -627,6 +666,9 @@ export async function getSharedBriefBySlug(
       has_creator_chapters as "hasCreatorChapters",
       status,
       error_message as "errorMessage",
+      transcript,
+      metrics,
+      frames_status as "framesStatus",
       created_at as "createdAt",
       updated_at as "updatedAt"
     FROM digests
@@ -776,7 +818,9 @@ export async function completePendingBrief(
   briefId: string,
   metadata: VideoMetadata,
   brief: StructuredBrief,
-  hasCreatorChapters: boolean
+  hasCreatorChapters: boolean,
+  transcript: StoredTranscript | null,
+  metrics: BriefMetrics | null
 ): Promise<void> {
   const channelSlug = createSlug(metadata.channelTitle);
   const thumbnailUrl = getThumbnailUrl(metadata.videoId);
@@ -796,6 +840,8 @@ export async function completePendingBrief(
       other_links = ${JSON.stringify(brief.otherLinks)},
       has_creator_chapters = ${hasCreatorChapters},
       search_text = ${searchText},
+      transcript = ${transcript ? JSON.stringify(transcript) : null},
+      metrics = ${metrics ? JSON.stringify(metrics) : null},
       status = 'completed',
       error_message = NULL,
       updated_at = NOW()

--- a/apps/web/src/lib/summarize.ts
+++ b/apps/web/src/lib/summarize.ts
@@ -1,19 +1,19 @@
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { generateText, Output } from "ai";
 import { z } from "zod";
-import { DIGEST_MODEL } from "@brief/core";
-import type { TranscriptEntry, VideoMetadata, StructuredBrief, ContentSection, Chapter, KeyPoint } from "./types";
+import { DIGEST_MODEL, formatTranscript } from "@brief/core";
+import type { TranscriptResult } from "@brief/core";
+import type {
+  BriefMetrics,
+  Chapter,
+  ContentSection,
+  KeyPoint,
+  StructuredBrief,
+  TranscriptEntry,
+  VideoMetadata,
+} from "./types";
 import { combineUrls } from "./url-extractor";
 import { systemPrompt, buildUserPrompt, buildChapterUserPrompt } from "./prompts";
-
-/**
- * Formats a timestamp in seconds to MM:SS format
- */
-function formatTimestamp(seconds: number): string {
-  const minutes = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60);
-  return `${minutes}:${secs.toString().padStart(2, "0")}`;
-}
 
 /**
  * Parses a timestamp string (MM:SS or H:MM:SS) to seconds
@@ -177,14 +177,23 @@ export async function generateBrief(
   metadata: VideoMetadata,
   apiKey: string,
   chapters?: Chapter[] | null
-): Promise<StructuredBrief> {
-  // Format transcript with timestamps
-  const formattedTranscript = transcript
-    .map((entry) => {
-      const timestamp = formatTimestamp(entry.offset);
-      return `[${timestamp}] ${entry.text}`;
-    })
-    .join("\n");
+): Promise<{ brief: StructuredBrief; metrics: BriefMetrics }> {
+  // Format transcript with `[M:SS] line` anchors via @brief/core's canonical
+  // formatter. We wrap the in-memory web-shape entries in a TranscriptResult
+  // stub because formatTranscript operates on results, not bare entries — the
+  // source field is meaningless here (we already have the entries) but the
+  // type requires it.
+  const stubResult: TranscriptResult = {
+    kind: "ok",
+    source: "youtube-transcript-plus",
+    entries: transcript.map((e) => ({
+      offsetSec: e.offset,
+      durationSec: e.duration,
+      text: e.text,
+      ...(e.lang ? { lang: e.lang } : {}),
+    })),
+  };
+  const formattedTranscript = formatTranscript(stubResult, "timestamped");
 
   // Extract all URLs from description and pinned comment
   const allUrls = combineUrls(metadata.description, metadata.pinnedComment);
@@ -214,12 +223,14 @@ export async function generateBrief(
     const openrouter = createOpenRouter({ apiKey });
     const model = openrouter(DIGEST_MODEL);
 
+    const startedAt = Date.now();
     const result = await generateText({
       model,
       output: Output.object({ schema: briefSchema }),
       system: systemPrompt,
       prompt: userPrompt,
     });
+    const latencyMs = Date.now() - startedAt;
 
     const brief = result.output as StructuredBrief;
 
@@ -236,10 +247,19 @@ export async function generateBrief(
     const processedSections = mergeTangentOnlyChapters(dedupedSections, !!hasChapters);
 
     // Sort sections and key points chronologically
-    return sortBriefChronologically({
+    const finalBrief = sortBriefChronologically({
       ...brief,
       sections: processedSections,
     });
+
+    const metrics: BriefMetrics = {
+      inputTokens: result.usage.inputTokens ?? 0,
+      outputTokens: result.usage.outputTokens ?? 0,
+      model: DIGEST_MODEL,
+      latencyMs,
+    };
+
+    return { brief: finalBrief, metrics };
   } catch (error: any) {
     if (error.message?.includes("401") || error.message?.includes("authentication")) {
       throw new Error(

--- a/apps/web/src/lib/summarize.ts
+++ b/apps/web/src/lib/summarize.ts
@@ -186,6 +186,7 @@ export async function generateBrief(
   const stubResult: TranscriptResult = {
     kind: "ok",
     source: "youtube-transcript-plus",
+    ...(transcript[0]?.lang ? { lang: transcript[0].lang } : {}),
     entries: transcript.map((e) => ({
       offsetSec: e.offset,
       durationSec: e.duration,

--- a/apps/web/src/lib/transcript.ts
+++ b/apps/web/src/lib/transcript.ts
@@ -1,5 +1,17 @@
 import { fetchTranscript as fetchTranscriptCore } from "@brief/core";
-import type { TranscriptEntry } from "./types";
+import type { SourceName, TranscriptEntry } from "./types";
+
+/**
+ * Result of fetching a video's transcript. Carries the speech entries (web
+ * shape: offset/duration in seconds), the source that produced them, and the
+ * detected language when known. Persistence layers can reshape entries to
+ * `@brief/core`'s canonical `offsetSec/durationSec` form for storage.
+ */
+export interface FetchedTranscript {
+  entries: TranscriptEntry[];
+  source: SourceName;
+  lang?: string;
+}
 
 /**
  * Fetches the transcript for a YouTube video via `@brief/core`'s cascade.
@@ -10,14 +22,14 @@ import type { TranscriptEntry } from "./types";
  * The core layer provides retry policy + structured outcomes for free.
  *
  * @param videoId - YouTube video ID
- * @returns Array of transcript entries with timestamps in seconds
+ * @returns Entries, source, and detected language
  * @throws Error with a user-facing message; the brief API routes surface
  *         these via `body.error` and the Chrome extension reads them directly,
  *         so the wording is part of the contract.
  */
 export async function fetchTranscript(
   videoId: string,
-): Promise<TranscriptEntry[]> {
+): Promise<FetchedTranscript> {
   const startTime = Date.now();
   const supadataApiKey = process.env.SUPADATA_API_KEY;
   const useSupadata = !!supadataApiKey;
@@ -41,7 +53,11 @@ export async function fetchTranscript(
     console.log(
       `[TRANSCRIPT] Success in ${Date.now() - startTime}ms, entries: ${entries.length}`,
     );
-    return entries;
+    return {
+      entries,
+      source: result.source,
+      ...(result.lang ? { lang: result.lang } : {}),
+    };
   }
 
   console.error(

--- a/apps/web/src/lib/transcript.ts
+++ b/apps/web/src/lib/transcript.ts
@@ -1,152 +1,87 @@
-import { Supadata, type Transcript } from "@supadata/js";
-import { fetchTranscript as fetchYouTubeTranscript } from "youtube-transcript-plus";
+import { fetchTranscript as fetchTranscriptCore } from "@brief/core";
 import type { TranscriptEntry } from "./types";
 
 /**
- * Convert Supadata transcript to our TranscriptEntry format
- */
-function convertSupadataTranscript(transcript: Transcript): TranscriptEntry[] {
-  if (typeof transcript.content === "string") {
-    throw new Error("Transcript returned without timestamps - cannot process");
-  }
-  if (!transcript.content) {
-    throw new Error("No transcript content available");
-  }
-  // Supadata returns offset/duration in milliseconds, we need seconds
-  return transcript.content.map((entry) => ({
-    text: entry.text,
-    offset: entry.offset / 1000,
-    duration: entry.duration / 1000,
-    lang: transcript.lang,
-  }));
-}
-
-/**
- * Fetches transcript using Supadata API (for cloud deployments)
- * Uses mode: 'auto' which falls back to AI generation if native transcript unavailable
- */
-async function fetchWithSupadata(videoId: string): Promise<TranscriptEntry[]> {
-  const supadata = new Supadata({
-    apiKey: process.env.SUPADATA_API_KEY!,
-  });
-
-  // Use the newer transcript() API with mode: 'auto' which may have better success
-  // than the deprecated youtube.transcript() method
-  const result = await supadata.transcript({
-    url: `https://www.youtube.com/watch?v=${videoId}`,
-    mode: "auto",
-  });
-
-  // Handle error returned as data (Supadata SDK quirk - doesn't always throw)
-  if ("error" in result) {
-    const { details, message } = result as { details?: string; message?: string };
-    throw new Error(details || message || "Unknown Supadata error");
-  }
-
-  // Handle async job case - transcript is being generated
-  if ("jobId" in result) {
-    console.log(
-      `[TRANSCRIPT] Transcript generation queued, jobId: ${result.jobId}`
-    );
-    throw new Error(
-      "TRANSCRIPT_GENERATING: This video's transcript is being generated. Please try again in 1-2 minutes."
-    );
-  }
-
-  return convertSupadataTranscript(result);
-}
-
-/**
- * Fetches transcript using youtube-transcript-plus (for local development)
- * This library works without an API key but is blocked by YouTube on cloud platforms
- */
-async function fetchWithYoutubeTranscriptPlus(
-  videoId: string
-): Promise<TranscriptEntry[]> {
-  const rawTranscript = await fetchYouTubeTranscript(videoId);
-
-  // youtube-transcript-plus returns timestamps already in seconds
-  return rawTranscript.map((entry) => ({
-    text: entry.text,
-    offset: entry.offset,
-    duration: entry.duration,
-    lang: entry.lang,
-  }));
-}
-
-/**
- * Fetches the transcript for a YouTube video
+ * Fetches the transcript for a YouTube video via `@brief/core`'s cascade.
  *
- * Uses Supadata API when SUPADATA_API_KEY is set (required for cloud deployments),
- * otherwise falls back to youtube-transcript-plus (works locally without API key)
+ * Source selection preserves the original env-driven exclusivity: when
+ * `SUPADATA_API_KEY` is set, only Supadata is used (cloud deployments);
+ * otherwise only `youtube-transcript-plus` is used (local development).
+ * The core layer provides retry policy + structured outcomes for free.
  *
  * @param videoId - YouTube video ID
- * @returns Array of transcript entries with timestamps
- * @throws Error if captions are disabled or unavailable
+ * @returns Array of transcript entries with timestamps in seconds
+ * @throws Error with a user-facing message; the brief API routes surface
+ *         these via `body.error` and the Chrome extension reads them directly,
+ *         so the wording is part of the contract.
  */
 export async function fetchTranscript(
-  videoId: string
+  videoId: string,
 ): Promise<TranscriptEntry[]> {
   const startTime = Date.now();
-  const useSupadata = !!process.env.SUPADATA_API_KEY;
+  const supadataApiKey = process.env.SUPADATA_API_KEY;
+  const useSupadata = !!supadataApiKey;
 
   console.log(
-    `[TRANSCRIPT] Starting fetch for videoId: ${videoId} using ${useSupadata ? "Supadata API" : "youtube-transcript-plus (local mode)"}`
+    `[TRANSCRIPT] Starting fetch for videoId: ${videoId} using ${useSupadata ? "Supadata API" : "youtube-transcript-plus (local mode)"}`,
   );
 
-  try {
-    const entries = useSupadata
-      ? await fetchWithSupadata(videoId)
-      : await fetchWithYoutubeTranscriptPlus(videoId);
+  const result = await fetchTranscriptCore(videoId, {
+    supadataApiKey,
+    sources: useSupadata ? ["supadata"] : ["youtube-transcript-plus"],
+  });
 
+  if (result.kind === "ok") {
+    const entries: TranscriptEntry[] = result.entries.map((e) => ({
+      text: e.text,
+      offset: e.offsetSec,
+      duration: e.durationSec,
+      lang: e.lang,
+    }));
     console.log(
-      `[TRANSCRIPT] Success in ${Date.now() - startTime}ms, entries: ${entries.length}`
+      `[TRANSCRIPT] Success in ${Date.now() - startTime}ms, entries: ${entries.length}`,
     );
-
     return entries;
-  } catch (error: unknown) {
-    console.error(
-      `[TRANSCRIPT] Failed in ${Date.now() - startTime}ms:`,
-      error
+  }
+
+  console.error(
+    `[TRANSCRIPT] Failed in ${Date.now() - startTime}ms: ${result.kind} — ${result.message}`,
+  );
+
+  if (result.kind === "pending") {
+    throw new Error(
+      "This video's transcript is being generated. Please try again in 1-2 minutes.",
     );
+  }
 
-    const errorMsg =
-      error instanceof Error ? error.message?.toLowerCase() : "";
-
-    // Pass through transcript generation message as-is
-    if (errorMsg.includes("transcript_generating")) {
+  if (result.kind === "unavailable") {
+    if (result.reason === "no-captions") {
       throw new Error(
-        "This video's transcript is being generated. Please try again in 1-2 minutes."
+        "No captions/transcript available for this video. Try a video with auto-generated or manual captions.",
       );
     }
-
-    if (errorMsg.includes("disabled") || errorMsg.includes("not available")) {
-      throw new Error(
-        "No captions/transcript available for this video. Try a video with auto-generated or manual captions."
-      );
-    }
-
-    if (errorMsg.includes("unavailable")) {
+    if (result.reason === "video-removed" || result.reason === "video-private") {
       throw new Error("Video is unavailable or has been removed");
     }
-
-    if (errorMsg.includes("invalid")) {
+    if (result.reason === "invalid-id") {
       throw new Error("Invalid video ID");
     }
-
-    // Supadata credit/billing errors
-    if (
-      errorMsg.includes("credit") ||
-      errorMsg.includes("billing") ||
-      errorMsg.includes("subscription") ||
-      errorMsg.includes("limit exceeded")
-    ) {
-      throw new Error(
-        "Supadata API credits exhausted. Please add credits in your Supadata dashboard."
-      );
-    }
-
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Failed to fetch transcript: ${message}`);
   }
+
+  // Transient (or any other failure). Supadata's credit/billing/quota errors
+  // surface as transient messages; preserve the dedicated user-facing string
+  // for those so operators know what to fix.
+  const msg = result.message.toLowerCase();
+  if (
+    msg.includes("credit") ||
+    msg.includes("billing") ||
+    msg.includes("subscription") ||
+    msg.includes("limit exceeded")
+  ) {
+    throw new Error(
+      "Supadata API credits exhausted. Please add credits in your Supadata dashboard.",
+    );
+  }
+
+  throw new Error(`Failed to fetch transcript: ${result.message}`);
 }

--- a/apps/web/src/lib/transcript.ts
+++ b/apps/web/src/lib/transcript.ts
@@ -91,6 +91,7 @@ export async function fetchTranscript(
   if (
     msg.includes("credit") ||
     msg.includes("billing") ||
+    msg.includes("quota") ||
     msg.includes("subscription") ||
     msg.includes("limit exceeded")
   ) {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -57,6 +57,52 @@ export interface BriefResult {
   outputPath?: string;
 }
 
+/**
+ * Status of the optional video-frames augmentation for a brief.
+ *
+ * - `not-requested` — frames weren't requested for this generation (default).
+ * - `included`      — frames were requested and successfully woven in.
+ * - `attempted-failed` — frames were requested but the pipeline failed; the
+ *                       brief still generated from the transcript alone.
+ *
+ * Only `not-requested` is written by today's code path. The frames feature
+ * (#87) populates the other values when it lands.
+ */
+export type FramesStatus = "not-requested" | "included" | "attempted-failed";
+
+/**
+ * Per-generation telemetry persisted alongside each brief. Token counts and
+ * model are the durable factual data; cost is derived at read time via
+ * `estimateCost(model, in, out)` from `@brief/core` so the row stays currency-
+ * and pricing-snapshot agnostic.
+ */
+export interface BriefMetrics {
+  inputTokens: number;
+  outputTokens: number;
+  model: string;     // e.g. "openai/gpt-5.5" (OpenRouter form)
+  latencyMs: number;
+}
+
+/**
+ * Canonical stored shape for a brief's transcript. Uses `@brief/core`'s entry
+ * field names (`offsetSec` / `durationSec`) so downstream LLM consumers can
+ * read the JSONB and pass it straight into `formatTranscript()` from core.
+ */
+export interface StoredTranscriptEntry {
+  text: string;
+  offsetSec: number;
+  durationSec: number;
+  lang?: string;
+}
+
+export type SourceName = "youtube-transcript-plus" | "supadata";
+
+export interface StoredTranscript {
+  entries: StoredTranscriptEntry[];
+  source: SourceName;
+  lang?: string;
+}
+
 // Tag types
 export interface Tag {
   id: string;
@@ -84,6 +130,9 @@ export interface DbBrief {
   hasCreatorChapters: boolean | null;
   status: string;
   errorMessage: string | null;
+  transcript: StoredTranscript | null;
+  metrics: BriefMetrics | null;
+  framesStatus: FramesStatus;
   createdAt: Date;
   updatedAt: Date;
   tags?: Tag[];

--- a/packages/core/src/format.test.ts
+++ b/packages/core/src/format.test.ts
@@ -33,9 +33,9 @@ const transientResult: TranscriptResult = {
   message: "Network error talking to upstream",
 };
 
-describe("formatTranscript text format", () => {
+describe("formatTranscript prose format", () => {
   it("renders ok as a single space-separated blob of text", () => {
-    expect(formatTranscript(okResult, "text")).toBe("hello world later");
+    expect(formatTranscript(okResult, "prose")).toBe("hello world later");
   });
 
   it("normalizes internal soft-wrap newlines within entry text to spaces", () => {
@@ -51,7 +51,7 @@ describe("formatTranscript text format", () => {
         { offsetSec: 2, durationSec: 1, text: "single line" },
       ],
     };
-    expect(formatTranscript(result, "text")).toBe(
+    expect(formatTranscript(result, "prose")).toBe(
       "you know the rules and so do I single line"
     );
   });
@@ -65,7 +65,7 @@ describe("formatTranscript text format", () => {
         { offsetSec: 2, durationSec: 2, text: "second thought" },
       ],
     };
-    expect(formatTranscript(result, "text")).toBe(
+    expect(formatTranscript(result, "prose")).toBe(
       "first thought. second thought"
     );
   });
@@ -79,26 +79,74 @@ describe("formatTranscript text format", () => {
         { offsetSec: 30, durationSec: 2, text: "new topic begins" },
       ],
     };
-    expect(formatTranscript(result, "text")).toBe(
+    expect(formatTranscript(result, "prose")).toBe(
       "topic A wraps up new topic begins"
     );
   });
 
   it("renders pending as a single informative line", () => {
-    expect(formatTranscript(pendingResult, "text")).toBe(
+    expect(formatTranscript(pendingResult, "prose")).toBe(
       "Transcript generation queued (jobId: job-123, retryAfter: 90s)"
     );
   });
 
   it("renders unavailable as a single line with the reason", () => {
-    expect(formatTranscript(unavailableResult, "text")).toBe(
+    expect(formatTranscript(unavailableResult, "prose")).toBe(
       "Unavailable (no-captions): No captions available"
     );
   });
 
   it("renders transient as a single line with the cause", () => {
-    expect(formatTranscript(transientResult, "text")).toBe(
+    expect(formatTranscript(transientResult, "prose")).toBe(
       "Transient failure (ECONNRESET): Network error talking to upstream"
+    );
+  });
+});
+
+describe("formatTranscript timestamped format", () => {
+  it("renders ok as M:SS-prefixed lines, one per entry", () => {
+    expect(formatTranscript(okResult, "timestamped")).toBe(
+      "[0:00] hello\n[0:02] world\n[0:04] later"
+    );
+  });
+
+  it("zero-pads seconds but not minutes", () => {
+    const result: TranscriptResult = {
+      kind: "ok",
+      source: "youtube-transcript-plus",
+      entries: [
+        { offsetSec: 9, durationSec: 1, text: "nine seconds in" },
+        { offsetSec: 65, durationSec: 1, text: "past a minute" },
+        { offsetSec: 3725, durationSec: 1, text: "past an hour" },
+      ],
+    };
+    expect(formatTranscript(result, "timestamped")).toBe(
+      "[0:09] nine seconds in\n[1:05] past a minute\n[62:05] past an hour"
+    );
+  });
+
+  it("preserves entry text verbatim including internal newlines", () => {
+    const result: TranscriptResult = {
+      kind: "ok",
+      source: "youtube-transcript-plus",
+      entries: [
+        { offsetSec: 0, durationSec: 2, text: "first line\nsecond line" },
+      ],
+    };
+    expect(formatTranscript(result, "timestamped")).toBe(
+      "[0:00] first line\nsecond line"
+    );
+  });
+
+  it("falls back to prose rendering for non-ok results", () => {
+    expect(formatTranscript(pendingResult, "timestamped")).toBe(
+      formatTranscript(pendingResult, "prose")
+    );
+    expect(formatTranscript(unavailableResult, "timestamped")).toBe(
+      formatTranscript(unavailableResult, "prose")
+    );
+    expect(formatTranscript(transientResult, "timestamped")).toBe(
+      formatTranscript(transientResult, "prose")
     );
   });
 });

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -2,16 +2,36 @@ import type { TranscriptEntry, TranscriptResult } from "./types";
 
 export const SCHEMA_VERSION = "1.0.0";
 
-export type TranscriptFormat = "text" | "json";
+/**
+ * Output shapes for `formatTranscript`. Three consumers in mind:
+ *
+ * - `json` — programmatic. Structured envelope, schemaVersion, entries array.
+ * - `timestamped` — LLM-friendly. `[M:SS] text` lines preserving offsets as
+ *   anchors. Used by the digest prompt and any downstream LLM consumer.
+ * - `prose` — human-readable. Continuous joined text, no timestamp anchors.
+ *   Intended for CLI/document consumption.
+ *
+ * When visual frames are interleaved into the entries (the planned video-frames
+ * feature), `timestamped` and `prose` both render them inline at their offsets;
+ * `json` exposes them as additional entries. The public API stays the same.
+ */
+export type TranscriptFormat = "json" | "timestamped" | "prose";
 
 export function formatTranscript(
   result: TranscriptResult,
-  format: TranscriptFormat
+  format: TranscriptFormat,
 ): string {
-  return format === "text" ? renderText(result) : renderJson(result);
+  switch (format) {
+    case "json":
+      return renderJson(result);
+    case "timestamped":
+      return renderTimestamped(result);
+    case "prose":
+      return renderProse(result);
+  }
 }
 
-function renderText(result: TranscriptResult): string {
+function renderProse(result: TranscriptResult): string {
   switch (result.kind) {
     case "ok":
       return joinEntryText(result.entries);
@@ -21,6 +41,19 @@ function renderText(result: TranscriptResult): string {
       return `Unavailable (${result.reason}): ${result.message}`;
     case "transient":
       return `Transient failure (${result.cause}): ${result.message}`;
+  }
+}
+
+function renderTimestamped(result: TranscriptResult): string {
+  switch (result.kind) {
+    case "ok":
+      return result.entries
+        .map((e) => `[${formatOffset(e.offsetSec)}] ${e.text}`)
+        .join("\n");
+    case "pending":
+    case "unavailable":
+    case "transient":
+      return renderProse(result);
   }
 }
 
@@ -70,4 +103,16 @@ function joinEntryText(entries: TranscriptEntry[]): string {
     .map((e) => e.text.replace(/\s*\n\s*/g, " ").trim())
     .filter((t) => t.length > 0)
     .join(" ");
+}
+
+/**
+ * Format a seconds offset as `M:SS`. Used as the timestamp anchor in
+ * `timestamped` mode. Matches the convention the digest prompt was tuned on;
+ * minutes are not zero-padded so a 2-hour video reads `120:30` rather than
+ * `02:00:30`.
+ */
+function formatOffset(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${minutes}:${secs.toString().padStart(2, "0")}`;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,9 +112,6 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.1.6
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@supadata/js':
-        specifier: ^1.3.2
-        version: 1.3.2
       '@vercel/postgres':
         specifier: ^0.10.0
         version: 0.10.0
@@ -166,9 +163,6 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
-      youtube-transcript-plus:
-        specifier: ^1.1.2
-        version: 1.1.2
       zod:
         specifier: ^4.3.5
         version: 4.3.5
@@ -247,30 +241,6 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
-  spikes/brief-ab-test:
-    dependencies:
-      '@ai-sdk/anthropic':
-        specifier: ^3.0.15
-        version: 3.0.15(zod@4.3.6)
-      ai:
-        specifier: ^6.0.39
-        version: 6.0.39(zod@4.3.6)
-      zod:
-        specifier: ^4.3.6
-        version: 4.3.6
-
-  spikes/video-frames-pipeline:
-    dependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.95.1
-        version: 0.95.1(zod@4.3.6)
-
-  spikes/video-frames/api_test:
-    dependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.95.1
-        version: 0.95.1(zod@4.3.6)
-
 packages:
 
   '@1natsu/wait-element@4.1.2':
@@ -311,15 +281,6 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
-
-  '@anthropic-ai/sdk@0.95.1':
-    resolution: {integrity: sha512-OO9AF7hmAoU492c/mD7Q2cPqI2WNAj7rAPHlawgBeUgpwiboLRiDs+grsErGWeHHP9ZRWfzq2OVrODTt8aITVg==}
-    hasBin: true
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@babel/code-frame@7.28.6':
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
@@ -1681,9 +1642,6 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
-  '@stablelib/base64@1.0.1':
-    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
-
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -2922,9 +2880,6 @@ packages:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
 
-  fast-sha256@1.3.0:
-    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
-
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -3489,10 +3444,6 @@ packages:
   json-parse-even-better-errors@3.0.2:
     resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  json-schema-to-ts@3.1.1:
-    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
-    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -4446,9 +4397,6 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  standardwebhooks@1.0.0:
-    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
-
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
@@ -4624,9 +4572,6 @@ packages:
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
-
-  ts-algebra@2.0.0:
-    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -5073,12 +5018,6 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.8(zod@4.3.5)
       zod: 4.3.5
 
-  '@ai-sdk/anthropic@3.0.15(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.4
-      '@ai-sdk/provider-utils': 4.0.8(zod@4.3.6)
-      zod: 4.3.6
-
   '@ai-sdk/gateway@3.0.16(zod@4.3.5)':
     dependencies:
       '@ai-sdk/provider': 3.0.4
@@ -5086,26 +5025,12 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 4.3.5
 
-  '@ai-sdk/gateway@3.0.16(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.4
-      '@ai-sdk/provider-utils': 4.0.8(zod@4.3.6)
-      '@vercel/oidc': 3.1.0
-      zod: 4.3.6
-
   '@ai-sdk/provider-utils@4.0.8(zod@4.3.5)':
     dependencies:
       '@ai-sdk/provider': 3.0.4
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.3.5
-
-  '@ai-sdk/provider-utils@4.0.8(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.4
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
-      zod: 4.3.6
 
   '@ai-sdk/provider@3.0.4':
     dependencies:
@@ -5121,13 +5046,6 @@ snapshots:
       rollup: 4.57.1
 
   '@alloc/quick-lru@5.2.0': {}
-
-  '@anthropic-ai/sdk@0.95.1(zod@4.3.6)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-      standardwebhooks: 1.0.0
-    optionalDependencies:
-      zod: 4.3.6
 
   '@babel/code-frame@7.28.6':
     dependencies:
@@ -6304,8 +6222,6 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@stablelib/base64@1.0.1': {}
-
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -6813,14 +6729,6 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.8(zod@4.3.5)
       '@opentelemetry/api': 1.9.0
       zod: 4.3.5
-
-  ai@6.0.39(zod@4.3.6):
-    dependencies:
-      '@ai-sdk/gateway': 3.0.16(zod@4.3.6)
-      '@ai-sdk/provider': 3.0.4
-      '@ai-sdk/provider-utils': 4.0.8(zod@4.3.6)
-      '@opentelemetry/api': 1.9.0
-      zod: 4.3.6
 
   ajv@6.12.6:
     dependencies:
@@ -7552,8 +7460,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.3
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -7575,7 +7483,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7586,22 +7494,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7612,7 +7520,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7787,8 +7695,6 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-redact@3.5.0: {}
-
-  fast-sha256@1.3.0: {}
 
   fastq@1.20.1:
     dependencies:
@@ -8335,11 +8241,6 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@3.0.2: {}
-
-  json-schema-to-ts@3.1.1:
-    dependencies:
-      '@babel/runtime': 7.28.2
-      ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
 
@@ -9340,11 +9241,6 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  standardwebhooks@1.0.0:
-    dependencies:
-      '@stablelib/base64': 1.0.1
-      fast-sha256: 1.3.0
-
   std-env@3.10.0: {}
 
   stdin-discarder@0.3.1: {}
@@ -9522,8 +9418,6 @@ snapshots:
   tr46@0.0.3: {}
 
   tree-kill@1.2.2: {}
-
-  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Closes #85, closes #91.

## Summary

Two foundational pieces of the video-frames effort land together, sharing the same transcript flow:

1. **#91 — Transcript fetching migrated to `@brief/core`.** The web app's parallel `apps/web/src/lib/transcript.ts` is now a thin wrapper around `@brief/core`'s cascading `fetchTranscript`. Picks up the structured `(ok | pending | unavailable | transient)` outcomes, retry policy, and (future) cache hook for free. Existing user-facing error strings preserved verbatim for the Chrome extension contract per PR #83.
2. **#85 — Brief schema foundations.** New `transcript` (JSONB), `metrics` (JSONB), and `frames_status` columns on the `digests` table. Transcripts now persist alongside briefs (unblocks #36's "Ask this video"). Per-generation metrics — input/output tokens, model, latency — are recorded so cost can be computed on demand via `estimateCost()` rather than stored (currency-agnostic by design). `frames_status` defaults to `'not-requested'`, ready for #87 to populate the other values.

## What changed

### Schema (`apps/web/migrations/009_*.sql`)
- Three additive `ADD COLUMN IF NOT EXISTS` operations. Existing rows unaffected: `transcript`/`metrics` become NULL, `frames_status` backfills to the default via PG 11+'s metadata-only path.

### `@brief/core/src/format.ts`
- `TranscriptFormat` expanded to `"json" | "timestamped" | "prose"`. Renamed the old `"text"` to `"prose"` for clarity (joined entry text, no timestamps). Added `"timestamped"` mode (`[M:SS] line` anchors — what the digest prompt and any LLM-side consumer wants). The architecture is set up so #87 can later teach all three modes to render visual frames interleaved without changing the public API.

### `apps/web` consumers
- `summarize.ts`: `generateBrief()` returns `{ brief, metrics }`; the inline timestamp formatter is replaced with `formatTranscript(stub, "timestamped")`.
- `transcript.ts` wrapper: returns `{ entries, source, lang? }` so routes can build the canonical `StoredTranscript` for storage.
- `db.ts`: `saveBrief`, `updateBrief`, `copyBriefForUser`, `completePendingBrief` accept and persist the new fields. All 8 SELECT/RETURNING clauses updated.
- Types: `FramesStatus`, `BriefMetrics`, `StoredTranscript`, `StoredTranscriptEntry`, `SourceName`; `DbBrief` extended.
- 3 API routes destructure the new shapes and write the columns.

### Tooling
- `pnpm --filter @brief/web query "..."` — small helper for ad-hoc local DB inspection (local-only, no `--prod` flag).

## Verification

- 118 `@brief/core` tests pass (4 new for the timestamped format; existing tests renamed to "prose"). `tsc --noEmit` clean across all packages.
- Local migration: 30 pre-existing rows backfilled cleanly to `frames_status = 'not-requested'`; transcript/metrics stay NULL.
- End-to-end smoke: 507-entry transcript → brief generated → metrics `{ inputTokens: 8763, outputTokens: 1368, model: openai/gpt-5.5, latencyMs: 19915 }`. `estimateCost` derives $0.0849.
- JSONB roundtrip: write/read confirms the stored shape comes back intact.
- Manual UI exercise: fresh generate, regenerate on a new (post-migration) brief, regenerate on a legacy (pre-migration) brief. All three update paths work; legacy brief page renders correctly with NULL transcript before regeneration fills it in.

## Not exercised locally

`completePendingBrief` (the Chrome extension's async `/api/briefs` path) is structurally identical to `updateBrief` and typecheck-covered, but isn't hit by the normal browser flow. Worth a verify after deploy.

## Notes for the deploy

The migration is additive and runs near-instant on PG 11+ (Vercel/Neon). It needs to run before or alongside the code deploy — if code lands first, brief generation will fail trying to INSERT/UPDATE columns that don't exist yet. Standard `pnpm migrate 009_add_transcript_metrics_frames_status.sql --prod`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Briefs now capture generation metrics including token usage and latency information.
  * Transcripts now store detected language and source attribution details.
  * Added frames status tracking capability for briefs.

* **Bug Fixes**
  * Improved transcript text formatting output.
  * Enhanced transcript fetching error handling and structured data return.

* **Chores**
  * Database schema updated with new transcript, metrics, and frames status columns.
  * Removed unused dependencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niftymonkey/brief/pull/93)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->