### PR TITLE
docs: post-pivot frames + CLI thin-client architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ tsconfig.tsbuildinfo
 
 # Spikes / throwaway PoCs
 spikes/
+
+# Next.js auto-generated typedefs (regenerated per environment)
+apps/web/next-env.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ tsconfig.tsbuildinfo
 
 # Extension build output
 .output/
+
+# Spikes / throwaway PoCs
+spikes/

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docs/architecture/cli-thin-client.md
+++ b/docs/architecture/cli-thin-client.md
@@ -135,6 +135,7 @@ export const FramesMetricsSchema = z.object({
   classifierModel: z.string(),
   visionModel: z.string(),
   wallClockMs: z.number(),
+  costSource: z.literal("cli-reported"),   // v1 only; follow-up issue broadens this to z.enum(["cli-reported", "server-issued"])
 });
 
 export const TranscriptSubmissionSchema = z.object({
@@ -191,7 +192,7 @@ Callers pattern-match on `kind`. The `auth-required` branch triggers a `login` p
 
 ### BriefIntake contract (`apps/web`)
 
-```
+```http
 POST /api/brief/intake
 Authorization: Bearer <access-token>
 Content-Type: application/json
@@ -202,6 +203,7 @@ Body: TranscriptSubmission (Zod-validated)
 {
   "schemaVersion": "2.0.0",
   "briefId": "...",
+  "briefUrl": "https://brief.niftymonkey.dev/brief/...",
   "brief": { "summary": "...", "sections": [...], "relatedLinks": [...], "otherLinks": [...] },
   "metadata": { ... }
 }
@@ -333,7 +335,7 @@ The existing CLI emits `SCHEMA_VERSION = "1.0.0"` for transcript-only JSON outpu
 | Surface | v1 behavior | v2 behavior |
 |---|---|---|
 | CLI JSON output | Flat entries: `{ offsetSec, durationSec, text }` | Sum-type entries: `{ kind: "speech", offsetSec, durationSec, text }` |
-| `--json` consumer contract | `entries[i].text` accessible directly | Consumer must check `entries[i].kind === "speech"` before reading `text`; visual entries carry different fields |
+| `--json` consumer contract | `entries[i].text` accessible directly | `text` is on both variants; consumers branch on `kind` only for variant-specific fields (e.g., `durationSec` and `lang` on `speech`, `mode` on `visual`) |
 | Server intake | (does not exist in v1) | Accepts only `schemaVersion: "2.0.0"` initially. On `1.0.0`, return `409` with `serverAccepts: ["2.0.0"]` and a message telling the user to upgrade. |
 
 The CLI does not need to retain v1 output mode. There is no external programmatic consumer of the v1 CLI JSON today; the schema-version field exists precisely so this bump can happen cleanly. Web-app consumers of the existing transcript JSONB column in the database are unaffected — the column already stores a richer shape than the v1 CLI emitted.

--- a/docs/architecture/cli-thin-client.md
+++ b/docs/architecture/cli-thin-client.md
@@ -1,0 +1,374 @@
+# CLI Thin-Client Architecture
+
+Design pass for issue [#88](https://github.com/niftymonkey/brief/issues/88) — migrate brief's CLI from a standalone local pipeline (today: hits Supadata + Anthropic directly, prints transcript JSON) to a thin client of the hosted web service. The CLI authenticates against brief, runs work that needs residential-IP egress on the user's machine, and POSTs results back to the hosted API for persistence and brief generation. Captures locked architectural decisions; the issue + its follow-up comment are the working source of truth, this document is the artifact.
+
+## Why this design
+
+Two forces shape the CLI in 2026:
+
+1. **The egress constraint from [#84](https://github.com/niftymonkey/brief/issues/84).** Server-side yt-dlp from Vercel is reliably blocked by YouTube's anti-bot enforcement, and no ethical vendor sells MP4-bytes-for-YouTube the way Supadata sells transcripts. The only place the video-frames pipeline can run is the user's machine — which is where the CLI already is. The CLI becomes the host for any future feature whose inputs can't be acquired server-side.
+2. **The cost-and-quota story.** Brief is moving toward a unified billing surface where every brief's tokens, latency, and storage are accounted to a user account. A standalone CLI that hits Anthropic directly with the user's own key writes outside that surface. The thin-client migration lets the server own the brief-generation half and the metrics row, even when the CLI did residential-IP work locally.
+
+What the migration replaces:
+
+- **CLI today** prints a transcript JSON for the given URL and exits. It is not authenticated, not user-attributed, and writes nothing to brief's database.
+- **CLI tomorrow** is a verb-first thin client that exposes a subcommand surface (`login`, `logout`, `whoami`, `transcript`, `generate`). Local-only operations stay local; server-touching operations authenticate against the hosted service. The `generate` subcommand persists a brief to the user's account in brief's database, attributable in the same `digests` table the web app writes to, and returns the brief's public URL.
+
+What the migration does *not* attempt:
+
+- A full feature-parity surface with the web UI. CLI subcommands ship per use case as they're needed (v1: the five above; natural future additions like `list`, `get`, `open`, `delete`, `regenerate` follow the `gh`/`gcloud` pattern as they're asked for).
+- Reaching brief generation from the CLI without the hosted service. The CLI is a client, not a peer; `generate` always goes through the hosted API.
+- Holding LLM keys server-side in v1. The CLI uses the user's own OpenRouter key for local vision work; a follow-up issue moves that to server-issued ephemeral tokens once the auth shape is proven.
+
+## Industry-standard choices (locked)
+
+Three architectural decisions are picked from established 2026 industry standards rather than invented:
+
+| Concern | Pick | Why |
+|---|---|---|
+| **Authentication** | WorkOS CLI Auth — OAuth 2.0 Device Authorization Grant (RFC 8628) | WorkOS shipped this as a first-class feature 2025-06-27 specifically for this scenario. It is what `gh`, `gcloud`, `vercel`, and `aws` (post-2.22) all use. Documented endpoints: `POST /user_management/authorize/device` and `POST /user_management/authenticate` with `grant_type=urn:ietf:params:oauth:grant-type:device_code`. |
+| **Transport** | Shared Zod schemas in `@brief/core` + plain `fetch` | Zero new dependencies. Server validates with `Submission.parse(...)`; CLI imports the same schema and gets request types via `z.infer<typeof Submission>`. tRPC and Hono RPC are overkill given the only non-browser consumer is our own CLI in our own monorepo. |
+| **Schema versioning** | `schemaVersion` literal field on the submission; handler branches and normalizes to the latest internal shape | Dominant 2026 pattern for app-scale APIs. URL path stays `/api/brief/intake` until a true breaking change forces `/v2/`. Only additive changes within a major. |
+
+These three picks are the load-bearing constraints below them; the module landscape and the public interface follow from them.
+
+## Module landscape
+
+### `apps/cli`
+
+| Module | Role |
+|---|---|
+| **AuthFlow** | Concentrates the device-flow dance: requests a device code from WorkOS, displays the user-code + verification URI, polls `/user_management/authenticate` until success or expiry, persists the resulting access + refresh tokens. Surfaces `login()`, `logout()`, `currentSession()`. Backs the `login`/`logout`/`whoami` subcommands. |
+| **CredentialStore** | Local persistence for `{ accessToken, refreshToken, expiresAt, userId }`. Wraps `keytar` / `@napi-rs/keyring` for OS-keychain storage where available; falls back to `~/.config/brief/credentials.json` with `0600` perms on platforms without keychain access. Concentrates: cross-platform secret storage, atomic writes, refresh-on-stale. |
+| **HostedClient** | Cascade orchestrator for talking to brief's hosted service. Concentrates: base-URL resolution (env var or built-in default), `Authorization: Bearer <token>` injection, token-refresh-on-401, Zod-validated response parsing, retry on transient. Two production adapters (real `fetch`, in-memory stub for tests). Backs `whoami` (lightweight identity check) and `generate` (submission to intake). |
+| **Renderer** (existing) | Extended to cover four output shapes: bare transcript (existing), augmented transcript (transcript + visual markers from local frames pipeline), brief URL (one-line stdout for `generate`), brief JSON (structured response for `generate --json`). Format selection by subcommand + `--json` flag. |
+| **ExitCodeMapper** (existing) | Extended with two new codes: `5` (authentication required) and `6` (CLI/server schema mismatch — upgrade required). Existing codes (0/2/3/4/1) retain their meaning for the `transcript` subcommand. |
+| **Entrypoint** (existing) | Glue + subcommand dispatcher. Reads `argv[2]` as the subcommand name; routes to a per-subcommand handler. Bare-positional invocation (`brief <url>` with no subcommand verb) falls through to `transcript` for backward-compat with the existing CLI, emitting a one-line stderr tip suggesting the explicit form. |
+
+### `apps/web`
+
+| Module | Role |
+|---|---|
+| **BriefIntake** route handler (`POST /api/brief/intake`) | Receives a `TranscriptSubmission`, validates with Zod, normalizes by `schemaVersion`, persists the transcript + metrics into the existing `digests` table, runs `generateBrief()` synchronously, returns the brief. Reuses the same persistence helpers (`saveBrief`, `copyBriefForUser`) the existing brief route uses. |
+| **TokenAuth middleware** | Verifies `Authorization: Bearer <token>` against WorkOS sessions on every CLI-facing route. Returns 401 with a `WWW-Authenticate` header naming the device-flow URL when invalid. Parallels the existing `withAuth` wrapper but for token-bearer rather than cookie-session callers. |
+| **CLI token endpoint** (`POST /api/cli/token/refresh`) | Standard OAuth refresh-token exchange. Accepts a refresh token, returns a new access token. The CLI hits this transparently when its access token expires. |
+
+### `packages/core`
+
+| Module | Role |
+|---|---|
+| **`TranscriptSubmission`** | Discriminated-union Zod schema covering transcript-only and augmented submissions. The public contract between CLI and server. Lives in `@brief/core/submission`. |
+| **`TranscriptEntry` (sum-type migration)** | Existing `TranscriptEntry` becomes a discriminated union: `{ kind: "speech", … }` or `{ kind: "visual", … }`. Drives `SCHEMA_VERSION` bump to `"2.0.0"`. |
+| **`SCHEMA_VERSION`** | Bumps from `"1.0.0"` to `"2.0.0"`. The constant lives in `@brief/core`; CLI emits it, server reads it. |
+
+### Deleted candidates (recorded so they don't get re-suggested)
+
+- *Generic HTTP-transport wrapper* (a `RestClient` class wrapping `fetch`) — pass-through. The HostedClient methods build paths and Zod-parse responses; a generic wrapper underneath is one indirection too many. Inline `fetch` calls in HostedClient.
+- *Schema-version gatekeeper as a separate module* — a single `if (body.schemaVersion === "2.0.0")` branch inside BriefIntake. Not a module.
+- *Frame-or-transcript chooser as a module* — one boolean check (`opts.withFrames`) in the Entrypoint. Not a module.
+- *LLM-key loader as a module* — one env-var read where the frames pipeline gets invoked. Not a module.
+- *Per-CLI Supadata client* — `@brief/core`'s existing `fetchTranscript()` cascade already does this. CLI consumes it directly.
+
+## Subcommand surface (v1)
+
+The five subcommands split cleanly along whether they touch the hosted service:
+
+| Subcommand | Auth | Hits hosted service? | Touches YouTube? | Output |
+|---|---|---|---|---|
+| `brief login` | n/a (acquires) | WorkOS device endpoints + `GET /api/cli/whoami` post-success | No | Status line + user email on success |
+| `brief logout` | requires (or no-op) | Best-effort `POST /api/cli/logout` to revoke server-side; always clears local | No | Status line |
+| `brief whoami` | required | `GET /api/cli/whoami` | No | User email (or `--json` for full identity record) |
+| `brief transcript <url-or-id> [--with-frames] [--json]` | not required | No — fully local | Yes (transcript + optionally video bytes) | Transcript text (or augmented transcript if `--with-frames`); `--json` for structured form |
+| `brief generate <url-or-id> [--with-frames] [--json]` | required | `POST /api/brief/intake` | Yes (transcript + optionally video bytes) | Brief URL on stdout; `--json` for full structured response |
+
+**Bare-positional shortcut.** `brief <url-or-id>` with no subcommand verb routes to `transcript` for backward-compat with the existing CLI. A one-line stderr tip suggests the explicit form. This shortcut is documented as backward-compat, not as a load-bearing surface — future deprecation is on the table once existing users have migrated.
+
+**Why this split:** `transcript` is a pure local capability — it has been since v1 and the migration shouldn't take that away. It's also the entry point for local iteration on the frames pipeline without burning a brief generation (e.g., debugging which frames the classifier picks). `generate` is the new thin-client-shaped command — it submits work to brief and ties output to a user account. Splitting them means the local capability stays usable when offline, when not signed in, and when the user just wants the transcript.
+
+**Natural future subcommands** (not in v1, listed so the dispatcher shape accommodates them): `brief list` (recent briefs for the signed-in user), `brief get <id>` (fetch one brief), `brief open <id>` (open the brief's URL in a browser), `brief delete <id>`, `brief regenerate <id>` (re-run brief generation on an existing transcript without re-fetching). All follow the `gh pr <verb>` pattern.
+
+## Public interface
+
+### Submission shape (`@brief/core/submission`)
+
+```typescript
+import { z } from "zod";
+
+export const SCHEMA_VERSION = "2.0.0" as const;
+
+export const TranscriptEntrySchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("speech"),
+    offsetSec: z.number(),
+    durationSec: z.number(),
+    text: z.string(),
+    lang: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("visual"),
+    offsetSec: z.number(),
+    mode: z.enum(["verbatim", "summary"]),
+    text: z.string(),
+  }),
+]);
+
+export const VideoMetadataSchema = z.object({
+  videoId: z.string(),
+  title: z.string(),
+  channelTitle: z.string(),
+  channelId: z.string(),
+  duration: z.string(),       // ISO-8601
+  publishedAt: z.string(),    // ISO-8601
+  description: z.string(),
+  pinnedComment: z.string().optional(),
+});
+
+export const FramesMetricsSchema = z.object({
+  videoDurationSec: z.number(),
+  candidatesGenerated: z.number(),
+  candidatesAfterDedup: z.number(),
+  classifierYes: z.number(),
+  classifierNo: z.number(),
+  visionCalls: z.number(),
+  inputTokens: z.number(),
+  outputTokens: z.number(),
+  classifierModel: z.string(),
+  visionModel: z.string(),
+  wallClockMs: z.number(),
+});
+
+export const TranscriptSubmissionSchema = z.object({
+  schemaVersion: z.literal(SCHEMA_VERSION),
+  videoId: z.string(),
+  metadata: VideoMetadataSchema,
+  transcript: z.array(TranscriptEntrySchema),
+  frames: z.discriminatedUnion("kind", [
+    z.object({ kind: z.literal("not-requested") }),
+    z.object({ kind: z.literal("included"), metrics: FramesMetricsSchema }),
+    z.object({
+      kind: z.literal("attempted-failed"),
+      reason: z.string(),
+      phase: z.string(),
+      metrics: FramesMetricsSchema,
+    }),
+  ]),
+});
+
+export type TranscriptSubmission = z.infer<typeof TranscriptSubmissionSchema>;
+```
+
+### HostedClient interface (`apps/cli`)
+
+```typescript
+interface HostedClient {
+  submit(submission: TranscriptSubmission): Promise<BriefResult>;
+  whoami(): Promise<IdentityResult>;
+  logout(): Promise<LogoutResult>;       // best-effort server-side revoke
+}
+
+type BriefResult =
+  | { kind: "ok"; briefId: string; briefUrl: string; brief: BriefBody; metadata: VideoMetadata }
+  | { kind: "auth-required"; reason: "expired" | "revoked" | "missing" }
+  | { kind: "schema-mismatch"; serverAccepts: string[]; sent: string }
+  | { kind: "rate-limited"; retryAfterSeconds: number }
+  | { kind: "transient"; cause: string; message: string };
+
+type IdentityResult =
+  | { kind: "ok"; email: string; userId: string }
+  | { kind: "auth-required"; reason: "expired" | "revoked" | "missing" }
+  | { kind: "transient"; cause: string; message: string };
+
+type LogoutResult =
+  | { kind: "ok" }
+  | { kind: "transient"; cause: string };   // local credentials always cleared regardless
+```
+
+Naming follows the existing `@brief/core` convention: result types are named for what they represent (`TranscriptResult`, `MetadataResult`), not for the verb that produced them. `BriefResult` is the brief-or-failure outcome of a `generate`; `IdentityResult` is the identity-or-failure outcome of a `whoami`; `LogoutResult` is a one-off with no natural noun and is named after the operation it terminates.
+
+Callers pattern-match on `kind`. The `auth-required` branch triggers a `login` prompt; `schema-mismatch` triggers a "please upgrade brief" message; `transient` is retried per the existing retry-policy module from `@brief/core`.
+
+`briefUrl` on `BriefResult` is the canonical surface for `generate`'s default human output — one line on stdout, the URL the user can paste into a browser or share. The full `brief` body is included in the same response so `--json` consumers don't need a second round-trip.
+
+### BriefIntake contract (`apps/web`)
+
+```
+POST /api/brief/intake
+Authorization: Bearer <access-token>
+Content-Type: application/json
+
+Body: TranscriptSubmission (Zod-validated)
+
+200 OK
+{
+  "schemaVersion": "2.0.0",
+  "briefId": "...",
+  "brief": { "summary": "...", "sections": [...], "relatedLinks": [...], "otherLinks": [...] },
+  "metadata": { ... }
+}
+
+400 Bad Request — body fails Zod parse (response includes Zod error path)
+401 Unauthorized — token missing/expired/revoked (WWW-Authenticate names device-flow URL)
+409 Conflict — schemaVersion is one the server no longer accepts; response carries `serverAccepts: string[]`
+429 Too Many Requests — daily-quota hit (Retry-After header set)
+503 Service Unavailable — downstream LLM transient failure
+```
+
+The intake handler is synchronous in v1: it persists the row, runs `generateBrief()`, returns the brief in the same response. Wall-clock budget is bounded by brief generation alone (transcript already in hand from the CLI) — typically 5–15 s. If wall-clock pressure surfaces from real CLI use, revisit with the same async-job-runner trade-off the existing brief route would face — not earlier.
+
+## The auth seam
+
+This is the one real trade-off at design time. WorkOS supports two flows that fit our shape: **Authorization Code + PKCE on a loopback**, and **OAuth 2.0 Device Authorization Grant**. Other CLIs in 2026 ship both, defaulting to one.
+
+| Lens | PKCE loopback | Device flow |
+|---|---|---|
+| **UX (workstation)** | Best. CLI opens the user's browser; they're already logged into brief; one click and done. | Two-step. CLI prints a URL and a code; user opens browser, pastes code, confirms. |
+| **UX (headless: SSH, container, CI)** | Broken. Requires a browser on the same machine as the CLI. | Works. Code is portable; user authenticates anywhere. |
+| **Implementation surface** | CLI must run an HTTP server on a free port, handle the redirect, exchange code+PKCE-verifier. ~200 lines of careful code. | CLI just polls an endpoint. ~50 lines. |
+| **WorkOS SDK fit** | `@workos-inc/node` v8 has first-class PKCE helpers (`getAuthorizationUrlWithPKCE`, `authenticateWithCode`). | Endpoints are raw HTTP per WorkOS's own Node tutorial; no dedicated SDK method as of late 2025. |
+| **Token revocation story** | Same. Both flows produce standard access/refresh tokens revocable via WorkOS dashboard. | Same. |
+
+**Recommendation: device flow as the default in v1, with PKCE loopback as a v2 enhancement.** Three reasons:
+
+1. **Simpler implementation surface** — ~50 lines of polling vs ~200 of redirect-server plumbing. The flow ships sooner.
+2. **Headless-friendly by default** — many brief CLI use cases (AI coding agents, scripts, SSH sessions) won't have a usable local browser. PKCE-only would leave them broken.
+3. **WorkOS's launch posture leans this direction** — CLI Auth (device flow) is the named, documented feature; PKCE for public clients exists but isn't packaged as "CLI Auth."
+
+The v2 enhancement is straightforward: add PKCE loopback under `brief login`, demote device flow to `brief login --device`, follow the gh/gcloud/aws default-PKCE-fallback-device pattern. v1 ships device-only.
+
+## Failure-mode propagation
+
+The CLI's failure surface is structured around what a user sees and what the exit code carries. The entrypoint dispatches on subcommand:
+
+```typescript
+// Pseudocode of the entrypoint after parseArgs.
+
+switch (subcommand) {
+  case "login":      return runLogin(opts);
+  case "logout":     return runLogout(opts);
+  case "whoami":     return runWhoami(opts);
+  case "transcript": return runTranscript(positional, opts);
+  case "generate":   return runGenerate(positional, opts);
+  // Bare-positional shortcut: `brief <url>` → transcript.
+  default:           return runTranscript(positional, { ...opts, _bareShortcut: true });
+}
+```
+
+**`runTranscript` (local-only, no auth):**
+
+```typescript
+const transcript = await fetchTranscript(input, { ... });
+if (transcript.kind === "unavailable") return printAndExit(transcript, EXIT_UNAVAILABLE /* 3 */);
+if (transcript.kind === "transient")   return printAndExit(transcript, EXIT_TRANSIENT   /* 4 */);
+
+if (opts.withFrames) {
+  const frames = await extractFrames({ videoId, transcript: transcript.entries, ... });   // #87
+  // Frames failure downgrades to bare-transcript output; CLI still exits 0 unless transcript itself failed.
+  return renderTranscript({ transcript, frames }, opts.json ? "json" : "human");
+}
+
+return renderTranscript({ transcript }, opts.json ? "json" : "human");
+```
+
+**`runGenerate` (auth required, server-touching):**
+
+```typescript
+const tokens = await credentialStore.read();
+if (!tokens) {
+  process.stderr.write("Not signed in. Run `brief login` first.\n");
+  return EXIT_AUTH_REQUIRED;   // 5
+}
+
+const transcript = await fetchTranscript(input, { ... });
+if (transcript.kind === "unavailable") return printAndExit(transcript, EXIT_UNAVAILABLE /* 3 */);
+if (transcript.kind === "transient")   return printAndExit(transcript, EXIT_TRANSIENT   /* 4 */);
+
+const frames = opts.withFrames
+  ? await extractFrames({ videoId, transcript: transcript.entries, ... })
+  : { kind: "not-requested" as const };
+
+const submission = buildSubmission(transcript, metadata, frames);
+const result = await hostedClient.submit(submission);
+
+switch (result.kind) {
+  case "ok":
+    process.stdout.write(opts.json ? JSON.stringify(result) : `${result.briefUrl}\n`);
+    return EXIT_OK;            // 0
+  case "auth-required":
+    process.stderr.write("Authentication expired. Run `brief login`.\n");
+    return EXIT_AUTH_REQUIRED; // 5
+  case "schema-mismatch":
+    process.stderr.write("This brief CLI is out of date. Please upgrade.\n");
+    return EXIT_SCHEMA_MISMATCH; // 6
+  case "rate-limited":
+    process.stderr.write(`Daily quota reached. Try again in ${result.retryAfterSeconds}s.\n`);
+    return EXIT_TRANSIENT;     // 4
+  case "transient":
+    process.stderr.write(`Service temporarily unavailable: ${result.message}\n`);
+    return EXIT_TRANSIENT;     // 4
+}
+```
+
+A frames-pipeline failure inside `extractFrames()` does *not* fail either subcommand. In `transcript --with-frames`, the user gets a bare transcript with a stderr note. In `generate --with-frames`, the submission carries `frames.kind = "attempted-failed"` and the server produces a transcript-only brief. This matches the failure-mode contract already designed for `extractFrames()` in the existing (to-be-rewritten) `docs/architecture/video-frames.md`.
+
+## Dependency categories and test surface
+
+| Module | Dependencies | Category | Test strategy |
+|---|---|---|---|
+| `AuthFlow` | WorkOS user-management endpoints | 4 — True external | Stub HTTP responses for device-code, polling, success, expiry. Test the state machine, not the network. |
+| `CredentialStore` | OS keychain (`keytar` / `@napi-rs/keyring`), filesystem | 2 — Local-substitutable | Inject the store backend. In tests, use an in-memory implementation of the same interface. |
+| `HostedClient` | brief's hosted API | 3 — Remote but owned | Define a `Transport` port (`fetch`-shaped) at the seam. Production injects real `fetch`; tests inject a stub returning canned responses. Cascade-rule table tests at HostedClient's external interface. |
+| `Renderer` | `BriefResult` type | 1 — Pure | Direct unit tests. Synthesized result values; assert on stdout/stderr strings. |
+| `ExitCodeMapper` | `BriefResult` type | 1 — Pure | Direct unit tests. Matrix over `result.kind`. |
+| `Entrypoint` | All of the above | Mixed | Integration test: spawn the binary against a stubbed hosted service, assert on stdout/stderr/exit code. No mocking through the public interface. |
+| `BriefIntake` route | Postgres, `generateBrief()` | 2 — Local-substitutable | Existing brief-route test pattern: real Postgres in a transaction that rolls back, real Zod validation, stubbed LLM at the `generateBrief` seam. |
+| `TokenAuth` middleware | WorkOS session API | 4 — True external | Stub WorkOS's session-check call; assert on 401 shape and `WWW-Authenticate` header. |
+| `TranscriptSubmission` schema | Zod | 1 — Pure | Direct unit tests. Round-trip representative payloads through `parse()`; assert on rejection messages for breaking schema violations. |
+
+The Zod schema in `@brief/core` is the **shared test surface**: the same `TranscriptSubmissionSchema.parse(...)` runs in CLI tests (validating outbound payloads) and server tests (validating inbound payloads). Schema-drift between CLI and server is impossible by construction — both import the same module.
+
+## Backwards compatibility — `SCHEMA_VERSION` bump
+
+The existing CLI emits `SCHEMA_VERSION = "1.0.0"` for transcript-only JSON output. The new shape bumps to `"2.0.0"` because `TranscriptEntry` becomes a discriminated union and the top-level shape grows a `frames` field.
+
+| Surface | v1 behavior | v2 behavior |
+|---|---|---|
+| CLI JSON output | Flat entries: `{ offsetSec, durationSec, text }` | Sum-type entries: `{ kind: "speech", offsetSec, durationSec, text }` |
+| `--json` consumer contract | `entries[i].text` accessible directly | Consumer must check `entries[i].kind === "speech"` before reading `text`; visual entries carry different fields |
+| Server intake | (does not exist in v1) | Accepts only `schemaVersion: "2.0.0"` initially. On `1.0.0`, return `409` with `serverAccepts: ["2.0.0"]` and a message telling the user to upgrade. |
+
+The CLI does not need to retain v1 output mode. There is no external programmatic consumer of the v1 CLI JSON today; the schema-version field exists precisely so this bump can happen cleanly. Web-app consumers of the existing transcript JSONB column in the database are unaffected — the column already stores a richer shape than the v1 CLI emitted.
+
+## Locked decisions
+
+| # | Decision |
+|---|---|
+| 1 | Auth: WorkOS CLI Auth via device flow (RFC 8628). PKCE loopback deferred to v2 enhancement. |
+| 2 | Transport: shared Zod schemas in `@brief/core` + plain `fetch`. No tRPC, no Hono RPC, no OpenAPI codegen. |
+| 3 | Schema versioning: `schemaVersion` literal discriminator + handler-side normalize. URL stable until major break. |
+| 4 | Credential store: OS keychain via `keytar` / `@napi-rs/keyring`; FS fallback at `~/.config/brief/credentials.json` (`0600`). |
+| 5 | LLM key for vision lives on user's machine in v1. Follow-up issue tracks server-issued ephemeral tokens. |
+| 6 | Single intake endpoint: `POST /api/brief/intake` accepts both transcript-only and augmented submissions via a discriminated `frames` field. |
+| 7 | Synchronous response from intake: server runs `generateBrief()` and returns the brief in the same response. No SSE for CLI in v1. |
+| 8 | `TranscriptEntry` becomes a discriminated union (`speech` \| `visual`). `SCHEMA_VERSION` bumps `1.0.0` → `2.0.0`. |
+| 9 | Transcript fetch happens CLI-side using `@brief/core`'s existing cascade. Server does not fetch transcripts on behalf of the CLI. |
+| 10 | CLI subcommand surface (v1): `brief login`, `brief logout`, `brief whoami`, `brief transcript <url-or-id> [--with-frames]`, `brief generate <url-or-id> [--with-frames]`. `brief <url-or-id>` (no verb) is a backward-compat shortcut for `transcript`. Natural future subcommands (`list`/`get`/`open`/`delete`/`regenerate`) are out of scope for v1 but the dispatcher accommodates them. |
+| 11 | `transcript` is local-only (no auth, no server contact). `generate` requires auth and submits to `POST /api/brief/intake`. `whoami`/`login`/`logout` are the auth subcommands. This split keeps the existing local-iteration workflow intact (you can debug the frames pipeline without burning a brief generation) and matches the gh/gcloud verb-first pattern. |
+| 12 | `generate` default human output is the brief URL on stdout (one line); `--json` returns the full structured response including the brief body. |
+
+## Open questions for implementation
+
+These resolve during implementation, not at design time:
+
+- **Token refresh trigger.** Refresh on every command (cheap, always-fresh) or refresh only on 401 (lazier, fewer requests). Lazy is cheaper but adds one round-trip on the unlucky boundary case. Decide during build.
+- **`brief login` reauth UX.** After successful login, do we print a one-line confirmation or echo the user email? Match `gh auth status` style — terse, one line.
+- **Where the `extractFrames()` invocation sits in the entrypoint.** Could live inline in the Entrypoint or be wrapped in a small `runFramesIfRequested()` helper. Trivial — decide at write time. The frames module's own design is #87's deliverable.
+- **Quota check ordering.** Server returns 429 if the user is over their daily augmented-brief cap. Should the CLI also check quota locally before doing 5 minutes of frame work? Probably not — the server is the source of truth, and a CLI-side cache would drift. Accept the cost of finding out after the fact in v1; revisit if it becomes a real complaint.
+- **`brief whoami` content.** Email + plan tier + remaining quota? Or just email? Lean toward more once the quota story is concrete.
+
+## Cross-references
+
+- Predecessor: `docs/architecture/transcript-cli.md` — module-landscape pattern this doc mirrors; the CLI's existing `Renderer` and `ExitCodeMapper` come from that work.
+- Egress driver: `docs/youtube-tos-research.md` — why the frames pipeline can't run server-side.
+- Downstream consumer: `docs/architecture/video-frames.md` (to be rewritten) — `extractFrames()` is invoked from this CLI entrypoint; the contract between them is part of [#87](https://github.com/niftymonkey/brief/issues/87)'s design.
+- Industry-standard auth: [WorkOS CLI Auth docs](https://workos.com/docs/authkit/cli-auth), [RFC 8628 Device Authorization Grant](https://datatracker.ietf.org/doc/html/rfc8628).
+- Follow-up issue (planned): move LLM keys from CLI-side to server-issued ephemeral tokens, to unify the cost/quota story.

--- a/docs/architecture/video-frames.md
+++ b/docs/architecture/video-frames.md
@@ -1,28 +1,29 @@
 # Video Frames Architecture
 
-Design pass for the video-frames integration — issue D in the `docs/video-frames-plan.md` breakdown. Depends on #84 (YouTube ToS posture), #85 (brief schema), #86 (model selection layer / pickai). Captures locked module boundaries and the trade-offs at the integration seam; the issue + its follow-up comment are the working source of truth, this document is the artifact.
+Design pass for the video-frames integration — issue [#87](https://github.com/niftymonkey/brief/issues/87). Depends on [#88](https://github.com/niftymonkey/brief/issues/88) (CLI thin-client transition, which provides the auth + submission shape this module plugs into). Captures locked module boundaries and the trade-offs at the integration seam; the issue + its follow-up comment are the working source of truth, this document is the artifact.
 
 ## Executive summary
 
-A single deep module — `@brief/core`'s `frames/` package — owns the 8-phase pipeline that turns a video ID into an *augmented transcript*: speech entries interleaved temporally with vision-extracted on-screen content. Its public surface is one function: `extractFrames()`. Its public type is one discriminated union: `FramesResult` with two cases, `included` and `attempted-failed`. The third planning-doc state, `not-requested`, is a route-level decision (don't call) rather than a return shape.
+A single deep module — `@brief/core`'s `frames/` package — owns the 8-phase pipeline that turns a video ID into an *augmented transcript*: speech entries interleaved temporally with vision-extracted on-screen content. Its public surface is one function: `extractFrames()`. Its public type is one discriminated union: `FramesResult` with two cases, `included` and `attempted-failed`. The third planning-doc state, `not-requested`, is a caller-level decision (don't call) rather than a return shape.
 
-The web app brief route stays the orchestrator. It branches on the per-digest opt-in checkbox + allowlist, calls `extractFrames()` when both pass, falls back to the existing transcript-only path when frames return `attempted-failed`, and writes `transcript` (string), `framesStatus` (enum), and `metrics` (JSONB) onto the brief row regardless. `generateBrief()` learns one new thing: accept a pre-formatted transcript string in addition to the existing `TranscriptEntry[]` form, so frames-augmented and transcript-only digests reach the LLM through the same prompt template.
+**The pipeline runs on the user's machine, invoked by the brief CLI's `transcript --with-frames` and `generate --with-frames` subcommands. The hosted web service never invokes `extractFrames()` and never touches YouTube video bytes.** This is the load-bearing constraint that shapes everything downstream: the egress problem documented in `docs/youtube-tos-research.md` (#84) means server-side yt-dlp from Vercel is reliably blocked by YouTube's anti-bot enforcement, and the vendor research summarized in the [[frames-vendor-research]] memory found no ethical vendor selling MP4-bytes-for-YouTube the way Supadata sells transcripts. The architectural response is to put the egress where it is structurally allowed — the user's residential IP — and surface the result back to the hosted service as a pre-prepared augmented transcript via the CLI thin-client API contract.
 
-The 5-minute wall-clock fits inside the existing SSE stream — no background-job runner in v1. Allowlist scope (repo owner only) bounds the cost of getting that wrong; the route is the right place to revisit if real users get exposed.
+The CLI is the orchestrator. It branches on the `--with-frames` flag, calls `extractFrames()` when set, and either prints the augmented transcript (`brief transcript --with-frames`) or POSTs the augmented transcript + metrics to brief's hosted intake endpoint (`brief generate --with-frames`). The server's intake endpoint persists the submission and runs brief generation against it; it does not know or care whether the augmented transcript came from a frames pipeline or was hand-crafted.
 
-Eight internal sub-modules sit behind `extractFrames()`: pure computation (`selection`, `weave`) tests directly; local-binary adapters (`ffmpeg`, `download`) record-and-replay; the Anthropic adapter is the one true external seam and gets a real port. The cost lever (cheap Haiku classifier filter before expensive Sonnet vision) is preserved by keeping `classify` and `vision` as separate functions inside the Anthropic adapter, not collapsed into one call.
+Eight internal sub-modules sit behind `extractFrames()`: pure computation (`selection`, `weave`) tests directly; local-binary adapters (`ffmpeg`, `download`) record-and-replay; the OpenRouter vision adapter is the one true external seam and gets a real port. The cost lever (cheap classifier filter before expensive vision) is preserved by keeping `classify` and `vision` as separate functions inside the OpenRouter adapter, not collapsed into one call.
 
 ## Why this design
 
-The spike proved a specific pipeline shape works end-to-end on real content: ffmpeg scene detection + chapter + transcript-cue selection, paired cue+0/cue+3s captures, Haiku binary classifier, Sonnet VERBATIM/SUMMARY vision, temporal weave preserving formatting. The 4-round investigation in `continue-video-frames.md` records what works and what dead-ends to avoid (storyboards, Read-tool downsampling, MHTML rendering). The single reference implementation at `spikes/video-frames-pipeline/pipeline.mjs` is a working 8-phase orchestrator with disk caching — the production module *factors out of* this rather than reinventing it.
+The spike proved a specific pipeline shape works end-to-end on real content: ffmpeg scene detection + chapter + transcript-cue selection, paired cue+0/cue+3s captures, classifier binary verdict, vision VERBATIM/SUMMARY pass, temporal weave preserving formatting. The 4-round investigation in `continue-video-frames.md` records what works and what dead-ends to avoid (storyboards, Read-tool downsampling, MHTML rendering). The single reference implementation at `spikes/video-frames-pipeline/pipeline.mjs` is a working 8-phase orchestrator with disk caching — the production module *factors out of* this rather than reinventing it.
 
 What the design fixes versus the spike:
 
-- **Cache lives in the brief row, not on disk.** Disk caching across phases was an iteration accelerator during the spike. Production runs once per `(user, video)` and persists the augmented transcript to Postgres; no intermediate disk artifacts survive the request.
+- **Runs CLI-side, not server-side.** The spike ran on the developer's machine and that is the production environment. The web app stays transcript-only; frames are exclusively a CLI capability in v1.
+- **Cache lives in the brief row on the hosted server, not on disk.** Disk caching across phases was an iteration accelerator during the spike. Production runs once per `(user, video)` on the user's machine, ships the augmented transcript to the hosted service, and the hosted service persists to Postgres. No intermediate disk artifacts survive past the CLI process exit.
 - **Cost cap is enforced inside `extractFrames()`.** The spike has no hard cap; production must guarantee ≤100 candidate frames per video as a v1 default.
-- **Failure modes graceful.** The spike crashes on subprocess error; production downgrades to transcript-only and surfaces `framesStatus = 'attempted-failed'`.
-- **Metrics are first-class.** The spike logs to stdout; production returns metrics in the result so the route can persist them.
-- **Model choices route through pickai.** The spike hardcodes `claude-haiku-4-5-20251001` and `claude-sonnet-4-6`; production reads from `packages/core/src/models.ts` (issue #86).
+- **Failure modes graceful.** The spike crashes on subprocess error; production downgrades to bare-transcript output (CLI) or transcript-only submission (CLI → server) and surfaces `kind: "attempted-failed"` with the failing phase.
+- **Metrics are first-class.** The spike logs to stdout; production returns metrics in the result so the CLI can include them in the server submission.
+- **Model choices route through `@brief/core`'s model layer.** The spike hardcoded Anthropic Claude models; production reads `CLASSIFY_MODEL` and `VISION_MODEL` from `packages/core/src/models.ts` (issue #86, locked picks documented in `docs/llm-model-selection.md`).
 
 ## Module landscape
 
@@ -35,28 +36,35 @@ What the design fixes versus the spike:
 | **`selection`** | Pure. `(scenes, chapters, transcript, opts) → Candidate[]`. Concentrates: dedup window, source-priority ordering, cue-regex patterns, cue+3s pairing, video-start anchor. Determines which timestamps get extracted. |
 | **`weave`** | Pure. `(transcript, visionResults) → string`. Concentrates: temporal interleave, transcript chunking (~12s), format preservation (no whitespace squash), `[MM:SS-MM:SS]` and `[MM:SS] [VISUAL]` markers. |
 | **`ffmpeg`** | Local-binary adapter. Two functions: `detectScenes(videoPath, threshold)` and `extractFrameAt(videoPath, timestamp, outPath)`. Concentrates: ffmpeg argv assembly, stderr parsing for `pts_time`, subprocess error normalization. |
-| **`download`** | Local-binary adapter. `downloadAt1080p(videoId, workDir) → { videoPath, infoJsonPath }`. Wraps yt-dlp. Concentrates: format selector string, output naming, info.json schema validation, ToS-relevant failure surfaces. |
-| **`anthropic`** | True-external adapter. Two functions: `classify(framePath) → 'yes' \| 'no'` and `describe(framePath) → VisionResult`. Concentrates: image-content-block construction, API key handling, bounded concurrency (`pmap`), token-usage capture, per-frame retry. |
+| **`download`** | Local-binary adapter. `downloadAt1080p(videoId, workDir) → { videoPath, infoJsonPath }`. Wraps yt-dlp. Concentrates: format selector string, output naming, info.json schema validation, public-only pre-flight rejection, anti-bot challenge detection. Never passes `--cookies` or any cookie-jar argument; cookie-authenticated pulls are out of scope per `docs/youtube-tos-research.md` §8.2.6. Video bytes deleted in a `finally` block on every code path. |
+| **`vision`** | True-external adapter via OpenRouter. Two functions: `classify(framePath) → 'yes' \| 'no'` and `describe(framePath) → VisionResult`. Concentrates: image-content-block construction, API key handling (caller-supplied, from CLI environment), bounded concurrency (`pmap`), token-usage capture, per-frame retry. |
 | **`types`** | `FramesResult` discriminated union, `Candidate`, `VisionResult`, `FramesOptions`, `FramesMetrics`. The interface the package presents to callers. |
 
 ### Deleted candidates (recorded so they don't get re-suggested)
 
-- *`frames/sources/` abstraction for video bytes* — one adapter (yt-dlp) today is a hypothetical seam. The transcript fetcher's multi-source pattern is justified by two real adapters (`youtube-transcript-plus`, `supadata`); video bytes have no such second adapter. Inline the yt-dlp call into `frames/download.ts`. Revisit if issue #84 surfaces a vendor or alternate technique.
-- *`frames/metrics/` as a separate module* — a `MetricsAccumulator` type and helper inside the orchestrator suffices. No leverage from a standalone module.
-- *Separate `classifier` and `vision` modules* — both are Anthropic SDK calls with image content blocks; they share API key handling, base64 encoding, concurrency control, and error mapping. Different prompts and result shapes do not justify two adapter modules; they justify two functions inside one adapter.
-- *Streaming-style result with per-frame events* — `extractFrames()` returns atomically. Progress to the SSE stream is the route's concern (it can emit `analyzing` events around `await extractFrames(...)` if granularity matters later). The frames module does not know about SSE.
+- *`frames/sources/` abstraction for video bytes* — one adapter (yt-dlp) today is a hypothetical seam. The transcript fetcher's multi-source pattern is justified by two real adapters (`youtube-transcript-plus`, `supadata`); video bytes have no such second adapter, and vendor research (see [[frames-vendor-research]]) found none clean enough to consider. Inline the yt-dlp call into `frames/download.ts`.
+- *`frames/metrics/` as a separate module* — a `MetricsAccumulator` type and helper inside the orchestrator suffices.
+- *Separate `classifier` and `vision` modules* — both are vision-LLM calls with image content blocks; they share API key handling, base64 encoding, concurrency control, and error mapping. Different prompts and result shapes do not justify two adapter modules; they justify two functions inside one adapter.
+- *Streaming-style result with per-frame events* — `extractFrames()` returns atomically. Progress display in the CLI is the CLI's concern (it can print `analyzing` / `vision` progress lines around `await extractFrames(...)` if granularity matters). The frames module does not know about CLI rendering.
+- *Vendor-mediated download adapter* — explored during the architectural pivot session (2026-05-11). No vendor in the market cleanly delivers MP4-bytes-for-YouTube under the user's ethical bar (named public-facing developer product, not residential-proxy network). Architecture response was to move the egress to the user's machine via the CLI. The download adapter wraps yt-dlp directly on the user's residential IP; no vendor abstraction.
+- *Web-app integration of `extractFrames()`* — the original design called this from the brief route handler. The egress constraint (datacenter-IP blocking) makes this non-functional in production. The web app stays transcript-only; the CLI is the only invocation point.
 
-### `apps/web` integration points
+### `apps/cli` integration points
 
 | Surface | Change |
 |---|---|
-| **`api/brief/route.ts`** | Reads `withFrames` from request body. Gated by `isFramesAllowed(user.email)` (parallel to existing `isEmailAllowed`). When both pass, calls `extractFrames()` after transcript fetch; otherwise uses the existing transcript-only path. Writes `transcript`, `framesStatus`, `metrics` to the brief row in all branches. |
-| **`lib/summarize.ts`** | `generateBrief()` gains an overload to accept a pre-formatted transcript string. When the string form is used, it skips the internal `formatTimestamp` join. Prompt template is taught to recognize `[VISUAL]` markers (no structural change required — Sonnet handles them inline). |
-| **`lib/prompts/user-template-chapters.md`** | One additional instruction line acknowledging `[VISUAL]` markers as on-screen content captures and treating verbatim sections as copy-pasteable. |
-| **`lib/access.ts`** | New `isFramesAllowed(email)` constant, same shape as `isEmailAllowed`. Repo owner only in v1. |
-| **`components/url-form` (or equivalent)** | New "Include video frames" checkbox, rendered only when `isFramesAllowed(user.email)`. Posts `withFrames: true` to the brief route. |
+| **`brief transcript <url> --with-frames`** | Local-only. Calls `extractFrames()` after transcript fetch, renders the augmented transcript to stdout. No server contact. Useful for iterating on the frames pipeline without burning a brief generation. |
+| **`brief generate <url> --with-frames`** | Calls `extractFrames()` after transcript fetch, builds a `TranscriptSubmission` with `frames.kind = "included"` (or `"attempted-failed"`), POSTs to `/api/brief/intake`. Server treats the augmented transcript as pre-prepared and runs brief generation. |
+| **`apps/cli/src/handlers/runTranscript.ts`** (new) | The `transcript` subcommand handler. Calls `fetchTranscript` then optionally `extractFrames`. Renders to stdout. |
+| **`apps/cli/src/handlers/runGenerate.ts`** (new) | The `generate` subcommand handler. Same prelude as `runTranscript`, then builds a submission and POSTs via `HostedClient.submit()`. |
 
-The DB columns (`transcript`, `framesStatus`, `metrics`) and migration land in issue #85, not here. The model-selection layer (`packages/core/src/models.ts`) lands in issue #86; this design assumes it exists at integration time and imports from it.
+The DB columns (`transcript`, `framesStatus`, `metrics`) and migration shipped in #85 (PR #93). The model-selection layer (`packages/core/src/models.ts`) shipped in #86 (PR #92). The CLI auth + submission shape ship in #88. This issue (#87) lands the frames module and its two CLI handler integrations on top of that foundation.
+
+### `apps/web` integration points
+
+**None for #87.** The web app's brief route remains transcript-only. There is no "include video frames" checkbox in the URL form; there is no `isFramesAllowed` allowlist; there is no `framesQuotaRemaining` rate-limit gate. All of that scope existed under the prior server-side-orchestration design and is removed by the CLI-runs-locally pivot.
+
+The hosted intake endpoint (`POST /api/brief/intake`, defined by #88) receives augmented transcripts from the CLI without distinguishing them from transcript-only submissions at the routing layer — the discriminator is on the request body's `frames` field. The brief route writes `framesStatus = 'included'` for augmented submissions and `'not-requested'` for plain ones; the existing `framesStatus = 'attempted-failed'` value carries through when the CLI ships a failure result.
 
 ## Public interface
 
@@ -66,8 +74,8 @@ The DB columns (`transcript`, `framesStatus`, `metrics`) and migration land in i
 export interface FramesOptions {
   videoId: string;
   transcript: TranscriptEntry[];        // from @brief/core's fetchTranscript
-  chapters?: Chapter[] | null;          // from web app's extractChapters
-  anthropicApiKey: string;
+  chapters?: Chapter[] | null;          // from @brief/core's extractChapters
+  openRouterApiKey: string;             // caller-supplied; CLI reads from env
   workDir: string;                      // for video/frames; cleaned up by caller
   maxCandidates?: number;               // default 100
   signal?: AbortSignal;
@@ -78,11 +86,13 @@ export type FramesResult =
   | { kind: "attempted-failed"; reason: FramesFailReason; phase: FramesPhase; message: string; metrics: FramesMetrics };
 
 export type FramesFailReason =
-  | "download-failed"        // yt-dlp non-zero, network out, video unavailable
-  | "ffmpeg-failed"          // scene detection or frame extraction crashed
-  | "vision-failed"          // Anthropic API exhausted retries or auth failed
-  | "budget-exceeded"        // post-selection candidate count above cap
-  | "aborted"                // signal triggered
+  | "download-blocked-bot-detection"  // YouTube anti-bot challenge / unexpected from residential IP, but not impossible
+  | "video-not-public"                // private, unlisted, age-gated, or login-required (rejected pre-download)
+  | "download-failed"                 // yt-dlp non-zero for any other reason (network, removed, geo, etc.)
+  | "ffmpeg-failed"                   // scene detection or frame extraction crashed
+  | "vision-failed"                   // vision API exhausted retries or auth failed
+  | "budget-exceeded"                 // post-selection candidate count above cap
+  | "aborted"                         // signal triggered
   | "unknown";
 
 export type FramesPhase =
@@ -100,7 +110,6 @@ export interface FramesMetrics {
   visionSummary: number;
   inputTokens: number;
   outputTokens: number;
-  estimatedCostUsd: number;             // applied at the model-selection layer
   classifierModel: string;
   visionModel: string;
   wallClockMs: number;
@@ -115,79 +124,68 @@ export function extractFrames(opts: FramesOptions): Promise<FramesResult>;
 
 - `extractFrames` does not throw under normal failure conditions. Every failure becomes `attempted-failed` with a `reason` and `phase`. Exceptions propagate only for programmer errors (bad inputs, missing API key, signal misuse).
 - `metrics` is returned on both result kinds. Failures still record what got measured before bailing.
-- `transcript` (on the `included` kind) is the augmented form: existing speech entries interleaved with `[MM:SS] [VISUAL]` blocks. It is suitable for direct LLM input.
-- No DB writes. No SSE awareness. No filesystem state outside `workDir`. Caller cleans up `workDir`.
+- `transcript` (on the `included` kind) is the augmented form: existing speech entries interleaved with `[MM:SS] [VISUAL]` blocks. It is suitable for direct LLM input or for CLI rendering to stdout.
+- No DB writes. No network hops beyond `download` (yt-dlp's YouTube fetch) and `vision` (OpenRouter). No filesystem state outside `workDir`. Caller cleans up `workDir`.
 - Bounded concurrency: classifier 5-wide, vision 4-wide (matches spike defaults; revisit with metrics).
 - Cost cap: if `selection` produces more than `maxCandidates`, `extractFrames` returns `attempted-failed` with `reason: "budget-exceeded"` rather than running an expensive vision pass over a too-long video.
+- **Public-only acceptance.** Private, unlisted, age-gated, and login-required videos are rejected by the `download` adapter's pre-flight check; result is `attempted-failed` with `reason: "video-not-public"` and `phase: "download"`. The pipeline does not attempt to bypass any access control.
+- **Transient bytes.** Downloaded video bytes are deleted in a `finally` block on every code path through `download` — success, failure, or abort. No code path retains the path after `extractFrames()` returns.
+- **No cookies.** The `download` adapter never accepts a cookie jar, `--cookies` argument, or YouTube session credential. Cookie-authenticated pulls are out of scope per `docs/youtube-tos-research.md` §8.2.6.
+- **No external orchestration awareness.** The module does not know whether it's being called from `transcript` or `generate`, whether the caller will print the result or POST it to a server, whether there's an authenticated user or not. It returns a `FramesResult` and walks away.
 
 **Why this shape:**
 
-- *One function, not a class.* No long-lived state. Each call is a unit of work matching a unit of user intent (one digest).
-- *Transcript as input, not fetched internally.* The route already fetches the transcript before deciding whether to run frames; reusing the same fetch keeps frames decoupled from `@brief/core`'s transcript cascade.
-- *Discriminated union over thrown errors.* The route distinguishes "frames failed, use transcript-only" from "everything failed, surface error" by reading `result.kind`, not by catching exceptions. Exception paths remain for programmer errors only — clear failure-mode contract.
-- *Metrics always returned.* The route persists what's available regardless of outcome; partial metrics are useful for iteration ("we paid for 60 vision calls and then the weave step crashed").
+- *One function, not a class.* No long-lived state. Each call is a unit of work matching a unit of user intent (one CLI invocation).
+- *Transcript as input, not fetched internally.* The CLI handler already fetches the transcript before deciding whether to run frames; reusing the same fetch keeps frames decoupled from `@brief/core`'s transcript cascade.
+- *Discriminated union over thrown errors.* The CLI distinguishes "frames failed, fall back to bare transcript" from "everything failed, exit non-zero" by reading `result.kind`, not by catching exceptions.
+- *Metrics always returned.* The CLI persists what's available to the server submission regardless of outcome; partial metrics are useful for iteration ("we paid for 60 vision calls and then the weave step crashed").
 
-## The integration seam
+## The CLI ↔ frames seam
 
-There is one real trade-off in this design. It lives at the boundary between `extractFrames()` and `generateBrief()`.
+`extractFrames()` is invoked from the CLI's `transcript` and `generate` handlers. The two handlers consume the same `FramesResult` but render it differently:
 
-**Option A — String contract (recommended).** `FramesResult.transcript` is a pre-formatted string (`[MM:SS-MM:SS] speech` + `[MM:SS] [VISUAL] content` lines). `generateBrief()` gains a string-accepting form alongside the existing `TranscriptEntry[]` form, and the prompt template gets one line of guidance about `[VISUAL]` markers.
-
-**Option B — Entry contract.** Extend `TranscriptEntry` to a sum type — `{ kind: 'speech', offset, duration, text } | { kind: 'visual', offset, mode: 'verbatim' | 'summary', text }`. `extractFrames()` returns entries. `generateBrief()` formats both kinds via its existing timestamp-formatting loop.
-
-**Trade-off:**
-
-| Lens | A (string) | B (entries) |
+| Result kind | `runTranscript` behavior | `runGenerate` behavior |
 |---|---|---|
-| **Leverage** | One additional `generateBrief` overload; format logic stays in `weave`. | Every consumer of `TranscriptEntry[]` (CLI, web, future chat) must teach itself about visuals. |
-| **Locality** | Format changes (chunk size, marker style) live in `weave.ts`. Single owner. | Format changes ripple across `weave.ts` + `summarize.ts` + every renderer. |
-| **Coupling** | The augmented format is part of the contract between `weave` and the brief prompt. The prompt template depends on `[VISUAL]` markers existing. | The augmented format is a structural property of the entry type. Renderers choose how to display. |
-| **Future flexibility** | When/if the CLI thin-client (issue E) needs visuals, it consumes the same string. | The CLI thin-client could render visuals differently per output mode. |
-| **Migration cost** | Low. One overload, one prompt-template tweak. | High. Type fans out into every existing transcript consumer. |
-| **v1 risk** | Format drift between weave and prompt invalidates digests until matched. | Sum-type fan-out into legacy code paths (`SCHEMA_VERSION`, `formatTranscript`) requires deliberate migration. Risk of breaking the existing CLI JSON shape. |
+| `kind: "included"` | Print the augmented transcript (`result.transcript`) to stdout. Exit 0. | Build a `TranscriptSubmission` with `frames.kind = "included"` carrying `result.metrics`. POST to `/api/brief/intake`. Print the returned brief URL on stdout. Exit 0. |
+| `kind: "attempted-failed"` | Print the original transcript (transcript-only) to stdout. Print the failure reason + phase to stderr as a one-line note. Exit 0 (transcript still succeeded). | Build a `TranscriptSubmission` with `frames.kind = "attempted-failed"` carrying the failure reason/phase + partial metrics. POST. The server produces a transcript-only brief; the failure surfaces in the row's `metrics` JSONB for later iteration. Exit 0. |
 
-**Recommendation: Option A.** The CLI JSON shape is explicitly frozen in v1 (planning doc decision #12 — `SCHEMA_VERSION` stays at `"1.0.0"`). Extending `TranscriptEntry` to a sum type would push that change through `format.ts`, the CLI renderer, and the existing web app's transcript handling — all in service of a feature gated to one user. Defer the entry-form migration until the CLI thin-client work (issue E), where the right JSON shape for visuals gets designed deliberately.
+Frames-pipeline failures never fail the CLI run. They downgrade the output. This matches the failure-mode contract designed for `extractFrames()` and is what makes `--with-frames` safe to flip on — worst case you get a transcript-only result with a stderr note, never a crash.
 
-## Sync vs background
+## The integration seam to `generateBrief()`
 
-The 5-minute wall-clock budget (80 MB video download + ffmpeg + ~47 vision calls) fits inside the existing SSE stream. The route already streams `cached | metadata | transcript | analyzing | saving | complete | error` events; an `analyzing` event before `extractFrames()` and another before `generateBrief()` give the UI a progress signal across the longer wait.
+The hosted intake endpoint (defined by #88) receives a `TranscriptSubmission` carrying either a transcript-only payload or a transcript-plus-augmented-string payload. The intake handler normalizes both into the same input shape for `generateBrief()`, which lives server-side in `apps/web/src/lib/summarize.ts`.
 
-**No background-job runner in v1.** Justifications:
+**Locked decision: string contract over entry contract.** The augmented transcript ships as a pre-formatted string (`[MM:SS-MM:SS] speech` + `[MM:SS] [VISUAL] content` lines) in the submission. `generateBrief()` consumes the string directly when present; otherwise it formats `TranscriptEntry[]` via `formatTranscript(..., "timestamped")` as it does today. The prompt template gains one line of guidance about `[VISUAL]` markers being on-screen content captures.
 
-- Allowlist scope (repo owner only) bounds the cost of being wrong about timeout behavior.
-- Vercel/Next.js route timeout is configurable; existing route already runs minutes on transcript+brief generation for long videos. Frames extends the wall-clock but doesn't change the fundamental shape.
-- A background-job runner adds: a job table, a worker process, status polling, SSE reconnection logic, and a "where's my brief?" page. None of that is cheap to build or operate.
-- The right time to introduce one is when (a) the feature is generally available and (b) we have evidence that 5-minute requests time out in practice. Allowlist phase produces that evidence.
-
-**Revisit when:** the feature comes off the allowlist, or any single phase consistently exceeds the route timeout, or the user wants to start a digest and walk away from the tab without losing the result.
+The alternative — extending `TranscriptEntry` to a discriminated union of `speech` and `visual` entries — *is* still happening, but for a different reason: #88 needs the sum-type to model what the CLI emits in its JSON output (`brief transcript --json`) and what flows across the submission boundary. The point of locking the string contract for `generateBrief()` specifically is that the *prompt input* doesn't need to traffic in sum-type entries — a flat formatted string is exactly the shape LLMs already consume well. Sum-type entries are useful for *programmatic* consumers (the CLI's own JSON output, the future thin-client web rendering of augmented transcripts); they're not useful for prompt construction.
 
 ## Failure-mode propagation
 
-The route's contract with `extractFrames()`:
+The CLI handler's contract with `extractFrames()`:
 
 ```typescript
-const result = withFrames && isFramesAllowed(user.email)
-  ? await extractFrames({ /* ... */ })
-  : null;
+// Pseudocode of runGenerate's frames branch.
 
-if (result?.kind === "included") {
-  const brief = await generateBrief(result.transcript, metadata, key, chapters);
-  await saveBrief({ ..., transcript: result.transcript, framesStatus: "included", metrics: result.metrics });
-} else if (result?.kind === "attempted-failed") {
-  // Frames asked for but didn't deliver. Fall back to transcript-only.
-  const brief = await generateBrief(transcript, metadata, key, chapters);
-  await saveBrief({ ..., transcript: formatTranscript(transcript), framesStatus: "attempted-failed", metrics: result.metrics });
-  // The metrics row records WHICH phase failed, so iteration can target it.
-} else {
-  // Not requested: existing path. framesStatus = 'not-requested', no metrics.
-  const brief = await generateBrief(transcript, metadata, key, chapters);
-  await saveBrief({ ..., transcript: formatTranscript(transcript), framesStatus: "not-requested" });
-}
+const frames = opts.withFrames
+  ? await extractFrames({ videoId, transcript: transcript.entries, openRouterApiKey, workDir, signal })
+  : { kind: "not-requested" as const };
+
+const submission: TranscriptSubmission = {
+  schemaVersion: SCHEMA_VERSION,
+  videoId,
+  metadata,
+  transcript: transcript.entries,           // TranscriptEntry[] — sum-type entries from #88
+  frames:
+    frames.kind === "included"        ? { kind: "included", metrics: frames.metrics }
+  : frames.kind === "attempted-failed" ? { kind: "attempted-failed", reason: frames.reason, phase: frames.phase, metrics: frames.metrics }
+  :                                      { kind: "not-requested" },
+};
+
+const result = await hostedClient.submit(submission);
+// ...handle BriefResult (see #88's design).
 ```
 
-A `generateBrief` failure (Anthropic auth, rate limit, schema violation) is *not* a frames failure — it surfaces as the existing `error` SSE event. Frames failure only ever downgrades to transcript-only; it never blocks brief generation.
-
-A second layer of resilience: even in the `attempted-failed` branch, if `transcript` happens to be empty (the route's transcript fetch came back unavailable), the existing transcript-only error path takes over. Frames don't entangle the existing error semantics.
+A `generateBrief()` failure on the server (transient LLM failure, schema violation) surfaces as `BriefResult.kind === "transient"` in the CLI. Frames failure only ever downgrades to transcript-only; it never blocks brief generation. A transcript fetch failure (`unavailable` / `transient`) short-circuits both handlers before `extractFrames()` is even attempted — frames cannot run without a transcript.
 
 ## Dependency categories and test surface
 
@@ -196,12 +194,12 @@ A second layer of resilience: even in the `attempted-failed` branch, if `transcr
 | `selection` | 1 — In-process | None | Direct unit tests. Feed synthetic scenes + chapters + transcript, assert candidate timestamps and source-priority outcomes. Covers cue-regex patterns, dedup-window collisions, and chapter-interior ratios. |
 | `weave` | 1 — In-process | None | Direct unit tests. Feed synthetic transcript + vision results, assert interleaved markdown structure. Format-preservation regression test (the spike's whitespace-squash bug) belongs here. |
 | `ffmpeg` | 2 — Local-substitutable | Prod: real `ffmpeg`. Test: record fixture stderr/PNG once, replay. | Integration test with a small checked-in fixture clip (a few seconds, MIT-licensed sample) verifies subprocess invocation. Stderr-parsing unit-tested against recorded fixtures. |
-| `download` | 2 — Local-substitutable | Prod: real `yt-dlp`. Test: skipped in CI; smoke-test target. | No CI test — networked. A `pnpm test:smoke` target hits a known video and asserts the produced `info.json` shape matches the validation schema. |
-| `anthropic` | 4 — True external | Prod: `@anthropic-ai/sdk` client. Test: in-memory adapter returning canned classifier verdicts and vision results. | The adapter exposes an internal seam: a `MessagesClient` interface with one method (`createWithImage`). Production wires the real SDK; tests inject a stub. Two adapters justify the port. |
-| `orchestrator` | Same as its constituents | Inherits from sub-modules | Tests use the in-memory anthropic adapter + recorded ffmpeg fixtures. Asserts: budget enforcement, error-to-result translation, metrics aggregation, cancellation. |
+| `download` | 2 — Local-substitutable | Prod: real `yt-dlp`. Test: skipped in CI; smoke-test target. | No CI test — networked. A `pnpm test:smoke` target hits a known video and asserts the produced `info.json` shape matches the validation schema, plus that public-only and bot-detection rejection paths return the right `FramesFailReason`. |
+| `vision` | 4 — True external | Prod: OpenRouter via `@openrouter/ai-sdk-provider`. Test: in-memory adapter returning canned classifier verdicts and vision results. | The adapter exposes an internal seam: a `VisionClient` interface with one method (`describeImage`). Production wires the real provider; tests inject a stub. |
+| `orchestrator` | Same as its constituents | Inherits from sub-modules | Tests use the in-memory vision adapter + recorded ffmpeg fixtures. Asserts: budget enforcement, error-to-result translation, metrics aggregation, cancellation. |
 | `extractFrames` (public) | Aggregate | Same | Two contract-level tests: happy path (returns `included` with sane metrics) and budget overflow (returns `attempted-failed` with `reason: "budget-exceeded"` and zero vision tokens). Other failure modes covered at the orchestrator level. |
 
-The **interface is the test surface**: callers and contract tests cross `extractFrames()`'s discriminated-union return. Internal seams (the `MessagesClient` port inside `anthropic.ts`) exist to make the deep module testable without standing up a network — they are not part of the public interface.
+The **interface is the test surface**: callers and contract tests cross `extractFrames()`'s discriminated-union return. Internal seams (the `VisionClient` port inside `vision.ts`) exist to make the deep module testable without standing up a network — they are not part of the public interface.
 
 ## Metrics surfacing
 
@@ -212,25 +210,27 @@ The **interface is the test surface**: callers and contract tests cross `extract
 - `vision` reports `visionCalls`, `visionVerbatim`, `visionSummary` (by parsing whether the response leads with `[Label]` + code-fence vs a prose paragraph — or by structured prompt-output marker, see open question), `inputTokens`/`outputTokens`, `wallClockMs`.
 - `weave` reports `wallClockMs`.
 
-`estimatedCostUsd` is computed at the model-selection layer (`packages/core/src/models.ts`) since unit pricing lives there.
+Currency-agnostic shape per [[currency-agnostic-metrics]] (the decision from #85): the metrics blob stores tokens, model, and latency only. Cost is derived on demand via `estimateCost(model, in, out)` from `@brief/core`. v1 has no dashboard for this data; the value is iteration — "which phase is slow, which dominates cost, where do we tune."
 
-The route persists the entire `FramesMetrics` blob into the brief row's `metrics` JSONB unmodified. v1 has no analytics consumer; the value is iteration data — "which phase is slow, which dominates cost, where do we tune."
+The CLI persists the entire `FramesMetrics` blob into the brief row's `metrics` JSONB unmodified via the submission. There is a known limitation: in v1, the cost values derived from CLI-side LLM calls are *self-reported* — the server cannot independently verify token counts because it didn't make the calls. The submission carries a `cost_source: "cli-reported"` discriminator. The follow-up issue on server-issued ephemeral tokens (planned) flips this to `cost_source: "server-issued"` and makes the values trustable for billing/quota purposes.
 
-## Open questions for issue D's implementation
+## Open questions for issue #87's implementation
 
 These resolve during implementation, not at design time:
 
 - **Verbatim vs summary mode reporting.** The spike's vision prompt leaves mode choice implicit (model autonomously picks). For metrics, the orchestrator needs to know which mode each result used. Either (a) parse the response shape after the fact (fragile), or (b) extend the prompt to emit a leading `<mode>verbatim</mode>` marker the adapter strips. (b) is more robust; decide during build.
-- **`workDir` lifecycle.** Route creates a tempdir per request, passes to `extractFrames`, deletes after. Or `extractFrames` manages its own and returns nothing on disk. Latter is cleaner; the spike pattern is the former. Decide during build.
+- **`workDir` lifecycle.** CLI handler creates a tempdir per request, passes to `extractFrames`, deletes after. Or `extractFrames` manages its own and returns nothing on disk. Latter is cleaner; the spike pattern is the former. Decide during build.
 - **Cost-cap behavior on overflow.** Currently the design returns `attempted-failed`. Alternative: truncate to the highest-priority `maxCandidates` and proceed. The latter still delivers value for long videos; the former is more predictable. Lean toward predictable for v1, revisit with metrics.
 - **Cancellation granularity.** `signal` aborts between phases. Inside ffmpeg/yt-dlp/concurrent vision calls, cancellation requires either `child_process` kill propagation or letting in-flight phases finish. Specify in implementation; the contract just promises "soonest possible cancellation."
-- **Whether issue #84's findings change adapter design.** If the ToS research recommends a vendor download path or rate-limited approach, the `download` adapter's internal shape adjusts; the public interface of `frames/` does not.
+- **Anti-bot detection signature matching.** The `download` adapter needs to distinguish `download-blocked-bot-detection` from other download failures via stderr signature. The patterns in [yt-dlp issue #10128](https://github.com/yt-dlp/yt-dlp/issues/10128) (notably "Sign in to confirm you're not a bot" + HTTP 429 from suspicious-IP ranges) are the starting point. The CLI's run from a residential IP makes this rare but not impossible (some networks are flagged), so the signal is still worth surfacing distinctly.
 
 ## Cross-references
 
-- Predecessor: `docs/video-frames-plan.md` — locked decisions, naming canon, requirements, constraints.
+- Predecessor (planning): `docs/video-frames-plan.md` — locked decisions, naming canon, requirements, constraints.
 - Spike: `continue-video-frames.md` — 4-round investigation, dead ends, validated pipeline.
 - Reference implementation: `spikes/video-frames-pipeline/pipeline.mjs` — single-file 8-phase orchestrator.
-- Analogous prior design: `docs/architecture/transcript-cli.md` — same module-landscape format, same `@brief/core` package.
-- Dependencies: #84 (ToS posture), #85 (schema), #86 (model selection).
+- ToS / egress driver: `docs/youtube-tos-research.md` — why this pipeline runs CLI-side, not server-side.
+- CLI integration: `docs/architecture/cli-thin-client.md` (#88) — the auth + submission shape this module's output flows into.
+- Model-selection layer: `docs/architecture/model-selection.md` (#86) — provides `CLASSIFY_MODEL` and `VISION_MODEL`.
+- Schema foundation: PR #93 — `transcript`, `metrics`, `frames_status` columns on `digests`.
 - Downstream consumer: #36 ("Ask this video" chat) reads augmented transcripts from the brief row without doing its own vision work.

--- a/docs/architecture/video-frames.md
+++ b/docs/architecture/video-frames.md
@@ -58,13 +58,13 @@ What the design fixes versus the spike:
 | **`apps/cli/src/handlers/runTranscript.ts`** (new) | The `transcript` subcommand handler. Calls `fetchTranscript` then optionally `extractFrames`. Renders to stdout. |
 | **`apps/cli/src/handlers/runGenerate.ts`** (new) | The `generate` subcommand handler. Same prelude as `runTranscript`, then builds a submission and POSTs via `HostedClient.submit()`. |
 
-The DB columns (`transcript`, `framesStatus`, `metrics`) and migration shipped in #85 (PR #93). The model-selection layer (`packages/core/src/models.ts`) shipped in #86 (PR #92). The CLI auth + submission shape ship in #88. This issue (#87) lands the frames module and its two CLI handler integrations on top of that foundation.
+The DB columns (`transcript`, `frames_status`, `metrics`) and migration shipped in #85 (PR #93). The model-selection layer (`packages/core/src/models.ts`) shipped in #86 (PR #92). The CLI auth + submission shape ship in #88. This issue (#87) lands the frames module and its two CLI handler integrations on top of that foundation.
 
 ### `apps/web` integration points
 
 **None for #87.** The web app's brief route remains transcript-only. There is no "include video frames" checkbox in the URL form; there is no `isFramesAllowed` allowlist; there is no `framesQuotaRemaining` rate-limit gate. All of that scope existed under the prior server-side-orchestration design and is removed by the CLI-runs-locally pivot.
 
-The hosted intake endpoint (`POST /api/brief/intake`, defined by #88) receives augmented transcripts from the CLI without distinguishing them from transcript-only submissions at the routing layer — the discriminator is on the request body's `frames` field. The brief route writes `framesStatus = 'included'` for augmented submissions and `'not-requested'` for plain ones; the existing `framesStatus = 'attempted-failed'` value carries through when the CLI ships a failure result.
+The hosted intake endpoint (`POST /api/brief/intake`, defined by #88) receives augmented transcripts from the CLI without distinguishing them from transcript-only submissions at the routing layer — the discriminator is on the request body's `frames` field. The brief route writes `frames_status = 'included'` for augmented submissions and `'not-requested'` for plain ones; the existing `frames_status = 'attempted-failed'` value carries through when the CLI ships a failure result.
 
 ## Public interface
 
@@ -212,7 +212,7 @@ The **interface is the test surface**: callers and contract tests cross `extract
 
 Currency-agnostic shape per [[currency-agnostic-metrics]] (the decision from #85): the metrics blob stores tokens, model, and latency only. Cost is derived on demand via `estimateCost(model, in, out)` from `@brief/core`. v1 has no dashboard for this data; the value is iteration — "which phase is slow, which dominates cost, where do we tune."
 
-The CLI persists the entire `FramesMetrics` blob into the brief row's `metrics` JSONB unmodified via the submission. There is a known limitation: in v1, the cost values derived from CLI-side LLM calls are *self-reported* — the server cannot independently verify token counts because it didn't make the calls. The submission carries a `cost_source: "cli-reported"` discriminator. The follow-up issue on server-issued ephemeral tokens (planned) flips this to `cost_source: "server-issued"` and makes the values trustable for billing/quota purposes.
+The CLI persists the entire `FramesMetrics` blob into the brief row's `metrics` JSONB unmodified via the submission. There is a known limitation: in v1, the cost values derived from CLI-side LLM calls are *self-reported* — the server cannot independently verify token counts because it didn't make the calls. The `FramesMetrics` blob includes a `costSource: "cli-reported"` field (defined on `FramesMetricsSchema` in `docs/architecture/cli-thin-client.md`). The follow-up issue on server-issued ephemeral tokens (planned) broadens this to `costSource: "server-issued"` and makes the values trustable for billing/quota purposes.
 
 ## Open questions for issue #87's implementation
 

--- a/docs/video-frames-plan.md
+++ b/docs/video-frames-plan.md
@@ -41,9 +41,9 @@ Brief's digest pipeline feeds the LLM only the spoken transcript of a video. For
 
 1. **v1 launches via the CLI only.** Web app stays transcript-only. The egress constraint (see [Constraints](#constraints--boundaries)) makes server-side frame extraction non-functional in production; pushing the pipeline to the user's machine via the CLI is the architectural response.
 2. **Auth gating, not allowlist gating.** `brief generate` requires `brief login` (WorkOS device flow). Anyone signed in can run augmented briefs; quota/abuse are gated by per-account rate limits (v1: per-day cap on `generate` submissions), not by an email allowlist.
-3. **Graceful-degrade failure mode** with `framesStatus` markers. CLI never crashes on a frames failure — it falls back to transcript-only output and surfaces the failure reason in stderr / metrics.
+3. **Graceful-degrade failure mode** with `frames_status` markers. CLI never crashes on a frames failure — it falls back to transcript-only output and surfaces the failure reason in stderr / metrics.
 4. **Single `transcript` JSONB column** on `digests`. Content varies by submission: speech-only when `generate` is invoked without `--with-frames`; augmented (speech + `[VISUAL]` markers) when invoked with the flag.
-5. **Single `framesStatus` enum:** `'included' | 'attempted-failed' | 'not-requested'`. Three values capture intent and outcome together.
+5. **Single `frames_status` enum:** `'included' | 'attempted-failed' | 'not-requested'`. Three values capture intent and outcome together.
 6. **Replace on regenerate.** One brief per `(user, video)`. Submitting a new `generate` for the same video overwrites the previous brief.
 7. **Pickai foundational, landed in #86.** `@brief/core` exports `DIGEST_MODEL`, `CLASSIFY_MODEL`, `VISION_MODEL`. Discover-candidates pipeline is in `packages/core/scripts/`. Locked picks documented in `docs/llm-model-selection.md`.
 8. **Cost cap 100 candidates** per video as v1 default. Capture per-brief metrics in `metrics` JSONB column for data-driven iteration.

--- a/docs/video-frames-plan.md
+++ b/docs/video-frames-plan.md
@@ -1,138 +1,98 @@
 # Video Frames Plan
 
-> **Status:** Decided. Ready for issue filing.
-> **Last updated:** 2026-05-10
+> **Status:** Decided. Foundational issues (#84, #85, #86, #91) landed. Architectural pivot 2026-05-11 moves the frames pipeline to the CLI; #87 and #88 are reshaped accordingly.
+> **Last updated:** 2026-05-11
 > **Predecessor:** `continue-video-frames.md` (4-round technical spike)
+> **Companion docs:** `docs/architecture/video-frames.md` (#87), `docs/architecture/cli-thin-client.md` (#88), `docs/youtube-tos-research.md` (#84), `docs/architecture/model-selection.md` (#86)
 
 ## Problem / Opportunity
 
-Brief's digest pipeline feeds the LLM only the spoken transcript of a video.
-For visually-driven tutorials (slides, dashboards, IDE recordings, ad creative,
-on-screen prompts, brainstorming tables), this systematically loses information
-that's visible but never spoken — exactly the high-value detail viewers care
-about. A 4-round technical spike proved a pipeline that extracts frames at
-meaningful moments, runs them through a vision model, and weaves the results
-into the transcript produces dramatically richer digests at ~$0.50/video. The
-A/B comparison on a real tutorial showed the augmented digest capturing exact
-pricing tables, rejected brainstorm names, Reddit ad creative copy, MRR numbers,
-and verbatim copy-pasteable system prompts — none in the transcript.
+Brief's digest pipeline feeds the LLM only the spoken transcript of a video. For visually-driven tutorials (slides, dashboards, IDE recordings, ad creative, on-screen prompts, brainstorming tables), this systematically loses information that's visible but never spoken — exactly the high-value detail viewers care about. A 4-round technical spike proved a pipeline that extracts frames at meaningful moments, runs them through a vision model, and weaves the results into the transcript produces dramatically richer digests. The A/B comparison on a real tutorial showed the augmented digest capturing exact pricing tables, rejected brainstorm names, Reddit ad creative copy, MRR numbers, and verbatim copy-pasteable system prompts — none in the transcript.
 
 ## Target Users
 
-- **Initial dogfooding (allowlist phase):** repo owner only.
-- **Eventual rollout:** all brief users.
-- **Downstream consumers:** "Ask this video" chat (#36), digest renderer,
-  future CLI thin-client.
+- **v1 launch surface:** brief CLI users (anyone who's signed in with WorkOS via `brief login`). The web app stays transcript-only in v1.
+- **Eventual rollout:** CLI users are the only path to augmented briefs in the foreseeable future, by architectural necessity (see [Constraints](#constraints--boundaries)). The web app may grow a "view augmented brief" rendering surface but never a "generate augmented brief" trigger.
+- **Downstream consumers:** "Ask this video" chat (#36) reads augmented transcripts from the brief row regardless of which client produced them.
 
 ## Core Requirements
 
 **Must-have:**
 
-- Web app digest pipeline picks up augmented input (transcript + interleaved
-  visual descriptions) when an allowlisted user opts in via a per-digest
-  checkbox on the URL input form. No other UI changes.
-- Frame selection pipeline: ffmpeg scene detection at threshold 0.2 + chapter
-  starts + chapter-interior 33%/67% + transcript-cue regex + paired cue+0/cue+3
-  anchors + Haiku 4.5 classifier filter + Sonnet 4.6 vision (verbatim/summary
-  mode chosen per-frame by the model).
-- Failure modes graceful: pipeline failure → fall back to transcript-only;
-  brief is still produced; row marked `framesStatus = 'attempted-failed'`.
-- Cost cap: max 100 candidates per video, v1 default. Revisit with metrics
-  data.
-- Augmented transcript stored on the brief row (in `transcript` column).
-- Per-brief generation metrics stored on the brief row (in `metrics` JSONB
-  column).
-- Foundational work parallel-grabbable: transcript schema, pickai, and ToS
-  research can be picked up by agents simultaneously, in any order.
+- **Frames pipeline lives in `@brief/core/frames/` and is invoked exclusively by the CLI.** No server-side invocation of `extractFrames()` exists or is planned.
+- **CLI subcommands** expose frames as an opt-in flag:
+  - `brief transcript <url> --with-frames` — runs the local pipeline, prints the augmented transcript to stdout. No server contact.
+  - `brief generate <url> --with-frames` — runs the local pipeline, submits the result to brief's hosted intake endpoint, returns the brief URL.
+- **Frame selection pipeline:** ffmpeg scene detection at threshold 0.2 + chapter starts + chapter-interior 33%/67% + transcript-cue regex + paired cue+0/cue+3 anchors + classifier filter + vision pass (verbatim/summary mode chosen per-frame by the model).
+- **Model choices** come from `@brief/core`'s `CLASSIFY_MODEL` and `VISION_MODEL` constants (locked picks in `docs/llm-model-selection.md`); no hardcoded model IDs in `frames/`.
+- **Failure modes graceful:** pipeline failure → CLI downgrades to bare-transcript output (`transcript`) or transcript-only submission (`generate`); brief is still produced; row marked `frames_status = 'attempted-failed'`.
+- **Cost cap:** max 100 candidates per video, v1 default. Revisit with metrics data.
+- **Augmented transcript stored on the brief row** in the `transcript` JSONB column when shipped via `generate`. Per-brief generation metrics stored in the `metrics` JSONB column.
+- **Public-only video acceptance.** The `download` adapter pre-flight-rejects private, unlisted, age-gated, and login-required videos. No cookie-jar bypass.
+- **Transient video bytes.** Downloaded video bytes deleted in a `finally` block on every code path through `download`.
 
 **Nice-to-have (deferred):**
 
-- CLI surface for video frames — deferred to the CLI thin-client work.
-- Reactive two-pass extraction for the chat consumer — owned by future #36
-  follow-up.
-- Refinements to cue alignment, classifier prompt, vision prompt — left for
-  iteration after first ship.
+- Server-issued ephemeral OpenRouter tokens to unify cost/quota accounting. v1 uses the user's own OpenRouter key from CLI env. Follow-up issue tracks the unification.
+- Web-app rendering of augmented transcripts (showing `[VISUAL]` markers alongside speech in the brief view). Owned by a separate UI ticket.
+- PKCE-loopback auth flow as an alternative to WorkOS device flow. v1 ships device flow only; the gh/gcloud-style "PKCE default, device fallback" pattern is a v2 enhancement to #88.
 
 ## Key Decisions Made
 
-1. **v1 = web app digest pipeline only.** No CLI changes in v1. CLI keeps
-   today's behavior; thin-client transition is separate (issue E).
-2. **Opt-in per-digest** via checkbox on the URL form. Default off.
-3. **Allowlist gating** reuses the existing `isEmailAllowed` pattern (or a
-   parallel `isFramesAllowed` constant).
-4. **Graceful-degrade failure mode** with `framesStatus` markers. Existing
-   `RetryPolicy` shape reused for retries.
-5. **Single `transcript` column** on briefs — no separate `augmentedTranscript`.
-   Content varies by run: speech-only when not requested or failed; interleaved
-   with visuals when requested and succeeded.
-6. **Single `framesStatus` enum:** `'included' | 'attempted-failed' |
-   'not-requested'`. Three values capture intent and outcome together.
-7. **Replace on regenerate.** One brief per `(user, video)`. Toggling the
-   checkbox and regenerating overwrites the previous brief.
-8. **Pickai foundational, not deferred.** Build a `discover-candidates.ts` for
-   brief modeled on the prior art in `champ-sage/` and `review-kit/`.
-   Centralize all model choices in `packages/core/src/models.ts`. Migrate the
-   existing `summarize.ts:211` hardcode through the same module — opportunistic
-   cleanup.
-9. **Cost cap 100 candidates** per video as v1 default. Capture per-brief
-   metrics in `metrics` JSONB column for data-driven iteration.
-10. **YouTube ToS posture as a deep-research issue.** Output is a research doc,
-    not code. Findings inform whether/how the feature ships and what
-    user-facing ToS changes might be needed on brief itself.
-11. **Naming canon:**
+1. **v1 launches via the CLI only.** Web app stays transcript-only. The egress constraint (see [Constraints](#constraints--boundaries)) makes server-side frame extraction non-functional in production; pushing the pipeline to the user's machine via the CLI is the architectural response.
+2. **Auth gating, not allowlist gating.** `brief generate` requires `brief login` (WorkOS device flow). Anyone signed in can run augmented briefs; quota/abuse are gated by per-account rate limits (v1: per-day cap on `generate` submissions), not by an email allowlist.
+3. **Graceful-degrade failure mode** with `framesStatus` markers. CLI never crashes on a frames failure — it falls back to transcript-only output and surfaces the failure reason in stderr / metrics.
+4. **Single `transcript` JSONB column** on `digests`. Content varies by submission: speech-only when `generate` is invoked without `--with-frames`; augmented (speech + `[VISUAL]` markers) when invoked with the flag.
+5. **Single `framesStatus` enum:** `'included' | 'attempted-failed' | 'not-requested'`. Three values capture intent and outcome together.
+6. **Replace on regenerate.** One brief per `(user, video)`. Submitting a new `generate` for the same video overwrites the previous brief.
+7. **Pickai foundational, landed in #86.** `@brief/core` exports `DIGEST_MODEL`, `CLASSIFY_MODEL`, `VISION_MODEL`. Discover-candidates pipeline is in `packages/core/scripts/`. Locked picks documented in `docs/llm-model-selection.md`.
+8. **Cost cap 100 candidates** per video as v1 default. Capture per-brief metrics in `metrics` JSONB column for data-driven iteration.
+9. **YouTube ToS posture as a deep-research issue, landed in #84.** Yellow verdict: CLI-side egress is the architectural response that turns the yellow signal into a clean ship.
+10. **Naming canon:**
     - User-facing feature: "video frames"
-    - CLI flag (when CLI work happens): `--with-frames`
+    - CLI flag: `--with-frames` (on `transcript` and `generate`)
     - Module path: `packages/core/src/frames/`
     - Public function: `extractFrames()` returning `FramesResult`
-    - DB columns: `transcript`, `framesStatus`, `metrics`
-    - Web checkbox label: "Include video frames"
-12. **CLI JSON shape unchanged in v1.** `SCHEMA_VERSION` stays at `"1.0.0"`.
-    No new fields, no new `frames` block. The augmented apparatus lives
-    server-side only. CLI thin-client work (issue E) is where any future API
-    response shape gets designed.
+    - DB columns: `transcript`, `frames_status`, `metrics`
+    - No web checkbox — there is no web UI surface for frames in v1
+11. **CLI JSON shape bumps to `SCHEMA_VERSION = "2.0.0"`** as part of #88. `TranscriptEntry` becomes a discriminated union (`speech` | `visual`) to model augmented transcripts in machine-readable form. The bump happens once, in #88, and is reused by #87.
+12. **Single hosted intake endpoint, `POST /api/brief/intake`** (defined in #88), accepts both transcript-only and augmented submissions via a discriminated `frames` field on the body. The endpoint runs `generateBrief()` synchronously and returns the brief URL.
+13. **Vendor-mediated video-bytes download was evaluated and rejected.** No ethical vendor (under the "publicly owns the role" bar) cleanly delivers MP4-bytes-for-YouTube; see the [[frames-vendor-research]] memory and the architectural-pivot session notes. CLI-side residential-IP egress is the locked path.
 
 ## Constraints / Boundaries
 
-- **Cost:** each fresh augmented digest costs ~$0.50–$0.60 at Sonnet 4.6.
-  Cached digests free.
-- **Latency:** ~5 minutes wall-clock per fresh augmented digest including
-  video download.
-- **TOS:** video-byte downloads via yt-dlp are more aggressive than today's
-  transcript-only downloads. Issue A clarifies posture before frames can ship.
-- **Allowlist phase:** only the repo owner sees the checkbox; no other users
-  are exposed to cost, behavior changes, or schema-driven UI surprises.
-- **Schema additions are additive.** No breaking changes to the CLI's existing
-  `--json` output, existing API responses, or existing DB clients.
+- **Egress constraint (load-bearing).** Server-side yt-dlp from Vercel is reliably blocked by YouTube's anti-bot enforcement; #84's research established this is the dominant operational risk for any cloud-hosted invocation. CLI-side egress (the user's residential IP) sidesteps the constraint by structurally not being a datacenter IP. **This is why #87 lives in the CLI.**
+- **Cost (CLI user pays in v1).** Each fresh augmented digest's LLM cost is paid by the CLI user's own OpenRouter account. Server-side brief generation cost is paid by brief's account. The split is temporary; the follow-up issue on server-issued tokens unifies billing.
+- **Latency.** ~5 minutes wall-clock per fresh augmented digest including video download on a typical residential connection. The CLI's `generate` request's server-side phase is bounded by brief generation alone (transcript already in hand at submission time) — typically 5–15 s.
+- **ToS.** CLI-side egress + transient bytes + public-only acceptance + no-cookies matches `docs/youtube-tos-research.md` §8.2's ship conditions for the allowlist phase; under the new architecture the "allowlist" is now "anyone signed in via `brief login`" since the per-user egress moves the operational risk off brief's infrastructure entirely. The published ToS at `/terms` (a separate gap closure) remains worth doing for user-notice and revocability reasons, but is no longer blocking the frames feature on the egress-friction side.
+- **Schema additions are additive within `2.0.0`.** The bump from `1.0.0` happens once in #88. Inside `2.0.0`, all subsequent additions to the submission body must be optional or have server-side defaults.
 
 ## Issue Breakdown
 
-| # | Title | Depends on | Parallel-grabbable? |
+| # | Title | Status | Notes |
 |---|---|---|---|
-| A | Research: YouTube ToS posture for video downloads | — | Yes (research, doc deliverable) |
-| B | Brief schema foundations: add `transcript` + `framesStatus` + `metrics` columns | — | Yes (migration + types) |
-| C | Model selection layer: pickai + discover-candidates script + migrate existing digest hardcode | — | Yes (refactor + new tooling) |
-| D | Add video frames to brief generation | A, B, C landed | No (the integration step) |
-| E | CLI thin-client transition | — | Yes (orthogonal, anytime) |
+| #84 | Research: YouTube ToS posture for video downloads | **Done** (PR #89) | Yellow verdict. Findings drove the architectural pivot in this session. |
+| #85 | Brief schema foundations: `transcript` + `frames_status` + `metrics` columns | **Done** (PR #93) | Migration 009 applied; 30 existing rows backfilled. |
+| #86 | Model selection layer: pickai + discover-candidates + migrate existing hardcode | **Done** (PR #92) | `DIGEST_MODEL`, `CLASSIFY_MODEL`, `VISION_MODEL` exports. OpenRouter as production transport. |
+| #87 | Add video frames to brief generation (CLI-side pipeline) | **Reshaped** by pivot | Now depends on #88's auth + intake endpoint landing first. Frames module lives in `@brief/core/frames/` and is invoked by the CLI. No web-app integration. |
+| #88 | CLI thin-client transition | **Reshaped** by pivot | Scope grows: was "CLI authenticates and submits briefs"; now also owns the intake-endpoint API contract and the `TranscriptEntry` sum-type migration. Must land before #87. |
+| #90 | Evalite validation against locked role-model picks | **Filed** | Quality-improvement layer. Most-important thing to validate: the Anthropic `ifbench` anomaly. Doesn't block #87. |
+| #91 | Migrate `apps/web` transcript fetching to `@brief/core` | **Done** (bundled into PR #93) | |
 
-Three agents can simultaneously work A + B + C. A fourth can pick up E whenever.
-Only D has to wait.
+**Sequencing:** #88 → #87. #90 is parallel-grabbable at any time. The follow-up issue on server-issued OpenRouter tokens gets filed after #88 lands and the CLI-side flow proves out.
 
 ## Open Questions
 
-- None at the design level. Implementation specifics (Zod schemas, pickai
-  `recommend()` criteria, exact UI placement of the checkbox) get worked out
-  during execution of each issue.
-- **Conditional:** issue A's research output may surface mitigations the
-  frames feature has to honor (rate limiting, user consent UI, etc.). Those
-  feed into issue D's scope when known.
+- None at the design level. Architectural pivot (CLI-side pipeline + thin-client transition) is locked. Module boundaries are documented in the companion architecture docs.
+- **Implementation-time decisions** (deferred to each issue's build pass): verbatim-vs-summary metrics surfacing, `workDir` lifecycle ownership, cost-cap-overflow behavior, cancellation granularity, anti-bot signature matching in the `download` adapter. All listed in the open-questions sections of `docs/architecture/video-frames.md` and `docs/architecture/cli-thin-client.md`.
 
 ## References
 
-- `continue-video-frames.md` — technical spike doc (4 rounds complete) including
-  the reference implementation at `spikes/video-frames-pipeline/pipeline.mjs`
-  and concrete A/B output at `spikes/brief-ab-test/`.
-- Pickai prior art: `~/dev/niftymonkey/champ-sage/scripts/discover-candidates.ts`,
-  `~/dev/niftymonkey/review-kit/scripts/discover-candidates.ts`.
-- Related GitHub issues: #36 (downstream "Ask this video" chat consumer),
-  #73 (Postgres cache), #77 (transcript fetcher migration — analogous
-  architectural pattern).
+- `continue-video-frames.md` — technical spike doc (4 rounds complete) including the reference implementation at `spikes/video-frames-pipeline/pipeline.mjs` and concrete A/B output at `spikes/brief-ab-test/`.
+- `docs/architecture/video-frames.md` — #87 design doc, CLI-runs-locally shape.
+- `docs/architecture/cli-thin-client.md` — #88 design doc, auth + intake + submission shape.
+- `docs/architecture/model-selection.md` — #86 design doc.
+- `docs/llm-model-selection.md` — operational notes on the model-selection pipeline; locked picks.
+- `docs/youtube-tos-research.md` — #84 deliverable; yellow verdict + ship conditions.
+- Related GitHub issues: #36 (downstream "Ask this video" chat consumer), #73 (Postgres cache).
+- WorkOS CLI Auth docs (for #88's auth flow): https://workos.com/docs/authkit/cli-auth


### PR DESCRIPTION
## Summary

- Documents the architectural pivot for the video-frames feature: pipeline moves from server-side orchestration to CLI-side. Driver: #84's egress findings (server-side YouTube downloads from Vercel are reliably blocked by anti-bot enforcement) + vendor research found no ethical vendor cleanly delivering MP4-bytes-for-YouTube under the project's ethical bar.
- New design doc `docs/architecture/cli-thin-client.md` (#88) — locks industry-standard picks (WorkOS CLI Auth device flow, shared Zod via `@brief/core`, `schemaVersion` discriminator). Subcommand surface: `login`/`logout`/`whoami`/`transcript`/`generate`. Includes the `TranscriptEntry` sum-type migration and `SCHEMA_VERSION` bump to `2.0.0`. #88 now blocks #87 instead of being parallel.
- `docs/architecture/video-frames.md` rewritten for CLI invocation; `docs/video-frames-plan.md` refreshed to supersede prior locked decisions.
- Carry-ins: `.gitignore` adds `spikes/`; `apps/web/next-env.d.ts` synced to Next.js's current `.next/dev/types/` convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added architecture documentation for CLI authentication and integration with hosted service
  * Updated video frames extraction documentation to clarify local-only processing via CLI

* **Chores**
  * Updated project configuration files

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niftymonkey/brief/pull/95)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->