### PR TITLE
feat: CLI thin-client + bearer-token intake endpoint (#88)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -15,7 +15,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@brief/core": "workspace:*"
+    "@brief/core": "workspace:*",
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "@types/node": "^20.19.26",

--- a/apps/cli/src/auth.test.ts
+++ b/apps/cli/src/auth.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from "vitest";
+import { createAuthFlow } from "./auth";
+import type { Transport } from "./hosted-client";
+
+const WORKOS_URL = "https://api.test.workos.com";
+const CLIENT_ID = "client_test_abc";
+
+const sampleDeviceCode = {
+  device_code: "DEVICE_CODE_XYZ",
+  user_code: "ABCD-1234",
+  verification_uri: "https://example.com/device",
+  verification_uri_complete: "https://example.com/device?user_code=ABCD-1234",
+  expires_in: 300,
+  interval: 5,
+};
+
+const sampleTokens = {
+  access_token: "access_xxx",
+  refresh_token: "refresh_yyy",
+  user: {
+    id: "user_01H",
+    email: "user@example.com",
+  },
+};
+
+interface StubCall {
+  url: string;
+  init?: RequestInit;
+}
+
+type StubPlan = {
+  status?: number;
+  body?: unknown;
+  throw?: Error;
+};
+
+function createStubTransport(plans: StubPlan[]): Transport & { calls: StubCall[] } {
+  const calls: StubCall[] = [];
+  let i = 0;
+  return {
+    calls,
+    async fetch(input, init) {
+      const url = typeof input === "string" ? input : input.toString();
+      calls.push({ url, init });
+      const plan = plans[i++];
+      if (!plan) throw new Error(`No stub plan for call #${i}`);
+      if (plan.throw) throw plan.throw;
+      const status = plan.status ?? 200;
+      const body = plan.body !== undefined ? JSON.stringify(plan.body) : null;
+      const headers = new Headers();
+      if (plan.body !== undefined) headers.set("content-type", "application/json");
+      return new Response(body, { status, headers });
+    },
+  };
+}
+
+const sleepNoop = async () => {};
+
+describe("AuthFlow.login", () => {
+  it("returns ok with tokens when device flow completes on first poll", async () => {
+    const transport = createStubTransport([
+      { status: 200, body: sampleDeviceCode },
+      { status: 200, body: sampleTokens },
+    ]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+      sleep: sleepNoop,
+    });
+
+    const result = await flow.login();
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.tokens.accessToken).toBe("access_xxx");
+      expect(result.tokens.refreshToken).toBe("refresh_yyy");
+      expect(result.tokens.userId).toBe("user_01H");
+      expect(result.tokens.email).toBe("user@example.com");
+      expect(result.tokens.expiresAt).toBeGreaterThan(Date.now());
+    }
+  });
+
+  it("polls authorize/device endpoint with client_id", async () => {
+    const transport = createStubTransport([
+      { status: 200, body: sampleDeviceCode },
+      { status: 200, body: sampleTokens },
+    ]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+      sleep: sleepNoop,
+    });
+    await flow.login();
+    expect(transport.calls[0]?.url).toBe(`${WORKOS_URL}/user_management/authorize/device`);
+    const body = JSON.parse(transport.calls[0]?.init?.body as string);
+    expect(body.client_id).toBe(CLIENT_ID);
+  });
+
+  it("polls authenticate endpoint with the correct grant_type and device_code", async () => {
+    const transport = createStubTransport([
+      { status: 200, body: sampleDeviceCode },
+      { status: 200, body: sampleTokens },
+    ]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+      sleep: sleepNoop,
+    });
+    await flow.login();
+    expect(transport.calls[1]?.url).toBe(`${WORKOS_URL}/user_management/authenticate`);
+    const body = JSON.parse(transport.calls[1]?.init?.body as string);
+    expect(body.grant_type).toBe("urn:ietf:params:oauth:grant-type:device_code");
+    expect(body.device_code).toBe("DEVICE_CODE_XYZ");
+    expect(body.client_id).toBe(CLIENT_ID);
+  });
+
+  it("invokes onCode with user_code and verification URIs", async () => {
+    let captured: {
+      userCode: string;
+      verificationUri: string;
+      verificationUriComplete?: string;
+    } | null = null;
+    const transport = createStubTransport([
+      { status: 200, body: sampleDeviceCode },
+      { status: 200, body: sampleTokens },
+    ]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+      sleep: sleepNoop,
+      onCode: (info) => {
+        captured = info;
+      },
+    });
+    await flow.login();
+    expect(captured).toEqual({
+      userCode: "ABCD-1234",
+      verificationUri: "https://example.com/device",
+      verificationUriComplete: "https://example.com/device?user_code=ABCD-1234",
+    });
+  });
+
+  it("retries when server reports authorization_pending", async () => {
+    const transport = createStubTransport([
+      { status: 200, body: sampleDeviceCode },
+      { status: 400, body: { error: "authorization_pending" } },
+      { status: 400, body: { error: "authorization_pending" } },
+      { status: 200, body: sampleTokens },
+    ]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+      sleep: sleepNoop,
+    });
+    const result = await flow.login();
+    expect(result.kind).toBe("ok");
+    expect(transport.calls).toHaveLength(4);
+  });
+
+  it("respects slow_down by increasing the poll interval", async () => {
+    const sleeps: number[] = [];
+    const transport = createStubTransport([
+      { status: 200, body: { ...sampleDeviceCode, interval: 2 } },
+      { status: 400, body: { error: "slow_down" } },
+      { status: 200, body: sampleTokens },
+    ]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+    const result = await flow.login();
+    expect(result.kind).toBe("ok");
+    expect(sleeps[0]).toBe(2000);
+    expect(sleeps[1]).toBeGreaterThan(2000);
+  });
+
+  it("returns expired when server reports expired_token", async () => {
+    const transport = createStubTransport([
+      { status: 200, body: sampleDeviceCode },
+      { status: 400, body: { error: "expired_token" } },
+    ]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+      sleep: sleepNoop,
+    });
+    const result = await flow.login();
+    expect(result.kind).toBe("expired");
+  });
+
+  it("returns denied when user rejects the authorization", async () => {
+    const transport = createStubTransport([
+      { status: 200, body: sampleDeviceCode },
+      { status: 400, body: { error: "access_denied" } },
+    ]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+      sleep: sleepNoop,
+    });
+    const result = await flow.login();
+    expect(result.kind).toBe("denied");
+  });
+
+  it("returns transient when device-code request fails (network)", async () => {
+    const transport = createStubTransport([{ throw: new Error("ENETDOWN") }]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+      sleep: sleepNoop,
+    });
+    const result = await flow.login();
+    expect(result.kind).toBe("transient");
+  });
+
+  it("returns transient when authenticate request fails (network)", async () => {
+    const transport = createStubTransport([
+      { status: 200, body: sampleDeviceCode },
+      { throw: new Error("ECONNRESET") },
+    ]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+      sleep: sleepNoop,
+    });
+    const result = await flow.login();
+    expect(result.kind).toBe("transient");
+  });
+
+  it("returns transient when device-code response is malformed", async () => {
+    const transport = createStubTransport([
+      { status: 200, body: { foo: "bar" } },
+    ]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+      sleep: sleepNoop,
+    });
+    const result = await flow.login();
+    expect(result.kind).toBe("transient");
+  });
+
+  it("returns transient on 5xx during polling", async () => {
+    const transport = createStubTransport([
+      { status: 200, body: sampleDeviceCode },
+      { status: 503, body: {} },
+    ]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+      sleep: sleepNoop,
+    });
+    const result = await flow.login();
+    expect(result.kind).toBe("transient");
+  });
+});

--- a/apps/cli/src/auth.ts
+++ b/apps/cli/src/auth.ts
@@ -28,6 +28,7 @@ const PollErrorSchema = z.object({
 const DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 const DEFAULT_EXPIRES_IN_SEC = 5 * 60;
 const DEFAULT_WORKOS_BASE = "https://api.workos.com";
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
 
 export interface DeviceCodeInfo {
   userCode: string;
@@ -51,6 +52,7 @@ export interface AuthFlowOptions {
   transport?: Transport;
   onCode?: (info: DeviceCodeInfo) => void;
   sleep?: (ms: number) => Promise<void>;
+  requestTimeoutMs?: number;
 }
 
 export function createAuthFlow(opts: AuthFlowOptions): AuthFlow {
@@ -58,6 +60,7 @@ export function createAuthFlow(opts: AuthFlowOptions): AuthFlow {
   const base = (opts.workosBaseUrl ?? DEFAULT_WORKOS_BASE).replace(/\/$/, "");
   const sleep =
     opts.sleep ?? ((ms: number) => new Promise<void>((res) => setTimeout(res, ms)));
+  const requestTimeoutMs = opts.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
 
   function transientErr(cause: unknown, message: string): AuthFlowResult {
     const causeStr = cause instanceof Error ? cause.message : String(cause);
@@ -79,6 +82,7 @@ export function createAuthFlow(opts: AuthFlowOptions): AuthFlow {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ client_id: opts.clientId }),
+        signal: AbortSignal.timeout(requestTimeoutMs),
       });
     } catch (err) {
       return { kind: "throw" as const, err };
@@ -106,6 +110,7 @@ export function createAuthFlow(opts: AuthFlowOptions): AuthFlow {
           client_id: opts.clientId,
           device_code: deviceCode,
         }),
+        signal: AbortSignal.timeout(requestTimeoutMs),
       });
     } catch (err) {
       return { kind: "throw" as const, err };

--- a/apps/cli/src/auth.ts
+++ b/apps/cli/src/auth.ts
@@ -1,0 +1,207 @@
+import { z } from "zod";
+import type { Tokens } from "./credentials";
+import { defaultTransport, type Transport } from "./hosted-client";
+
+const DeviceCodeResponseSchema = z.object({
+  device_code: z.string(),
+  user_code: z.string(),
+  verification_uri: z.string(),
+  verification_uri_complete: z.string().optional(),
+  expires_in: z.number(),
+  interval: z.number(),
+});
+
+const TokenResponseSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string(),
+  expires_in: z.number().optional(),
+  user: z.object({
+    id: z.string(),
+    email: z.string(),
+  }),
+});
+
+const PollErrorSchema = z.object({
+  error: z.string(),
+});
+
+const DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+const DEFAULT_EXPIRES_IN_SEC = 5 * 60;
+const DEFAULT_WORKOS_BASE = "https://api.workos.com";
+
+export interface DeviceCodeInfo {
+  userCode: string;
+  verificationUri: string;
+  verificationUriComplete?: string;
+}
+
+export type AuthFlowResult =
+  | { kind: "ok"; tokens: Tokens }
+  | { kind: "expired"; message: string }
+  | { kind: "denied"; message: string }
+  | { kind: "transient"; cause: string; message: string };
+
+export interface AuthFlow {
+  login(): Promise<AuthFlowResult>;
+}
+
+export interface AuthFlowOptions {
+  clientId: string;
+  workosBaseUrl?: string;
+  transport?: Transport;
+  onCode?: (info: DeviceCodeInfo) => void;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export function createAuthFlow(opts: AuthFlowOptions): AuthFlow {
+  const transport = opts.transport ?? defaultTransport;
+  const base = (opts.workosBaseUrl ?? DEFAULT_WORKOS_BASE).replace(/\/$/, "");
+  const sleep =
+    opts.sleep ?? ((ms: number) => new Promise<void>((res) => setTimeout(res, ms)));
+
+  function transientErr(cause: unknown, message: string): AuthFlowResult {
+    const causeStr = cause instanceof Error ? cause.message : String(cause);
+    return { kind: "transient", cause: causeStr, message };
+  }
+
+  async function safeJson(res: Response): Promise<unknown> {
+    try {
+      return await res.json();
+    } catch {
+      return null;
+    }
+  }
+
+  async function requestDeviceCode() {
+    let res: Response;
+    try {
+      res = await transport.fetch(`${base}/user_management/authorize/device`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ client_id: opts.clientId }),
+      });
+    } catch (err) {
+      return { kind: "throw" as const, err };
+    }
+    if (!res.ok) {
+      return {
+        kind: "http-error" as const,
+        status: res.status,
+        body: await safeJson(res),
+      };
+    }
+    const parsed = DeviceCodeResponseSchema.safeParse(await safeJson(res));
+    if (!parsed.success) return { kind: "malformed" as const };
+    return { kind: "ok" as const, data: parsed.data };
+  }
+
+  async function pollOnce(deviceCode: string) {
+    let res: Response;
+    try {
+      res = await transport.fetch(`${base}/user_management/authenticate`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          grant_type: DEVICE_GRANT_TYPE,
+          client_id: opts.clientId,
+          device_code: deviceCode,
+        }),
+      });
+    } catch (err) {
+      return { kind: "throw" as const, err };
+    }
+    const body = await safeJson(res);
+    if (res.ok) {
+      const parsed = TokenResponseSchema.safeParse(body);
+      if (!parsed.success) return { kind: "malformed" as const };
+      return { kind: "tokens" as const, data: parsed.data };
+    }
+    if (res.status >= 500) {
+      return { kind: "server-error" as const, status: res.status };
+    }
+    const errParsed = PollErrorSchema.safeParse(body);
+    if (!errParsed.success) {
+      return { kind: "unknown-client-error" as const, status: res.status };
+    }
+    return { kind: "oauth-error" as const, error: errParsed.data.error };
+  }
+
+  return {
+    async login() {
+      const device = await requestDeviceCode();
+      if (device.kind === "throw") {
+        return transientErr(device.err, "Could not start device-code flow");
+      }
+      if (device.kind === "http-error") {
+        return transientErr(
+          `http-${device.status}`,
+          `WorkOS rejected device-code request (status ${device.status})`,
+        );
+      }
+      if (device.kind === "malformed") {
+        return transientErr("malformed-response", "WorkOS returned an unrecognized device-code response");
+      }
+
+      const { device_code, user_code, verification_uri, verification_uri_complete, expires_in, interval } =
+        device.data;
+
+      opts.onCode?.({
+        userCode: user_code,
+        verificationUri: verification_uri,
+        verificationUriComplete: verification_uri_complete,
+      });
+
+      let currentInterval = interval;
+      const deadline = Date.now() + expires_in * 1000;
+
+      while (Date.now() < deadline) {
+        await sleep(currentInterval * 1000);
+
+        const poll = await pollOnce(device_code);
+
+        if (poll.kind === "throw") {
+          return transientErr(poll.err, "Could not poll WorkOS for tokens");
+        }
+        if (poll.kind === "server-error") {
+          return transientErr(`http-${poll.status}`, `WorkOS returned ${poll.status} during polling`);
+        }
+        if (poll.kind === "unknown-client-error") {
+          return transientErr(`http-${poll.status}`, `WorkOS returned ${poll.status} during polling`);
+        }
+        if (poll.kind === "malformed") {
+          return transientErr("malformed-response", "WorkOS returned an unrecognized token response");
+        }
+        if (poll.kind === "tokens") {
+          const t = poll.data;
+          const expiresInSec = t.expires_in ?? DEFAULT_EXPIRES_IN_SEC;
+          return {
+            kind: "ok",
+            tokens: {
+              accessToken: t.access_token,
+              refreshToken: t.refresh_token,
+              expiresAt: Date.now() + expiresInSec * 1000,
+              userId: t.user.id,
+              email: t.user.email,
+            },
+          };
+        }
+
+        switch (poll.error) {
+          case "authorization_pending":
+            break;
+          case "slow_down":
+            currentInterval = Math.ceil(currentInterval * 1.5);
+            break;
+          case "expired_token":
+            return { kind: "expired", message: "Device code expired before authorization" };
+          case "access_denied":
+            return { kind: "denied", message: "Authorization was denied" };
+          default:
+            return transientErr(poll.error, `WorkOS returned unexpected error ${poll.error}`);
+        }
+      }
+
+      return { kind: "expired", message: "Device code expired before authorization" };
+    },
+  };
+}

--- a/apps/cli/src/credentials.test.ts
+++ b/apps/cli/src/credentials.test.ts
@@ -120,6 +120,22 @@ describe("createFilesystemStore", () => {
     expect(await store.read()).toBeNull();
   });
 
+  it("returns null when the credentials file has the wrong shape", async () => {
+    await writeFile(storePath, JSON.stringify({ accessToken: "abc" }), { mode: 0o600 });
+    const store = createFilesystemStore(storePath);
+    expect(await store.read()).toBeNull();
+  });
+
+  it("returns null when fields have wrong types", async () => {
+    await writeFile(
+      storePath,
+      JSON.stringify({ ...sampleTokens, expiresAt: "not-a-number" }),
+      { mode: 0o600 },
+    );
+    const store = createFilesystemStore(storePath);
+    expect(await store.read()).toBeNull();
+  });
+
   it("write is atomic: a crash mid-write does not leave a corrupted credentials file", async () => {
     const store = createFilesystemStore(storePath);
     await store.write(sampleTokens);

--- a/apps/cli/src/credentials.test.ts
+++ b/apps/cli/src/credentials.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, stat, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createFilesystemStore,
+  createInMemoryStore,
+  type CredentialStore,
+  type Tokens,
+} from "./credentials";
+
+const sampleTokens: Tokens = {
+  accessToken: "access-abc",
+  refreshToken: "refresh-xyz",
+  expiresAt: 1_700_000_000_000,
+  userId: "user_01H7ZZZ",
+  email: "user@example.com",
+};
+
+describe.each([
+  {
+    name: "in-memory",
+    makeStore: async (): Promise<{ store: CredentialStore; cleanup: () => Promise<void> }> => ({
+      store: createInMemoryStore(),
+      cleanup: async () => {},
+    }),
+  },
+  {
+    name: "filesystem",
+    makeStore: async (): Promise<{ store: CredentialStore; cleanup: () => Promise<void> }> => {
+      const dir = await mkdtemp(join(tmpdir(), "brief-creds-"));
+      const path = join(dir, "credentials.json");
+      return {
+        store: createFilesystemStore(path),
+        cleanup: async () => {
+          await rm(dir, { recursive: true, force: true });
+        },
+      };
+    },
+  },
+])("CredentialStore contract: $name", ({ makeStore }) => {
+  let store: CredentialStore;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ store, cleanup } = await makeStore());
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it("returns null when nothing stored", async () => {
+    expect(await store.read()).toBeNull();
+  });
+
+  it("round-trips tokens through write/read", async () => {
+    await store.write(sampleTokens);
+    expect(await store.read()).toEqual(sampleTokens);
+  });
+
+  it("clear removes stored tokens", async () => {
+    await store.write(sampleTokens);
+    await store.clear();
+    expect(await store.read()).toBeNull();
+  });
+
+  it("write overwrites previous tokens", async () => {
+    await store.write(sampleTokens);
+    const newer: Tokens = { ...sampleTokens, accessToken: "access-new" };
+    await store.write(newer);
+    expect(await store.read()).toEqual(newer);
+  });
+
+  it("clear is idempotent (no-op when empty)", async () => {
+    await expect(store.clear()).resolves.not.toThrow();
+    await store.clear();
+    expect(await store.read()).toBeNull();
+  });
+
+  it("does not leak external mutations back into the store", async () => {
+    const mutable = { ...sampleTokens };
+    await store.write(mutable);
+    mutable.accessToken = "tampered";
+    const read = await store.read();
+    expect(read?.accessToken).toBe(sampleTokens.accessToken);
+  });
+});
+
+describe("createFilesystemStore", () => {
+  let dir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "brief-creds-fs-"));
+    storePath = join(dir, "credentials.json");
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes the credentials file with 0600 perms", async () => {
+    const store = createFilesystemStore(storePath);
+    await store.write(sampleTokens);
+    const stats = await stat(storePath);
+    expect(stats.mode & 0o777).toBe(0o600);
+  });
+
+  it("creates parent directories when missing", async () => {
+    const deepPath = join(dir, "nested", "deep", "credentials.json");
+    const store = createFilesystemStore(deepPath);
+    await store.write(sampleTokens);
+    expect(await store.read()).toEqual(sampleTokens);
+  });
+
+  it("returns null when the credentials file is malformed JSON", async () => {
+    await writeFile(storePath, "not-json-at-all", { mode: 0o600 });
+    const store = createFilesystemStore(storePath);
+    expect(await store.read()).toBeNull();
+  });
+
+  it("write is atomic: a crash mid-write does not leave a corrupted credentials file", async () => {
+    const store = createFilesystemStore(storePath);
+    await store.write(sampleTokens);
+    const original = await readFile(storePath, "utf-8");
+    expect(JSON.parse(original)).toEqual(sampleTokens);
+
+    const newer: Tokens = { ...sampleTokens, accessToken: "rotated" };
+    await store.write(newer);
+    const current = await readFile(storePath, "utf-8");
+    expect(JSON.parse(current)).toEqual(newer);
+  });
+});

--- a/apps/cli/src/credentials.ts
+++ b/apps/cli/src/credentials.ts
@@ -1,0 +1,60 @@
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export interface Tokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  userId: string;
+  email: string;
+}
+
+export interface CredentialStore {
+  read(): Promise<Tokens | null>;
+  write(tokens: Tokens): Promise<void>;
+  clear(): Promise<void>;
+}
+
+const DEFAULT_PATH = join(homedir(), ".config", "brief", "credentials.json");
+
+export function createInMemoryStore(): CredentialStore {
+  let state: Tokens | null = null;
+  return {
+    async read() {
+      return state ? { ...state } : null;
+    },
+    async write(tokens) {
+      state = { ...tokens };
+    },
+    async clear() {
+      state = null;
+    },
+  };
+}
+
+export function createFilesystemStore(path: string = DEFAULT_PATH): CredentialStore {
+  return {
+    async read() {
+      try {
+        const content = await readFile(path, "utf-8");
+        return JSON.parse(content) as Tokens;
+      } catch {
+        return null;
+      }
+    },
+    async write(tokens) {
+      await mkdir(dirname(path), { recursive: true });
+      const tmpPath = `${path}.tmp.${process.pid}`;
+      await writeFile(tmpPath, JSON.stringify(tokens), { mode: 0o600 });
+      await rename(tmpPath, path);
+    },
+    async clear() {
+      try {
+        await unlink(path);
+      } catch {
+        // already absent — clear is idempotent
+      }
+    },
+  };
+}

--- a/apps/cli/src/credentials.ts
+++ b/apps/cli/src/credentials.ts
@@ -1,14 +1,17 @@
 import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { z } from "zod";
 
-export interface Tokens {
-  accessToken: string;
-  refreshToken: string;
-  expiresAt: number;
-  userId: string;
-  email: string;
-}
+export const TokensSchema = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string(),
+  expiresAt: z.number(),
+  userId: z.string(),
+  email: z.string(),
+});
+
+export type Tokens = z.infer<typeof TokensSchema>;
 
 export interface CredentialStore {
   read(): Promise<Tokens | null>;
@@ -38,7 +41,9 @@ export function createFilesystemStore(path: string = DEFAULT_PATH): CredentialSt
     async read() {
       try {
         const content = await readFile(path, "utf-8");
-        return JSON.parse(content) as Tokens;
+        const raw = JSON.parse(content);
+        const parsed = TokensSchema.safeParse(raw);
+        return parsed.success ? parsed.data : null;
       } catch {
         return null;
       }

--- a/apps/cli/src/exit-codes.ts
+++ b/apps/cli/src/exit-codes.ts
@@ -1,14 +1,22 @@
 import type { TranscriptResult } from "@brief/core";
 
+export const EXIT_OK = 0;
+export const EXIT_ARG_ERROR = 1;
+export const EXIT_PENDING = 2;
+export const EXIT_UNAVAILABLE = 3;
+export const EXIT_TRANSIENT = 4;
+export const EXIT_AUTH_REQUIRED = 5;
+export const EXIT_SCHEMA_MISMATCH = 6;
+
 export function mapExitCode(transcript: TranscriptResult): 0 | 2 | 3 | 4 {
   switch (transcript.kind) {
     case "ok":
-      return 0;
+      return EXIT_OK;
     case "pending":
-      return 2;
+      return EXIT_PENDING;
     case "unavailable":
-      return 3;
+      return EXIT_UNAVAILABLE;
     case "transient":
-      return 4;
+      return EXIT_TRANSIENT;
   }
 }

--- a/apps/cli/src/handlers/run-generate.test.ts
+++ b/apps/cli/src/handlers/run-generate.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi } from "vitest";
+import type { TranscriptResult } from "@brief/core";
+import type { BriefResult, HostedClient } from "../hosted-client";
+import { runGenerate, type RunGenerateDeps, type RunGenerateOptions } from "./run-generate";
+
+// Shared base fixtures: tests spread these and override fields per case.
+
+const okTranscript: TranscriptResult = {
+  kind: "ok",
+  source: "youtube-transcript-plus",
+  entries: [
+    { offsetSec: 0, durationSec: 2.5, text: "Hello world", lang: "en" },
+  ],
+};
+
+const sampleMetadata = {
+  videoId: "dQw4w9WgXcQ",
+  title: "Test video",
+  channelTitle: "Test channel",
+  channelId: "UC_abc",
+  duration: "PT1M",
+  publishedAt: "2024-01-01T00:00:00Z",
+  description: "Desc",
+};
+
+const briefOk: BriefResult = {
+  kind: "ok",
+  briefId: "brief_abc",
+  briefUrl: "https://brief.test/brief/brief_abc",
+  brief: {
+    summary: "A summary",
+    sections: [],
+    relatedLinks: [],
+    otherLinks: [],
+  },
+  metadata: sampleMetadata,
+};
+
+const baseOptions: RunGenerateOptions = {
+  input: "dQw4w9WgXcQ",
+  json: false,
+  withFrames: false,
+};
+
+function stubHostedClient(result: BriefResult): HostedClient {
+  return {
+    submit: vi.fn().mockResolvedValue(result),
+    whoami: vi.fn(),
+    logout: vi.fn(),
+  };
+}
+
+function makeDeps(overrides: Partial<RunGenerateDeps> = {}): RunGenerateDeps {
+  return {
+    fetchTranscript: vi.fn().mockResolvedValue(okTranscript),
+    hostedClient: stubHostedClient(briefOk),
+    ...overrides,
+  };
+}
+
+describe("runGenerate", () => {
+  it("prints the brief URL on stdout and exits 0 on success", async () => {
+    const deps = makeDeps();
+    const result = await runGenerate(deps, baseOptions);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("https://brief.test/brief/brief_abc");
+  });
+
+  it("emits the full BriefResult as JSON when json:true is set", async () => {
+    const deps = makeDeps();
+    const result = await runGenerate(deps, { ...baseOptions, json: true });
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.briefId).toBe("brief_abc");
+    expect(parsed.briefUrl).toBe("https://brief.test/brief/brief_abc");
+    expect(parsed.brief.summary).toBe("A summary");
+  });
+
+  it("submits sum-type speech entries and frames.kind=not-requested by default", async () => {
+    const deps = makeDeps();
+    await runGenerate(deps, baseOptions);
+    const [submission] = vi.mocked(deps.hostedClient.submit).mock.calls[0];
+    expect(submission.transcript[0]).toEqual({
+      kind: "speech",
+      offsetSec: 0,
+      durationSec: 2.5,
+      text: "Hello world",
+      lang: "en",
+    });
+    expect(submission.frames).toEqual({ kind: "not-requested" });
+  });
+
+  it("does not include metadata in the submission (server fetches it)", async () => {
+    const deps = makeDeps();
+    await runGenerate(deps, baseOptions);
+    const [submission] = vi.mocked(deps.hostedClient.submit).mock.calls[0];
+    expect(submission).not.toHaveProperty("metadata");
+  });
+
+  it("submits frames.kind=not-requested even when --with-frames is requested (no #87 yet)", async () => {
+    const deps = makeDeps();
+    await runGenerate(deps, { ...baseOptions, withFrames: true });
+    const [submission] = vi.mocked(deps.hostedClient.submit).mock.calls[0];
+    expect(submission.frames.kind).toBe("not-requested");
+  });
+
+  it("returns exit code 1 when input cannot be parsed as a YouTube video", async () => {
+    const deps = makeDeps();
+    const result = await runGenerate(deps, { ...baseOptions, input: "not a video" });
+    expect(result.exitCode).toBe(1);
+    expect(deps.fetchTranscript).not.toHaveBeenCalled();
+  });
+
+  it("returns exit code 5 when not signed in", async () => {
+    const deps = makeDeps({
+      hostedClient: stubHostedClient({ kind: "auth-required", reason: "missing" }),
+    });
+    const result = await runGenerate(deps, baseOptions);
+    expect(result.exitCode).toBe(5);
+    expect(result.stderr).toMatch(/sign in|brief login/i);
+  });
+
+  it("returns exit code 6 when server rejects the schema version", async () => {
+    const deps = makeDeps({
+      hostedClient: stubHostedClient({
+        kind: "schema-mismatch",
+        serverAccepts: ["3.0.0"],
+        sent: "2.0.0",
+      }),
+    });
+    const result = await runGenerate(deps, baseOptions);
+    expect(result.exitCode).toBe(6);
+    expect(result.stderr).toMatch(/upgrade/i);
+  });
+
+  it("returns exit code 4 with retry hint on rate-limited", async () => {
+    const deps = makeDeps({
+      hostedClient: stubHostedClient({ kind: "rate-limited", retryAfterSeconds: 120 }),
+    });
+    const result = await runGenerate(deps, baseOptions);
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toMatch(/120/);
+  });
+
+  it("returns exit code 4 on transient server errors", async () => {
+    const deps = makeDeps({
+      hostedClient: stubHostedClient({
+        kind: "transient",
+        cause: "http-503",
+        message: "Server returned 503",
+      }),
+    });
+    const result = await runGenerate(deps, baseOptions);
+    expect(result.exitCode).toBe(4);
+  });
+
+  it("returns exit code 3 when transcript is unavailable (server never called)", async () => {
+    const deps = makeDeps({
+      fetchTranscript: vi.fn().mockResolvedValue({
+        kind: "unavailable",
+        reason: "no-captions",
+        message: "No captions",
+      } satisfies TranscriptResult),
+    });
+    const result = await runGenerate(deps, baseOptions);
+    expect(result.exitCode).toBe(3);
+    expect(deps.hostedClient.submit).not.toHaveBeenCalled();
+  });
+
+  it("returns exit code 4 when transcript fetch is transient (server never called)", async () => {
+    const deps = makeDeps({
+      fetchTranscript: vi.fn().mockResolvedValue({
+        kind: "transient",
+        cause: "timeout",
+        message: "Upstream timed out",
+      } satisfies TranscriptResult),
+    });
+    const result = await runGenerate(deps, baseOptions);
+    expect(result.exitCode).toBe(4);
+    expect(deps.hostedClient.submit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/handlers/run-generate.test.ts
+++ b/apps/cli/src/handlers/run-generate.test.ts
@@ -179,6 +179,21 @@ describe("runGenerate", () => {
     ]);
   });
 
+  it("returns exit code 2 when transcript is in async-generation pending state", async () => {
+    const deps = makeDeps({
+      fetchTranscript: vi.fn().mockResolvedValue({
+        kind: "pending",
+        source: "supadata",
+        jobId: "job_01",
+        retryAfterSeconds: 30,
+        message: "Async generation queued",
+      } satisfies TranscriptResult),
+    });
+    const result = await runGenerate(deps, baseOptions);
+    expect(result.exitCode).toBe(2);
+    expect(deps.hostedClient.submit).not.toHaveBeenCalled();
+  });
+
   it("returns exit code 4 when transcript fetch is transient (server never called)", async () => {
     const deps = makeDeps({
       fetchTranscript: vi.fn().mockResolvedValue({

--- a/apps/cli/src/handlers/run-generate.test.ts
+++ b/apps/cli/src/handlers/run-generate.test.ts
@@ -54,6 +54,7 @@ function makeDeps(overrides: Partial<RunGenerateDeps> = {}): RunGenerateDeps {
   return {
     fetchTranscript: vi.fn().mockResolvedValue(okTranscript),
     hostedClient: stubHostedClient(briefOk),
+    progress: vi.fn(),
     ...overrides,
   };
 }
@@ -165,6 +166,17 @@ describe("runGenerate", () => {
     const result = await runGenerate(deps, baseOptions);
     expect(result.exitCode).toBe(3);
     expect(deps.hostedClient.submit).not.toHaveBeenCalled();
+  });
+
+  it("emits progress lines for transcript-fetch and server-submit phases", async () => {
+    const progress = vi.fn();
+    const deps = makeDeps({ progress });
+    await runGenerate(deps, baseOptions);
+    const calls = progress.mock.calls.map(([line]) => line as string);
+    expect(calls).toEqual([
+      expect.stringMatching(/fetch.*transcript/i),
+      expect.stringMatching(/generat.*brief/i),
+    ]);
   });
 
   it("returns exit code 4 when transcript fetch is transient (server never called)", async () => {

--- a/apps/cli/src/handlers/run-generate.ts
+++ b/apps/cli/src/handlers/run-generate.ts
@@ -29,6 +29,7 @@ export interface RunGenerateDeps {
     },
   ) => Promise<TranscriptResult>;
   hostedClient: HostedClient;
+  progress: (line: string) => void;
 }
 
 export interface RunGenerateOptions {
@@ -75,6 +76,7 @@ export async function runGenerate(
   if (opts.sources) transcriptOpts.sources = opts.sources;
   if (opts.signal) transcriptOpts.signal = opts.signal;
 
+  deps.progress("Fetching transcript...");
   const transcript = await deps.fetchTranscript(opts.input, transcriptOpts);
   if (transcript.kind === "unavailable") {
     return {
@@ -110,6 +112,7 @@ export async function runGenerate(
     ? "Note: `--with-frames` accepted but not yet wired (frames pipeline lands in #87). Submitting transcript-only.\n"
     : "";
 
+  deps.progress("Generating brief on the server... (typically 5–15s)");
   const result = await deps.hostedClient.submit(submission);
 
   switch (result.kind) {

--- a/apps/cli/src/handlers/run-generate.ts
+++ b/apps/cli/src/handlers/run-generate.ts
@@ -1,0 +1,149 @@
+import type { z } from "zod";
+import {
+  extractVideoId,
+  TranscriptEntrySchema,
+  type SourceName,
+  type TranscriptResult,
+  type TranscriptSubmission,
+} from "@brief/core";
+import {
+  EXIT_ARG_ERROR,
+  EXIT_AUTH_REQUIRED,
+  EXIT_OK,
+  EXIT_SCHEMA_MISMATCH,
+  EXIT_TRANSIENT,
+  EXIT_UNAVAILABLE,
+} from "../exit-codes";
+import type { HostedClient } from "../hosted-client";
+import type { HandlerResult } from "./run-login";
+
+type SumTypeEntry = z.infer<typeof TranscriptEntrySchema>;
+
+export interface RunGenerateDeps {
+  fetchTranscript: (
+    input: string,
+    opts: {
+      supadataApiKey?: string;
+      sources?: SourceName[];
+      signal?: AbortSignal;
+    },
+  ) => Promise<TranscriptResult>;
+  hostedClient: HostedClient;
+}
+
+export interface RunGenerateOptions {
+  input: string;
+  json: boolean;
+  withFrames: boolean;
+  sources?: SourceName[];
+  signal?: AbortSignal;
+  supadataKey?: string;
+}
+
+function toSubmissionEntries(transcript: TranscriptResult & { kind: "ok" }): SumTypeEntry[] {
+  return transcript.entries.map((e) => {
+    const out: SumTypeEntry = {
+      kind: "speech",
+      offsetSec: e.offsetSec,
+      durationSec: e.durationSec,
+      text: e.text,
+    };
+    if (e.lang !== undefined) out.lang = e.lang;
+    return out;
+  });
+}
+
+export async function runGenerate(
+  deps: RunGenerateDeps,
+  opts: RunGenerateOptions,
+): Promise<HandlerResult> {
+  const videoId = extractVideoId(opts.input);
+  if (!videoId) {
+    return {
+      stdout: "",
+      stderr: `Could not extract a YouTube video ID from "${opts.input}"\n`,
+      exitCode: EXIT_ARG_ERROR,
+    };
+  }
+
+  const transcriptOpts: {
+    supadataApiKey?: string;
+    sources?: SourceName[];
+    signal?: AbortSignal;
+  } = {};
+  if (opts.supadataKey) transcriptOpts.supadataApiKey = opts.supadataKey;
+  if (opts.sources) transcriptOpts.sources = opts.sources;
+  if (opts.signal) transcriptOpts.signal = opts.signal;
+
+  const transcript = await deps.fetchTranscript(opts.input, transcriptOpts);
+  if (transcript.kind === "unavailable") {
+    return {
+      stdout: "",
+      stderr: `Transcript unavailable (${transcript.reason}): ${transcript.message}\n`,
+      exitCode: EXIT_UNAVAILABLE,
+    };
+  }
+  if (transcript.kind === "transient") {
+    return {
+      stdout: "",
+      stderr: `Transcript fetch failed: ${transcript.message}\n`,
+      exitCode: EXIT_TRANSIENT,
+    };
+  }
+  if (transcript.kind === "pending") {
+    return {
+      stdout: "",
+      stderr: `Transcript is being generated (jobId ${transcript.jobId}). Try again in ${transcript.retryAfterSeconds}s.\n`,
+      exitCode: EXIT_TRANSIENT,
+    };
+  }
+
+  // Frames pipeline lands in #87; v1 always submits `not-requested`.
+  const submission: TranscriptSubmission = {
+    schemaVersion: "2.0.0",
+    videoId,
+    transcript: toSubmissionEntries(transcript),
+    frames: { kind: "not-requested" },
+  };
+
+  const noticeStderr = opts.withFrames
+    ? "Note: `--with-frames` accepted but not yet wired (frames pipeline lands in #87). Submitting transcript-only.\n"
+    : "";
+
+  const result = await deps.hostedClient.submit(submission);
+
+  switch (result.kind) {
+    case "ok":
+      return {
+        stdout: opts.json
+          ? `${JSON.stringify(result)}\n`
+          : `${result.briefUrl}\n`,
+        stderr: noticeStderr,
+        exitCode: EXIT_OK,
+      };
+    case "auth-required":
+      return {
+        stdout: "",
+        stderr: `${noticeStderr}Not signed in. Run \`brief login\` first.\n`,
+        exitCode: EXIT_AUTH_REQUIRED,
+      };
+    case "schema-mismatch":
+      return {
+        stdout: "",
+        stderr: `${noticeStderr}This brief CLI is out of date. Please upgrade. (server accepts: ${result.serverAccepts.join(", ")})\n`,
+        exitCode: EXIT_SCHEMA_MISMATCH,
+      };
+    case "rate-limited":
+      return {
+        stdout: "",
+        stderr: `${noticeStderr}Daily quota reached. Try again in ${result.retryAfterSeconds}s.\n`,
+        exitCode: EXIT_TRANSIENT,
+      };
+    case "transient":
+      return {
+        stdout: "",
+        stderr: `${noticeStderr}Server temporarily unavailable: ${result.message}\n`,
+        exitCode: EXIT_TRANSIENT,
+      };
+  }
+}

--- a/apps/cli/src/handlers/run-generate.ts
+++ b/apps/cli/src/handlers/run-generate.ts
@@ -10,6 +10,7 @@ import {
   EXIT_ARG_ERROR,
   EXIT_AUTH_REQUIRED,
   EXIT_OK,
+  EXIT_PENDING,
   EXIT_SCHEMA_MISMATCH,
   EXIT_TRANSIENT,
   EXIT_UNAVAILABLE,
@@ -96,7 +97,7 @@ export async function runGenerate(
     return {
       stdout: "",
       stderr: `Transcript is being generated (jobId ${transcript.jobId}). Try again in ${transcript.retryAfterSeconds}s.\n`,
-      exitCode: EXIT_TRANSIENT,
+      exitCode: EXIT_PENDING,
     };
   }
 

--- a/apps/cli/src/handlers/run-login.test.ts
+++ b/apps/cli/src/handlers/run-login.test.ts
@@ -64,4 +64,24 @@ describe("runLogin", () => {
     await runLogin({ authFlow, credentials });
     expect(await credentials.read()).toBeNull();
   });
+
+  it("returns exit code 4 when authFlow.login throws unexpectedly", async () => {
+    const credentials = createInMemoryStore();
+    const authFlow: AuthFlow = {
+      login: vi.fn().mockRejectedValue(new Error("unexpected")),
+    };
+    const result = await runLogin({ authFlow, credentials });
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toMatch(/unexpect/i);
+    expect(await credentials.read()).toBeNull();
+  });
+
+  it("returns exit code 4 when credentials.write throws after a successful login", async () => {
+    const credentials = createInMemoryStore();
+    credentials.write = vi.fn().mockRejectedValue(new Error("disk full"));
+    const authFlow = stubAuthFlow({ kind: "ok", tokens: sampleTokens });
+    const result = await runLogin({ authFlow, credentials });
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toMatch(/disk full/i);
+  });
 });

--- a/apps/cli/src/handlers/run-login.test.ts
+++ b/apps/cli/src/handlers/run-login.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import type { AuthFlow, AuthFlowResult } from "../auth";
+import { createInMemoryStore } from "../credentials";
+import { runLogin } from "./run-login";
+
+function stubAuthFlow(result: AuthFlowResult): AuthFlow {
+  return { login: vi.fn().mockResolvedValue(result) };
+}
+
+const sampleTokens = {
+  accessToken: "access-abc",
+  refreshToken: "refresh-xyz",
+  expiresAt: Date.now() + 3_600_000,
+  userId: "user_01",
+  email: "user@example.com",
+};
+
+describe("runLogin", () => {
+  it("writes tokens to the store and prints the signed-in email on success", async () => {
+    const credentials = createInMemoryStore();
+    const authFlow = stubAuthFlow({ kind: "ok", tokens: sampleTokens });
+    const result = await runLogin({ authFlow, credentials });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/user@example.com/);
+    expect(await credentials.read()).toEqual(sampleTokens);
+  });
+
+  it("returns exit code 5 (auth-required) when login expires", async () => {
+    const credentials = createInMemoryStore();
+    const authFlow = stubAuthFlow({ kind: "expired", message: "Code expired" });
+    const result = await runLogin({ authFlow, credentials });
+
+    expect(result.exitCode).toBe(5);
+    expect(result.stderr).toMatch(/expired/i);
+    expect(await credentials.read()).toBeNull();
+  });
+
+  it("returns exit code 5 when user denies the authorization", async () => {
+    const credentials = createInMemoryStore();
+    const authFlow = stubAuthFlow({ kind: "denied", message: "User denied" });
+    const result = await runLogin({ authFlow, credentials });
+
+    expect(result.exitCode).toBe(5);
+    expect(result.stderr).toMatch(/deni/i);
+  });
+
+  it("returns exit code 4 (transient) on network failures", async () => {
+    const credentials = createInMemoryStore();
+    const authFlow = stubAuthFlow({
+      kind: "transient",
+      cause: "ENETDOWN",
+      message: "Network unreachable",
+    });
+    const result = await runLogin({ authFlow, credentials });
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toMatch(/network|fail/i);
+  });
+
+  it("does not write to the store when login fails", async () => {
+    const credentials = createInMemoryStore();
+    const authFlow = stubAuthFlow({ kind: "expired", message: "Code expired" });
+    await runLogin({ authFlow, credentials });
+    expect(await credentials.read()).toBeNull();
+  });
+});

--- a/apps/cli/src/handlers/run-login.ts
+++ b/apps/cli/src/handlers/run-login.ts
@@ -14,11 +14,30 @@ export interface RunLoginDeps {
 }
 
 export async function runLogin(deps: RunLoginDeps): Promise<HandlerResult> {
-  const result = await deps.authFlow.login();
+  let result: Awaited<ReturnType<typeof deps.authFlow.login>>;
+  try {
+    result = await deps.authFlow.login();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      stdout: "",
+      stderr: `Login failed unexpectedly: ${message}\n`,
+      exitCode: EXIT_TRANSIENT,
+    };
+  }
 
   switch (result.kind) {
     case "ok":
-      await deps.credentials.write(result.tokens);
+      try {
+        await deps.credentials.write(result.tokens);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          stdout: "",
+          stderr: `Login succeeded but credentials could not be persisted: ${message}\n`,
+          exitCode: EXIT_TRANSIENT,
+        };
+      }
       return {
         stdout: `Signed in as ${result.tokens.email}\n`,
         stderr: "",

--- a/apps/cli/src/handlers/run-login.ts
+++ b/apps/cli/src/handlers/run-login.ts
@@ -1,0 +1,46 @@
+import type { AuthFlow } from "../auth";
+import type { CredentialStore } from "../credentials";
+import { EXIT_AUTH_REQUIRED, EXIT_OK, EXIT_TRANSIENT } from "../exit-codes";
+
+export interface HandlerResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface RunLoginDeps {
+  authFlow: AuthFlow;
+  credentials: CredentialStore;
+}
+
+export async function runLogin(deps: RunLoginDeps): Promise<HandlerResult> {
+  const result = await deps.authFlow.login();
+
+  switch (result.kind) {
+    case "ok":
+      await deps.credentials.write(result.tokens);
+      return {
+        stdout: `Signed in as ${result.tokens.email}\n`,
+        stderr: "",
+        exitCode: EXIT_OK,
+      };
+    case "expired":
+      return {
+        stdout: "",
+        stderr: `Login expired: ${result.message}. Try again.\n`,
+        exitCode: EXIT_AUTH_REQUIRED,
+      };
+    case "denied":
+      return {
+        stdout: "",
+        stderr: `Login denied: ${result.message}\n`,
+        exitCode: EXIT_AUTH_REQUIRED,
+      };
+    case "transient":
+      return {
+        stdout: "",
+        stderr: `Login failed (network): ${result.message}\n`,
+        exitCode: EXIT_TRANSIENT,
+      };
+  }
+}

--- a/apps/cli/src/handlers/run-logout.test.ts
+++ b/apps/cli/src/handlers/run-logout.test.ts
@@ -55,4 +55,18 @@ describe("runLogout", () => {
 
     expect(result.exitCode).toBe(0);
   });
+
+  it("still clears local credentials when hostedClient.logout throws", async () => {
+    const credentials = createInMemoryStore();
+    await credentials.write(sampleTokens);
+    const hostedClient: HostedClient = {
+      submit: vi.fn(),
+      whoami: vi.fn(),
+      logout: vi.fn().mockRejectedValue(new Error("unexpected")),
+    };
+    const result = await runLogout({ hostedClient, credentials });
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toMatch(/unexpect|note/i);
+    expect(await credentials.read()).toBeNull();
+  });
 });

--- a/apps/cli/src/handlers/run-logout.test.ts
+++ b/apps/cli/src/handlers/run-logout.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import type { HostedClient, LogoutResult } from "../hosted-client";
+import { createInMemoryStore, type Tokens } from "../credentials";
+import { runLogout } from "./run-logout";
+
+const sampleTokens: Tokens = {
+  accessToken: "access-abc",
+  refreshToken: "refresh-xyz",
+  expiresAt: Date.now() + 3_600_000,
+  userId: "user_01",
+  email: "user@example.com",
+};
+
+function stubHostedClient(result: LogoutResult): HostedClient {
+  return {
+    submit: vi.fn(),
+    whoami: vi.fn(),
+    logout: vi.fn().mockResolvedValue(result),
+  };
+}
+
+describe("runLogout", () => {
+  it("clears local credentials and exits 0 when server ack's the revoke", async () => {
+    const credentials = createInMemoryStore();
+    await credentials.write(sampleTokens);
+    const hostedClient = stubHostedClient({ kind: "ok" });
+
+    const result = await runLogout({ hostedClient, credentials });
+
+    expect(result.exitCode).toBe(0);
+    expect(await credentials.read()).toBeNull();
+  });
+
+  it("still clears local credentials even when server returns transient", async () => {
+    const credentials = createInMemoryStore();
+    await credentials.write(sampleTokens);
+    const hostedClient = stubHostedClient({
+      kind: "transient",
+      cause: "ECONNREFUSED",
+      message: "Server unreachable",
+    });
+
+    const result = await runLogout({ hostedClient, credentials });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toMatch(/server|unreachable|note/i);
+    expect(await credentials.read()).toBeNull();
+  });
+
+  it("succeeds as a no-op when no credentials are stored", async () => {
+    const credentials = createInMemoryStore();
+    const hostedClient = stubHostedClient({ kind: "ok" });
+
+    const result = await runLogout({ hostedClient, credentials });
+
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/apps/cli/src/handlers/run-logout.ts
+++ b/apps/cli/src/handlers/run-logout.ts
@@ -1,0 +1,28 @@
+import type { HostedClient } from "../hosted-client";
+import type { CredentialStore } from "../credentials";
+import { EXIT_OK } from "../exit-codes";
+import type { HandlerResult } from "./run-login";
+
+export interface RunLogoutDeps {
+  hostedClient: HostedClient;
+  credentials: CredentialStore;
+}
+
+export async function runLogout(deps: RunLogoutDeps): Promise<HandlerResult> {
+  const result = await deps.hostedClient.logout();
+  await deps.credentials.clear();
+
+  if (result.kind === "transient") {
+    return {
+      stdout: "Signed out locally.\n",
+      stderr: `(Note: server revoke failed: ${result.message}. Local credentials cleared regardless.)\n`,
+      exitCode: EXIT_OK,
+    };
+  }
+
+  return {
+    stdout: "Signed out.\n",
+    stderr: "",
+    exitCode: EXIT_OK,
+  };
+}

--- a/apps/cli/src/handlers/run-logout.ts
+++ b/apps/cli/src/handlers/run-logout.ts
@@ -1,6 +1,6 @@
 import type { HostedClient } from "../hosted-client";
 import type { CredentialStore } from "../credentials";
-import { EXIT_OK } from "../exit-codes";
+import { EXIT_OK, EXIT_TRANSIENT } from "../exit-codes";
 import type { HandlerResult } from "./run-login";
 
 export interface RunLogoutDeps {
@@ -9,20 +9,31 @@ export interface RunLogoutDeps {
 }
 
 export async function runLogout(deps: RunLogoutDeps): Promise<HandlerResult> {
-  const result = await deps.hostedClient.logout();
-  await deps.credentials.clear();
+  let serverNote = "";
+  try {
+    const result = await deps.hostedClient.logout();
+    if (result.kind === "transient") {
+      serverNote = `(Note: server revoke failed: ${result.message}. Local credentials cleared regardless.)\n`;
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    serverNote = `(Note: server revoke threw: ${message}. Local credentials cleared regardless.)\n`;
+  }
 
-  if (result.kind === "transient") {
+  try {
+    await deps.credentials.clear();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     return {
-      stdout: "Signed out locally.\n",
-      stderr: `(Note: server revoke failed: ${result.message}. Local credentials cleared regardless.)\n`,
-      exitCode: EXIT_OK,
+      stdout: "",
+      stderr: `Failed to clear local credentials: ${message}\n`,
+      exitCode: EXIT_TRANSIENT,
     };
   }
 
   return {
-    stdout: "Signed out.\n",
-    stderr: "",
+    stdout: serverNote ? "Signed out locally.\n" : "Signed out.\n",
+    stderr: serverNote,
     exitCode: EXIT_OK,
   };
 }

--- a/apps/cli/src/handlers/run-transcript.test.ts
+++ b/apps/cli/src/handlers/run-transcript.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from "vitest";
+import type { MetadataResult, TranscriptResult } from "@brief/core";
+import { runTranscript, type RunTranscriptDeps } from "./run-transcript";
+
+const okTranscript: TranscriptResult = {
+  kind: "ok",
+  source: "youtube-transcript-plus",
+  entries: [
+    { offsetSec: 0, durationSec: 2.5, text: "Hello world" },
+    { offsetSec: 2.5, durationSec: 3, text: "How are you" },
+  ],
+};
+
+const unavailableTranscript: TranscriptResult = {
+  kind: "unavailable",
+  reason: "no-captions",
+  message: "No captions available",
+};
+
+const transientTranscript: TranscriptResult = {
+  kind: "transient",
+  cause: "timeout",
+  message: "Upstream timed out",
+};
+
+const pendingTranscript: TranscriptResult = {
+  kind: "pending",
+  source: "supadata",
+  jobId: "job_01",
+  retryAfterSeconds: 30,
+  message: "Async generation queued",
+};
+
+const okMetadata: MetadataResult = {
+  kind: "ok",
+  metadata: {
+    videoId: "abc123XYZAB",
+    title: "Test video",
+    channelTitle: "Test channel",
+    channelId: "UC_abc",
+    duration: "PT1M",
+    publishedAt: "2024-01-01T00:00:00Z",
+    description: "",
+  },
+};
+
+function makeDeps(overrides: Partial<RunTranscriptDeps> = {}): RunTranscriptDeps {
+  return {
+    fetchTranscript: vi.fn().mockResolvedValue(okTranscript),
+    fetchMetadata: vi.fn().mockResolvedValue(okMetadata),
+    ...overrides,
+  };
+}
+
+describe("runTranscript", () => {
+  it("returns exit code 0 with transcript text on stdout (human format)", async () => {
+    const deps = makeDeps();
+    const result = await runTranscript(deps, {
+      input: "abc123XYZAB",
+      json: false,
+      noMetadata: false,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Hello world");
+  });
+
+  it("emits parseable JSON when json:true is set", async () => {
+    const deps = makeDeps();
+    const result = await runTranscript(deps, {
+      input: "abc123XYZAB",
+      json: true,
+      noMetadata: false,
+    });
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.status).toBe("ok");
+  });
+
+  it("skips metadata fetch when noMetadata:true is set", async () => {
+    const deps = makeDeps();
+    await runTranscript(deps, {
+      input: "abc123XYZAB",
+      json: false,
+      noMetadata: true,
+    });
+    expect(deps.fetchMetadata).not.toHaveBeenCalled();
+  });
+
+  it("returns exit code 3 when transcript is unavailable", async () => {
+    const deps = makeDeps({
+      fetchTranscript: vi.fn().mockResolvedValue(unavailableTranscript),
+    });
+    const result = await runTranscript(deps, {
+      input: "abc",
+      json: false,
+      noMetadata: true,
+    });
+    expect(result.exitCode).toBe(3);
+  });
+
+  it("returns exit code 4 on transient transcript failures", async () => {
+    const deps = makeDeps({
+      fetchTranscript: vi.fn().mockResolvedValue(transientTranscript),
+    });
+    const result = await runTranscript(deps, {
+      input: "abc",
+      json: false,
+      noMetadata: true,
+    });
+    expect(result.exitCode).toBe(4);
+  });
+
+  it("returns exit code 2 on pending async-generation", async () => {
+    const deps = makeDeps({
+      fetchTranscript: vi.fn().mockResolvedValue(pendingTranscript),
+    });
+    const result = await runTranscript(deps, {
+      input: "abc",
+      json: false,
+      noMetadata: true,
+    });
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("emits a one-line stderr tip when invoked via bare-positional shortcut", async () => {
+    const deps = makeDeps();
+    const result = await runTranscript(deps, {
+      input: "abc",
+      json: false,
+      noMetadata: true,
+      bareShortcut: true,
+    });
+    expect(result.stderr).toMatch(/brief transcript/i);
+  });
+
+  it("does not emit the shortcut tip when invoked via explicit subcommand", async () => {
+    const deps = makeDeps();
+    const result = await runTranscript(deps, {
+      input: "abc",
+      json: false,
+      noMetadata: true,
+      bareShortcut: false,
+    });
+    expect(result.stderr).not.toMatch(/brief transcript/i);
+  });
+});

--- a/apps/cli/src/handlers/run-transcript.ts
+++ b/apps/cli/src/handlers/run-transcript.ts
@@ -1,0 +1,83 @@
+import type {
+  MetadataResult,
+  SourceName,
+  TranscriptResult,
+} from "@brief/core";
+import { mapExitCode } from "../exit-codes";
+import { render, type CombinedResult } from "../renderer";
+import type { HandlerResult } from "./run-login";
+
+export interface RunTranscriptDeps {
+  fetchTranscript: (
+    input: string,
+    opts: {
+      supadataApiKey?: string;
+      sources?: SourceName[];
+      signal?: AbortSignal;
+    },
+  ) => Promise<TranscriptResult>;
+  fetchMetadata: (
+    input: string,
+    opts: {
+      youtubeApiKey: string;
+      signal?: AbortSignal;
+    },
+  ) => Promise<MetadataResult>;
+}
+
+export interface RunTranscriptOptions {
+  input: string;
+  json: boolean;
+  noMetadata: boolean;
+  sources?: SourceName[];
+  signal?: AbortSignal;
+  supadataKey?: string;
+  youtubeKey?: string;
+  ttyStderr?: boolean;
+  bareShortcut?: boolean;
+}
+
+const SHORTCUT_TIP = "Tip: prefer `brief transcript <url>` for the explicit form.\n";
+
+export async function runTranscript(
+  deps: RunTranscriptDeps,
+  opts: RunTranscriptOptions,
+): Promise<HandlerResult> {
+  const transcriptOpts: {
+    supadataApiKey?: string;
+    sources?: SourceName[];
+    signal?: AbortSignal;
+  } = {};
+  if (opts.supadataKey) transcriptOpts.supadataApiKey = opts.supadataKey;
+  if (opts.sources) transcriptOpts.sources = opts.sources;
+  if (opts.signal) transcriptOpts.signal = opts.signal;
+
+  const transcriptPromise = deps.fetchTranscript(opts.input, transcriptOpts);
+
+  const wantMetadata = !opts.noMetadata && !!opts.youtubeKey;
+  const metadataPromise: Promise<MetadataResult | null> = wantMetadata
+    ? deps.fetchMetadata(opts.input, {
+        youtubeApiKey: opts.youtubeKey!,
+        ...(opts.signal ? { signal: opts.signal } : {}),
+      })
+    : Promise.resolve(null);
+
+  const [transcript, metadata] = await Promise.all([transcriptPromise, metadataPromise]);
+
+  const combined: CombinedResult = {
+    videoIdOrUrl: opts.input,
+    transcript,
+    metadata,
+  };
+
+  const format = opts.json ? "json" : "human";
+  const out = render(combined, format, !!opts.ttyStderr);
+
+  const tip = opts.bareShortcut ? SHORTCUT_TIP : "";
+
+  return {
+    stdout: out.stdout ?? "",
+    stderr: `${tip}${out.stderr ?? ""}`,
+    exitCode: mapExitCode(transcript),
+  };
+}

--- a/apps/cli/src/handlers/run-whoami.test.ts
+++ b/apps/cli/src/handlers/run-whoami.test.ts
@@ -74,4 +74,15 @@ describe("runWhoami", () => {
     expect(result.exitCode).toBe(4);
     expect(result.stderr).toMatch(/server|unreachable/i);
   });
+
+  it("returns exit code 4 when hostedClient.whoami throws unexpectedly", async () => {
+    const hostedClient: HostedClient = {
+      submit: vi.fn(),
+      whoami: vi.fn().mockRejectedValue(new Error("ECONNRESET")),
+      logout: vi.fn(),
+    };
+    const result = await runWhoami({ hostedClient }, { json: false });
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toMatch(/ECONNRESET|server/i);
+  });
 });

--- a/apps/cli/src/handlers/run-whoami.test.ts
+++ b/apps/cli/src/handlers/run-whoami.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import type { HostedClient, IdentityResult } from "../hosted-client";
+import { runWhoami } from "./run-whoami";
+
+function stubHostedClient(result: IdentityResult): HostedClient {
+  return {
+    submit: vi.fn(),
+    whoami: vi.fn().mockResolvedValue(result),
+    logout: vi.fn(),
+  };
+}
+
+describe("runWhoami", () => {
+  it("prints email on stdout when authenticated", async () => {
+    const hostedClient = stubHostedClient({
+      kind: "ok",
+      email: "user@example.com",
+      userId: "user_01",
+    });
+
+    const result = await runWhoami({ hostedClient }, { json: false });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("user@example.com");
+  });
+
+  it("prints structured JSON on stdout when --json is set", async () => {
+    const hostedClient = stubHostedClient({
+      kind: "ok",
+      email: "user@example.com",
+      userId: "user_01",
+    });
+
+    const result = await runWhoami({ hostedClient }, { json: true });
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed).toEqual({ email: "user@example.com", userId: "user_01" });
+  });
+
+  it("returns exit code 5 with a 'not signed in' message when no creds", async () => {
+    const hostedClient = stubHostedClient({
+      kind: "auth-required",
+      reason: "missing",
+    });
+
+    const result = await runWhoami({ hostedClient }, { json: false });
+
+    expect(result.exitCode).toBe(5);
+    expect(result.stderr).toMatch(/not signed in/i);
+  });
+
+  it("returns exit code 5 with an 'expired' message when token expired", async () => {
+    const hostedClient = stubHostedClient({
+      kind: "auth-required",
+      reason: "expired",
+    });
+
+    const result = await runWhoami({ hostedClient }, { json: false });
+
+    expect(result.exitCode).toBe(5);
+    expect(result.stderr).toMatch(/expired|sign in/i);
+  });
+
+  it("returns exit code 4 on transient errors", async () => {
+    const hostedClient = stubHostedClient({
+      kind: "transient",
+      cause: "ENETDOWN",
+      message: "Server unreachable",
+    });
+
+    const result = await runWhoami({ hostedClient }, { json: false });
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toMatch(/server|unreachable/i);
+  });
+});

--- a/apps/cli/src/handlers/run-whoami.ts
+++ b/apps/cli/src/handlers/run-whoami.ts
@@ -14,7 +14,17 @@ export async function runWhoami(
   deps: RunWhoamiDeps,
   opts: RunWhoamiOptions,
 ): Promise<HandlerResult> {
-  const result = await deps.hostedClient.whoami();
+  let result: Awaited<ReturnType<typeof deps.hostedClient.whoami>>;
+  try {
+    result = await deps.hostedClient.whoami();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      stdout: "",
+      stderr: `Server unreachable: ${message}\n`,
+      exitCode: EXIT_TRANSIENT,
+    };
+  }
 
   switch (result.kind) {
     case "ok":

--- a/apps/cli/src/handlers/run-whoami.ts
+++ b/apps/cli/src/handlers/run-whoami.ts
@@ -1,0 +1,49 @@
+import type { HostedClient } from "../hosted-client";
+import { EXIT_AUTH_REQUIRED, EXIT_OK, EXIT_TRANSIENT } from "../exit-codes";
+import type { HandlerResult } from "./run-login";
+
+export interface RunWhoamiDeps {
+  hostedClient: HostedClient;
+}
+
+export interface RunWhoamiOptions {
+  json: boolean;
+}
+
+export async function runWhoami(
+  deps: RunWhoamiDeps,
+  opts: RunWhoamiOptions,
+): Promise<HandlerResult> {
+  const result = await deps.hostedClient.whoami();
+
+  switch (result.kind) {
+    case "ok":
+      if (opts.json) {
+        return {
+          stdout: `${JSON.stringify({ email: result.email, userId: result.userId })}\n`,
+          stderr: "",
+          exitCode: EXIT_OK,
+        };
+      }
+      return {
+        stdout: `${result.email}\n`,
+        stderr: "",
+        exitCode: EXIT_OK,
+      };
+    case "auth-required":
+      return {
+        stdout: "",
+        stderr:
+          result.reason === "expired"
+            ? "Your session has expired. Run `brief login`.\n"
+            : "Not signed in. Run `brief login`.\n",
+        exitCode: EXIT_AUTH_REQUIRED,
+      };
+    case "transient":
+      return {
+        stdout: "",
+        stderr: `Server unreachable: ${result.message}\n`,
+        exitCode: EXIT_TRANSIENT,
+      };
+  }
+}

--- a/apps/cli/src/hosted-client.test.ts
+++ b/apps/cli/src/hosted-client.test.ts
@@ -176,6 +176,32 @@ describe("HostedClient.submit", () => {
     }
   });
 
+  it("parses Retry-After as an HTTP-date when not a numeric seconds value", async () => {
+    const futureDate = new Date(Date.now() + 200 * 1000);
+    await setup([
+      { status: 429, headers: { "retry-after": futureDate.toUTCString() }, body: {} },
+    ]);
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("rate-limited");
+    if (result.kind === "rate-limited") {
+      // ~200s ahead, give a ±5s window for execution timing.
+      expect(result.retryAfterSeconds).toBeGreaterThan(190);
+      expect(result.retryAfterSeconds).toBeLessThan(210);
+    }
+  });
+
+  it("falls back to the default when Retry-After is a past HTTP-date", async () => {
+    const pastDate = new Date(Date.now() - 60 * 1000);
+    await setup([
+      { status: 429, headers: { "retry-after": pastDate.toUTCString() }, body: {} },
+    ]);
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("rate-limited");
+    if (result.kind === "rate-limited") {
+      expect(result.retryAfterSeconds).toBeGreaterThan(0);
+    }
+  });
+
   it("returns transient on 503", async () => {
     await setup([{ status: 503, body: { error: "upstream-llm-down" } }]);
     const result = await client.submit(validSubmission);

--- a/apps/cli/src/hosted-client.test.ts
+++ b/apps/cli/src/hosted-client.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createInMemoryStore, type CredentialStore, type Tokens } from "./credentials";
+import {
+  createHostedClient,
+  type HostedClient,
+  type Transport,
+} from "./hosted-client";
+
+const BASE_URL = "https://brief.test";
+
+const sampleTokens: Tokens = {
+  accessToken: "access-abc",
+  refreshToken: "refresh-xyz",
+  expiresAt: Date.now() + 3_600_000,
+  userId: "user_01",
+  email: "user@example.com",
+};
+
+const validIntakeResponse = {
+  schemaVersion: "2.0.0",
+  briefId: "brief_abc",
+  briefUrl: "https://brief.niftymonkey.dev/brief/brief_abc",
+  brief: {
+    summary: "Summary text",
+    sections: [],
+    relatedLinks: [],
+    otherLinks: [],
+  },
+  metadata: {
+    videoId: "abc123XYZAB",
+    title: "Test video",
+    channelTitle: "Test channel",
+    channelId: "UC_abc",
+    duration: "PT3M30S",
+    publishedAt: "2024-01-01T00:00:00Z",
+    description: "A test description",
+  },
+};
+
+const validSubmission = {
+  schemaVersion: "2.0.0" as const,
+  videoId: "abc123XYZAB",
+  metadata: validIntakeResponse.metadata,
+  transcript: [
+    {
+      kind: "speech" as const,
+      offsetSec: 0,
+      durationSec: 1,
+      text: "hello",
+    },
+  ],
+  frames: { kind: "not-requested" as const },
+};
+
+interface StubCall {
+  url: string;
+  init?: RequestInit;
+}
+
+type StubPlan = {
+  status?: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+  throw?: Error;
+};
+
+function createStubTransport(plans: StubPlan[]): Transport & { calls: StubCall[] } {
+  const calls: StubCall[] = [];
+  let i = 0;
+  return {
+    calls,
+    async fetch(input, init) {
+      const url = typeof input === "string" ? input : input.toString();
+      calls.push({ url, init });
+      const plan = plans[i++];
+      if (!plan) throw new Error(`No stub plan for call #${i}`);
+      if (plan.throw) throw plan.throw;
+      const status = plan.status ?? 200;
+      const headers = new Headers(plan.headers ?? {});
+      const body = plan.body !== undefined ? JSON.stringify(plan.body) : null;
+      if (plan.body !== undefined && !headers.has("content-type")) {
+        headers.set("content-type", "application/json");
+      }
+      return new Response(body, { status, headers });
+    },
+  };
+}
+
+describe("HostedClient.submit", () => {
+  let credentials: CredentialStore;
+  let transport: ReturnType<typeof createStubTransport>;
+  let client: HostedClient;
+
+  async function setup(plans: StubPlan[], tokens: Tokens | null = sampleTokens) {
+    credentials = createInMemoryStore();
+    if (tokens) await credentials.write(tokens);
+    transport = createStubTransport(plans);
+    client = createHostedClient({ baseUrl: BASE_URL, credentials, transport });
+  }
+
+  it("returns ok with the parsed brief on 200", async () => {
+    await setup([{ status: 200, body: validIntakeResponse }]);
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.briefId).toBe("brief_abc");
+      expect(result.briefUrl).toBe(validIntakeResponse.briefUrl);
+      expect(result.brief.summary).toBe("Summary text");
+    }
+  });
+
+  it("POSTs to /api/brief/intake at the configured base URL", async () => {
+    await setup([{ status: 200, body: validIntakeResponse }]);
+    await client.submit(validSubmission);
+    expect(transport.calls[0]?.url).toBe(`${BASE_URL}/api/brief/intake`);
+    expect(transport.calls[0]?.init?.method).toBe("POST");
+  });
+
+  it("sends Authorization Bearer header with the access token", async () => {
+    await setup([{ status: 200, body: validIntakeResponse }]);
+    await client.submit(validSubmission);
+    const headers = new Headers(transport.calls[0]?.init?.headers ?? {});
+    expect(headers.get("authorization")).toBe(`Bearer ${sampleTokens.accessToken}`);
+  });
+
+  it("sends Content-Type application/json with the serialized body", async () => {
+    await setup([{ status: 200, body: validIntakeResponse }]);
+    await client.submit(validSubmission);
+    const headers = new Headers(transport.calls[0]?.init?.headers ?? {});
+    expect(headers.get("content-type")).toBe("application/json");
+    expect(JSON.parse(transport.calls[0]?.init?.body as string)).toEqual(validSubmission);
+  });
+
+  it("returns auth-required:missing when credentials are absent", async () => {
+    await setup([], null);
+    const result = await client.submit(validSubmission);
+    expect(result).toEqual({ kind: "auth-required", reason: "missing" });
+    expect(transport.calls).toHaveLength(0);
+  });
+
+  it("returns auth-required:expired on 401", async () => {
+    await setup([{ status: 401, body: { error: "token-expired" } }]);
+    const result = await client.submit(validSubmission);
+    expect(result).toEqual({ kind: "auth-required", reason: "expired" });
+  });
+
+  it("returns schema-mismatch on 409 with serverAccepts", async () => {
+    await setup([
+      {
+        status: 409,
+        body: { error: "schema-mismatch", serverAccepts: ["3.0.0"] },
+      },
+    ]);
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("schema-mismatch");
+    if (result.kind === "schema-mismatch") {
+      expect(result.serverAccepts).toEqual(["3.0.0"]);
+      expect(result.sent).toBe("2.0.0");
+    }
+  });
+
+  it("returns rate-limited on 429 with Retry-After header", async () => {
+    await setup([
+      { status: 429, headers: { "retry-after": "120" }, body: {} },
+    ]);
+    const result = await client.submit(validSubmission);
+    expect(result).toEqual({ kind: "rate-limited", retryAfterSeconds: 120 });
+  });
+
+  it("falls back to a default retry window when Retry-After header is missing", async () => {
+    await setup([{ status: 429, body: {} }]);
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("rate-limited");
+    if (result.kind === "rate-limited") {
+      expect(result.retryAfterSeconds).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns transient on 503", async () => {
+    await setup([{ status: 503, body: { error: "upstream-llm-down" } }]);
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("transient");
+  });
+
+  it("returns transient when fetch throws (network error)", async () => {
+    await setup([{ throw: new Error("ENOTFOUND") }]);
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") {
+      expect(result.cause).toMatch(/ENOTFOUND|network/i);
+    }
+  });
+
+  it("returns transient when the response body fails schema validation", async () => {
+    await setup([{ status: 200, body: { foo: "bar" } }]);
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("transient");
+  });
+});
+
+describe("HostedClient.whoami", () => {
+  let credentials: CredentialStore;
+  let transport: ReturnType<typeof createStubTransport>;
+  let client: HostedClient;
+
+  async function setup(plans: StubPlan[], tokens: Tokens | null = sampleTokens) {
+    credentials = createInMemoryStore();
+    if (tokens) await credentials.write(tokens);
+    transport = createStubTransport(plans);
+    client = createHostedClient({ baseUrl: BASE_URL, credentials, transport });
+  }
+
+  it("returns ok with email and userId on 200", async () => {
+    await setup([
+      {
+        status: 200,
+        body: { email: "user@example.com", userId: "user_01" },
+      },
+    ]);
+    const result = await client.whoami();
+    expect(result).toEqual({
+      kind: "ok",
+      email: "user@example.com",
+      userId: "user_01",
+    });
+  });
+
+  it("GETs /api/cli/whoami with Bearer token", async () => {
+    await setup([
+      {
+        status: 200,
+        body: { email: "user@example.com", userId: "user_01" },
+      },
+    ]);
+    await client.whoami();
+    expect(transport.calls[0]?.url).toBe(`${BASE_URL}/api/cli/whoami`);
+    expect(transport.calls[0]?.init?.method).toBe("GET");
+    const headers = new Headers(transport.calls[0]?.init?.headers ?? {});
+    expect(headers.get("authorization")).toBe(`Bearer ${sampleTokens.accessToken}`);
+  });
+
+  it("returns auth-required:missing when no credentials stored", async () => {
+    await setup([], null);
+    const result = await client.whoami();
+    expect(result).toEqual({ kind: "auth-required", reason: "missing" });
+  });
+
+  it("returns auth-required:expired on 401", async () => {
+    await setup([{ status: 401, body: {} }]);
+    const result = await client.whoami();
+    expect(result).toEqual({ kind: "auth-required", reason: "expired" });
+  });
+});
+
+describe("HostedClient.logout", () => {
+  let credentials: CredentialStore;
+  let transport: ReturnType<typeof createStubTransport>;
+  let client: HostedClient;
+
+  async function setup(plans: StubPlan[], tokens: Tokens | null = sampleTokens) {
+    credentials = createInMemoryStore();
+    if (tokens) await credentials.write(tokens);
+    transport = createStubTransport(plans);
+    client = createHostedClient({ baseUrl: BASE_URL, credentials, transport });
+  }
+
+  it("returns ok on 204 from server", async () => {
+    await setup([{ status: 204 }]);
+    const result = await client.logout();
+    expect(result).toEqual({ kind: "ok" });
+  });
+
+  it("POSTs to /api/cli/logout with Bearer", async () => {
+    await setup([{ status: 204 }]);
+    await client.logout();
+    expect(transport.calls[0]?.url).toBe(`${BASE_URL}/api/cli/logout`);
+    expect(transport.calls[0]?.init?.method).toBe("POST");
+  });
+
+  it("returns ok (no-op) when no credentials stored", async () => {
+    await setup([], null);
+    const result = await client.logout();
+    expect(result).toEqual({ kind: "ok" });
+    expect(transport.calls).toHaveLength(0);
+  });
+
+  it("returns transient when server unreachable, so local clear still proceeds", async () => {
+    await setup([{ throw: new Error("ECONNREFUSED") }]);
+    const result = await client.logout();
+    expect(result.kind).toBe("transient");
+  });
+});

--- a/apps/cli/src/hosted-client.ts
+++ b/apps/cli/src/hosted-client.ts
@@ -51,13 +51,29 @@ export interface HostedClientOptions {
   baseUrl: string;
   credentials: CredentialStore;
   transport?: Transport;
+  /** Per-request timeout for fetch calls. Defaults to 60s to accommodate server-side LLM generation. */
+  requestTimeoutMs?: number;
 }
 
 const DEFAULT_RATE_LIMIT_RETRY_SEC = 60;
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+
+function parseRetryAfter(value: string | null): number {
+  if (!value) return DEFAULT_RATE_LIMIT_RETRY_SEC;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds > 0) return seconds;
+  const dateMs = Date.parse(value);
+  if (!Number.isNaN(dateMs)) {
+    const diffSec = Math.ceil((dateMs - Date.now()) / 1000);
+    if (diffSec > 0) return diffSec;
+  }
+  return DEFAULT_RATE_LIMIT_RETRY_SEC;
+}
 
 export function createHostedClient(opts: HostedClientOptions): HostedClient {
   const transport = opts.transport ?? defaultTransport;
   const base = opts.baseUrl.replace(/\/$/, "");
+  const requestTimeoutMs = opts.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
 
   async function authorized(
     path: string,
@@ -68,7 +84,11 @@ export function createHostedClient(opts: HostedClientOptions): HostedClient {
     const headers = new Headers(init.headers ?? {});
     headers.set("authorization", `Bearer ${tokens.accessToken}`);
     try {
-      const res = await transport.fetch(`${base}${path}`, { ...init, headers });
+      const res = await transport.fetch(`${base}${path}`, {
+        ...init,
+        headers,
+        signal: init.signal ?? AbortSignal.timeout(requestTimeoutMs),
+      });
       return { kind: "response", res };
     } catch (err) {
       return { kind: "throw", err };
@@ -115,11 +135,9 @@ export function createHostedClient(opts: HostedClientOptions): HostedClient {
         };
       }
       if (res.status === 429) {
-        const retryAfter = res.headers.get("retry-after");
-        const seconds = retryAfter ? Number(retryAfter) : NaN;
         return {
           kind: "rate-limited",
-          retryAfterSeconds: Number.isFinite(seconds) && seconds > 0 ? seconds : DEFAULT_RATE_LIMIT_RETRY_SEC,
+          retryAfterSeconds: parseRetryAfter(res.headers.get("retry-after")),
         };
       }
       if (res.status >= 500) {

--- a/apps/cli/src/hosted-client.ts
+++ b/apps/cli/src/hosted-client.ts
@@ -1,0 +1,181 @@
+import {
+  IntakeResponseSchema,
+  SchemaMismatchResponseSchema,
+  WhoamiResponseSchema,
+  type BriefBody,
+  type TranscriptSubmission,
+  type VideoMetadata,
+  type WhoamiResponse,
+} from "@brief/core";
+import type { CredentialStore } from "./credentials";
+
+export interface Transport {
+  fetch(input: string | URL, init?: RequestInit): Promise<Response>;
+}
+
+export const defaultTransport: Transport = {
+  fetch: (input, init) => globalThis.fetch(input, init),
+};
+
+export type AuthRequiredReason = "missing" | "expired" | "revoked";
+
+export type BriefResult =
+  | {
+      kind: "ok";
+      briefId: string;
+      briefUrl: string;
+      brief: BriefBody;
+      metadata: VideoMetadata;
+    }
+  | { kind: "auth-required"; reason: AuthRequiredReason }
+  | { kind: "schema-mismatch"; serverAccepts: string[]; sent: string }
+  | { kind: "rate-limited"; retryAfterSeconds: number }
+  | { kind: "transient"; cause: string; message: string };
+
+export type IdentityResult =
+  | { kind: "ok"; email: string; userId: string }
+  | { kind: "auth-required"; reason: AuthRequiredReason }
+  | { kind: "transient"; cause: string; message: string };
+
+export type LogoutResult =
+  | { kind: "ok" }
+  | { kind: "transient"; cause: string; message: string };
+
+export interface HostedClient {
+  submit(submission: TranscriptSubmission): Promise<BriefResult>;
+  whoami(): Promise<IdentityResult>;
+  logout(): Promise<LogoutResult>;
+}
+
+export interface HostedClientOptions {
+  baseUrl: string;
+  credentials: CredentialStore;
+  transport?: Transport;
+}
+
+const DEFAULT_RATE_LIMIT_RETRY_SEC = 60;
+
+export function createHostedClient(opts: HostedClientOptions): HostedClient {
+  const transport = opts.transport ?? defaultTransport;
+  const base = opts.baseUrl.replace(/\/$/, "");
+
+  async function authorized(
+    path: string,
+    init: RequestInit,
+  ): Promise<{ kind: "no-creds" } | { kind: "response"; res: Response } | { kind: "throw"; err: unknown }> {
+    const tokens = await opts.credentials.read();
+    if (!tokens) return { kind: "no-creds" };
+    const headers = new Headers(init.headers ?? {});
+    headers.set("authorization", `Bearer ${tokens.accessToken}`);
+    try {
+      const res = await transport.fetch(`${base}${path}`, { ...init, headers });
+      return { kind: "response", res };
+    } catch (err) {
+      return { kind: "throw", err };
+    }
+  }
+
+  function transientFromThrow(err: unknown): BriefResult & { kind: "transient" } {
+    const message = err instanceof Error ? err.message : String(err);
+    return { kind: "transient", cause: message, message: `Network error: ${message}` };
+  }
+
+  function transientFromBody(message: string): BriefResult & { kind: "transient" } {
+    return { kind: "transient", cause: "invalid-response", message };
+  }
+
+  async function safeJson(res: Response): Promise<unknown> {
+    try {
+      return await res.json();
+    } catch {
+      return null;
+    }
+  }
+
+  return {
+    async submit(submission) {
+      const headers = new Headers({ "content-type": "application/json" });
+      const call = await authorized("/api/brief/intake", {
+        method: "POST",
+        headers,
+        body: JSON.stringify(submission),
+      });
+      if (call.kind === "no-creds") return { kind: "auth-required", reason: "missing" };
+      if (call.kind === "throw") return transientFromThrow(call.err);
+      const res = call.res;
+
+      if (res.status === 401) return { kind: "auth-required", reason: "expired" };
+      if (res.status === 409) {
+        const body = await safeJson(res);
+        const parsed = SchemaMismatchResponseSchema.safeParse(body);
+        return {
+          kind: "schema-mismatch",
+          serverAccepts: parsed.success ? parsed.data.serverAccepts : [],
+          sent: submission.schemaVersion,
+        };
+      }
+      if (res.status === 429) {
+        const retryAfter = res.headers.get("retry-after");
+        const seconds = retryAfter ? Number(retryAfter) : NaN;
+        return {
+          kind: "rate-limited",
+          retryAfterSeconds: Number.isFinite(seconds) && seconds > 0 ? seconds : DEFAULT_RATE_LIMIT_RETRY_SEC,
+        };
+      }
+      if (res.status >= 500) {
+        return { kind: "transient", cause: `http-${res.status}`, message: `Server returned ${res.status}` };
+      }
+      if (!res.ok) {
+        return { kind: "transient", cause: `http-${res.status}`, message: `Unexpected status ${res.status}` };
+      }
+
+      const body = await safeJson(res);
+      const parsed = IntakeResponseSchema.safeParse(body);
+      if (!parsed.success) return transientFromBody("Server returned an unrecognized body shape");
+      return {
+        kind: "ok",
+        briefId: parsed.data.briefId,
+        briefUrl: parsed.data.briefUrl,
+        brief: parsed.data.brief,
+        metadata: parsed.data.metadata,
+      };
+    },
+
+    async whoami() {
+      const call = await authorized("/api/cli/whoami", { method: "GET" });
+      if (call.kind === "no-creds") return { kind: "auth-required", reason: "missing" };
+      if (call.kind === "throw") {
+        const message = call.err instanceof Error ? call.err.message : String(call.err);
+        return { kind: "transient", cause: message, message: `Network error: ${message}` };
+      }
+      const res = call.res;
+      if (res.status === 401) return { kind: "auth-required", reason: "expired" };
+      if (!res.ok) {
+        return { kind: "transient", cause: `http-${res.status}`, message: `Unexpected status ${res.status}` };
+      }
+      const body = await safeJson(res);
+      const parsed = WhoamiResponseSchema.safeParse(body);
+      if (!parsed.success) {
+        return { kind: "transient", cause: "invalid-response", message: "Server returned an unrecognized identity shape" };
+      }
+      const result: WhoamiResponse = parsed.data;
+      return { kind: "ok", email: result.email, userId: result.userId };
+    },
+
+    async logout() {
+      const tokens = await opts.credentials.read();
+      if (!tokens) return { kind: "ok" };
+      const call = await authorized("/api/cli/logout", { method: "POST" });
+      if (call.kind === "no-creds") return { kind: "ok" };
+      if (call.kind === "throw") {
+        const message = call.err instanceof Error ? call.err.message : String(call.err);
+        return { kind: "transient", cause: message, message: `Network error: ${message}` };
+      }
+      const res = call.res;
+      if (res.ok || res.status === 401) {
+        return { kind: "ok" };
+      }
+      return { kind: "transient", cause: `http-${res.status}`, message: `Unexpected status ${res.status}` };
+    },
+  };
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -249,7 +249,14 @@ async function dispatchGenerate(argv: string[]): Promise<number> {
   if (common.supadataKey) generateOpts.supadataKey = common.supadataKey;
 
   return writeResult(
-    await runGenerate({ fetchTranscript, hostedClient }, generateOpts),
+    await runGenerate(
+      {
+        fetchTranscript,
+        hostedClient,
+        progress: (line) => process.stderr.write(`${line}\n`),
+      },
+      generateOpts,
+    ),
   );
 }
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,19 +1,14 @@
 import { parseArgs } from "node:util";
-import {
-  fetchMetadata,
-  fetchTranscript,
-  type MetadataResult,
-  type SourceName,
-  type TranscriptResult,
-} from "@brief/core";
+import { fetchMetadata, fetchTranscript, type SourceName } from "@brief/core";
 import { createAuthFlow } from "./auth";
 import { createFilesystemStore } from "./credentials";
-import { EXIT_ARG_ERROR, mapExitCode } from "./exit-codes";
+import { EXIT_ARG_ERROR } from "./exit-codes";
 import { createHostedClient } from "./hosted-client";
+import { runGenerate } from "./handlers/run-generate";
 import { runLogin } from "./handlers/run-login";
 import { runLogout } from "./handlers/run-logout";
+import { runTranscript } from "./handlers/run-transcript";
 import { runWhoami } from "./handlers/run-whoami";
-import { render, type CombinedResult } from "./renderer";
 
 const DEFAULT_API_BASE = "https://brief.niftymonkey.dev";
 
@@ -25,15 +20,17 @@ Subcommands:
   login                                    Sign in via WorkOS device flow
   logout                                   Sign out (clears local credentials)
   whoami [--json]                          Show the signed-in account
-  <url-or-id> [options]                    Fetch a YouTube transcript (legacy positional form)
+  transcript <url-or-id> [options]         Fetch a YouTube transcript locally
+  generate <url-or-id> [options]           Generate a brief on brief.niftymonkey.dev (requires login)
 
-Options (transcript flow):
+Options:
   --json                                   Emit machine-readable JSON
-  --no-metadata                            Skip YouTube Data API metadata fetch
-  --source=<auto|local|supadata>           Override the cascade. Default: auto.
-  --timeout=<ms>                           Overall request budget in ms
+  --no-metadata                            (transcript) Skip video-metadata fetch in the header
+  --with-frames                            (placeholder; frames pipeline lands in #87)
+  --source=<auto|local|supadata>           Override the transcript cascade
+  --timeout=<ms>                           Overall request budget
   --supadata-key=<key>                     Override SUPADATA_API_KEY env var
-  --youtube-key=<key>                      Override YOUTUBE_API_KEY env var
+  --youtube-key=<key>                      (transcript) Override YOUTUBE_API_KEY env var
   --help                                   Show this help
 
 Environment:
@@ -49,10 +46,11 @@ Exit codes:
   5  Authentication required (run \`brief login\`)
   6  CLI / server schema mismatch (upgrade brief)`;
 
-type ParsedTranscript = {
+type ParsedFlags = {
   values: {
     json?: boolean;
     "no-metadata"?: boolean;
+    "with-frames"?: boolean;
     source?: string;
     timeout?: string;
     "supadata-key"?: string;
@@ -62,13 +60,14 @@ type ParsedTranscript = {
   positionals: string[];
 };
 
-function parseTranscriptArgs(argv: string[]): ParsedTranscript {
+function parseFlags(argv: string[]): ParsedFlags {
   return parseArgs({
     args: argv,
     allowPositionals: true,
     options: {
       json: { type: "boolean" },
       "no-metadata": { type: "boolean" },
+      "with-frames": { type: "boolean" },
       source: { type: "string" },
       timeout: { type: "string" },
       "supadata-key": { type: "string" },
@@ -93,6 +92,59 @@ function writeResult(result: { stdout: string; stderr: string; exitCode: number 
 
 function getApiBase(): string {
   return process.env.BRIEF_API_URL ?? DEFAULT_API_BASE;
+}
+
+interface ParsedCommon {
+  input: string;
+  json: boolean;
+  noMetadata: boolean;
+  withFrames: boolean;
+  sources?: SourceName[];
+  signal?: AbortSignal;
+  supadataKey?: string;
+  youtubeKey?: string;
+}
+
+function buildCommonOpts(parsed: ParsedFlags): ParsedCommon | { error: string } {
+  const positional = parsed.positionals[0];
+  if (!positional) return { error: `Missing positional argument <url-or-id>\n\n${USAGE}\n` };
+
+  let sources: SourceName[] | undefined;
+  try {
+    sources = mapSource(parsed.values.source);
+  } catch (err) {
+    return { error: `${err instanceof Error ? err.message : String(err)}\n` };
+  }
+
+  let signal: AbortSignal | undefined;
+  if (parsed.values.timeout) {
+    const ms = Number(parsed.values.timeout);
+    if (!Number.isFinite(ms) || ms <= 0) {
+      return { error: "--timeout must be a positive number of ms\n" };
+    }
+    signal = AbortSignal.timeout(ms);
+  }
+
+  const supadataKey = parsed.values["supadata-key"] ?? process.env.SUPADATA_API_KEY;
+  const youtubeKey = parsed.values["youtube-key"] ?? process.env.YOUTUBE_API_KEY;
+
+  if (parsed.values.source === "supadata" && !supadataKey) {
+    return {
+      error: "--source=supadata requires SUPADATA_API_KEY or --supadata-key\n",
+    };
+  }
+
+  const opts: ParsedCommon = {
+    input: positional,
+    json: !!parsed.values.json,
+    noMetadata: !!parsed.values["no-metadata"],
+    withFrames: !!parsed.values["with-frames"],
+  };
+  if (sources) opts.sources = sources;
+  if (signal) opts.signal = signal;
+  if (supadataKey) opts.supadataKey = supadataKey;
+  if (youtubeKey) opts.youtubeKey = youtubeKey;
+  return opts;
 }
 
 async function dispatchLogin(): Promise<number> {
@@ -125,10 +177,7 @@ async function dispatchLogout(): Promise<number> {
 async function dispatchWhoami(argv: string[]): Promise<number> {
   let json = false;
   try {
-    const parsed = parseArgs({
-      args: argv,
-      options: { json: { type: "boolean" } },
-    });
+    const parsed = parseArgs({ args: argv, options: { json: { type: "boolean" } } });
     json = !!parsed.values.json;
   } catch (err) {
     process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
@@ -139,84 +188,69 @@ async function dispatchWhoami(argv: string[]): Promise<number> {
   return writeResult(await runWhoami({ hostedClient }, { json }));
 }
 
-async function dispatchLegacyTranscript(argv: string[]): Promise<number> {
-  let parsed: ParsedTranscript;
+async function dispatchTranscript(argv: string[], bareShortcut: boolean): Promise<number> {
+  let parsed: ParsedFlags;
   try {
-    parsed = parseTranscriptArgs(argv);
+    parsed = parseFlags(argv);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`${msg}\n\n${USAGE}\n`);
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n\n${USAGE}\n`);
     return EXIT_ARG_ERROR;
   }
-
   if (parsed.values.help) {
     process.stdout.write(`${USAGE}\n`);
     return EXIT_ARG_ERROR;
   }
-
-  const positional = parsed.positionals[0];
-  if (!positional) {
-    process.stderr.write(`Missing positional argument <url-or-id>\n\n${USAGE}\n`);
+  const common = buildCommonOpts(parsed);
+  if ("error" in common) {
+    process.stderr.write(common.error);
     return EXIT_ARG_ERROR;
   }
 
-  let sources: SourceName[] | undefined;
+  return writeResult(
+    await runTranscript(
+      { fetchTranscript, fetchMetadata },
+      {
+        ...common,
+        ...(bareShortcut ? { bareShortcut: true } : {}),
+        ttyStderr: !!process.stderr.isTTY,
+      },
+    ),
+  );
+}
+
+async function dispatchGenerate(argv: string[]): Promise<number> {
+  let parsed: ParsedFlags;
   try {
-    sources = mapSource(parsed.values.source);
+    parsed = parseFlags(argv);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`${msg}\n`);
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n\n${USAGE}\n`);
+    return EXIT_ARG_ERROR;
+  }
+  if (parsed.values.help) {
+    process.stdout.write(`${USAGE}\n`);
+    return EXIT_ARG_ERROR;
+  }
+  const common = buildCommonOpts(parsed);
+  if ("error" in common) {
+    process.stderr.write(common.error);
     return EXIT_ARG_ERROR;
   }
 
-  const supadataKey = parsed.values["supadata-key"] ?? process.env.SUPADATA_API_KEY;
-  const youtubeKey = parsed.values["youtube-key"] ?? process.env.YOUTUBE_API_KEY;
+  const credentials = createFilesystemStore();
+  const hostedClient = createHostedClient({ baseUrl: getApiBase(), credentials });
 
-  if (parsed.values.source === "supadata" && !supadataKey) {
-    process.stderr.write(
-      `--source=supadata requires SUPADATA_API_KEY or --supadata-key\n`,
-    );
-    return EXIT_ARG_ERROR;
-  }
-
-  let signal: AbortSignal | undefined;
-  if (parsed.values.timeout) {
-    const ms = Number(parsed.values.timeout);
-    if (!Number.isFinite(ms) || ms <= 0) {
-      process.stderr.write(`--timeout must be a positive number of ms\n`);
-      return EXIT_ARG_ERROR;
-    }
-    signal = AbortSignal.timeout(ms);
-  }
-
-  const wantMetadata = !parsed.values["no-metadata"] && !!youtubeKey;
-
-  const transcriptPromise: Promise<TranscriptResult> = fetchTranscript(positional, {
-    ...(supadataKey ? { supadataApiKey: supadataKey } : {}),
-    ...(sources ? { sources } : {}),
-    ...(signal ? { signal } : {}),
-  });
-  const metadataPromise: Promise<MetadataResult | null> = wantMetadata
-    ? fetchMetadata(positional, {
-        youtubeApiKey: youtubeKey!,
-        ...(signal ? { signal } : {}),
-      })
-    : Promise.resolve(null);
-
-  const [transcript, metadata] = await Promise.all([transcriptPromise, metadataPromise]);
-
-  const combined: CombinedResult = {
-    videoIdOrUrl: positional,
-    transcript,
-    metadata,
+  const generateOpts: Parameters<typeof runGenerate>[1] = {
+    input: common.input,
+    json: common.json,
+    withFrames: common.withFrames,
   };
+  if (common.sources) generateOpts.sources = common.sources;
+  if (common.signal) generateOpts.signal = common.signal;
+  if (common.supadataKey) generateOpts.supadataKey = common.supadataKey;
 
-  const format = parsed.values.json ? "json" : "human";
-  const out = render(combined, format, !!process.stderr.isTTY);
-  if (out.stdout) process.stdout.write(out.stdout);
-  if (out.stderr) process.stderr.write(out.stderr);
-
-  return mapExitCode(transcript);
+  return writeResult(
+    await runGenerate({ fetchTranscript, hostedClient }, generateOpts),
+  );
 }
 
 async function main(): Promise<number> {
@@ -230,8 +264,12 @@ async function main(): Promise<number> {
       return dispatchLogout();
     case "whoami":
       return dispatchWhoami(argv.slice(1));
+    case "transcript":
+      return dispatchTranscript(argv.slice(1), false);
+    case "generate":
+      return dispatchGenerate(argv.slice(1));
     default:
-      return dispatchLegacyTranscript(argv);
+      return dispatchTranscript(argv, true);
   }
 }
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -198,7 +198,7 @@ async function dispatchTranscript(argv: string[], bareShortcut: boolean): Promis
   }
   if (parsed.values.help) {
     process.stdout.write(`${USAGE}\n`);
-    return EXIT_ARG_ERROR;
+    return 0;
   }
   const common = buildCommonOpts(parsed);
   if ("error" in common) {
@@ -228,7 +228,7 @@ async function dispatchGenerate(argv: string[]): Promise<number> {
   }
   if (parsed.values.help) {
     process.stdout.write(`${USAGE}\n`);
-    return EXIT_ARG_ERROR;
+    return 0;
   }
   const common = buildCommonOpts(parsed);
   if ("error" in common) {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -6,31 +6,50 @@ import {
   type SourceName,
   type TranscriptResult,
 } from "@brief/core";
-import { mapExitCode } from "./exit-codes";
+import { createAuthFlow } from "./auth";
+import { createFilesystemStore } from "./credentials";
+import { EXIT_ARG_ERROR, mapExitCode } from "./exit-codes";
+import { createHostedClient } from "./hosted-client";
+import { runLogin } from "./handlers/run-login";
+import { runLogout } from "./handlers/run-logout";
+import { runWhoami } from "./handlers/run-whoami";
 import { render, type CombinedResult } from "./renderer";
 
-const USAGE = `Usage: brief <url-or-id> [options]
+const DEFAULT_API_BASE = "https://brief.niftymonkey.dev";
 
-Fetch a YouTube transcript on stdout.
+const USAGE = `Usage:
+  brief <subcommand> [options]
+  brief <url-or-id> [options]              # shortcut for: brief transcript <url-or-id>
 
-Options:
-  --json                    Emit machine-readable JSON instead of human output
-  --no-metadata             Skip the YouTube Data API metadata fetch
-  --source=<auto|local|supadata>
-                            Override the cascade. Default: auto.
-  --timeout=<ms>            Overall request budget in milliseconds
-  --supadata-key=<key>      Override SUPADATA_API_KEY env var
-  --youtube-key=<key>       Override YOUTUBE_API_KEY env var
-  --help                    Show this help
+Subcommands:
+  login                                    Sign in via WorkOS device flow
+  logout                                   Sign out (clears local credentials)
+  whoami [--json]                          Show the signed-in account
+  <url-or-id> [options]                    Fetch a YouTube transcript (legacy positional form)
+
+Options (transcript flow):
+  --json                                   Emit machine-readable JSON
+  --no-metadata                            Skip YouTube Data API metadata fetch
+  --source=<auto|local|supadata>           Override the cascade. Default: auto.
+  --timeout=<ms>                           Overall request budget in ms
+  --supadata-key=<key>                     Override SUPADATA_API_KEY env var
+  --youtube-key=<key>                      Override YOUTUBE_API_KEY env var
+  --help                                   Show this help
+
+Environment:
+  BRIEF_API_URL                            Hosted brief service URL (default: ${DEFAULT_API_BASE})
+  WORKOS_CLIENT_ID                         WorkOS client ID (required for login)
 
 Exit codes:
-  0  Transcript retrieved
+  0  Success
   1  Argument or unexpected error
   2  Async generation queued (jobId in output)
   3  Permanently unavailable
-  4  Transient failure after retries`;
+  4  Transient failure
+  5  Authentication required (run \`brief login\`)
+  6  CLI / server schema mismatch (upgrade brief)`;
 
-type Parsed = {
+type ParsedTranscript = {
   values: {
     json?: boolean;
     "no-metadata"?: boolean;
@@ -43,7 +62,7 @@ type Parsed = {
   positionals: string[];
 };
 
-function parse(argv: string[]): Parsed {
+function parseTranscriptArgs(argv: string[]): ParsedTranscript {
   return parseArgs({
     args: argv,
     allowPositionals: true,
@@ -66,25 +85,79 @@ function mapSource(value: string | undefined): SourceName[] | undefined {
   throw new Error(`Invalid --source=${value}; expected auto|local|supadata`);
 }
 
-async function main(): Promise<number> {
-  let parsed: Parsed;
+function writeResult(result: { stdout: string; stderr: string; exitCode: number }): number {
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  return result.exitCode;
+}
+
+function getApiBase(): string {
+  return process.env.BRIEF_API_URL ?? DEFAULT_API_BASE;
+}
+
+async function dispatchLogin(): Promise<number> {
+  const clientId = process.env.WORKOS_CLIENT_ID;
+  if (!clientId) {
+    process.stderr.write(
+      "Login requires WORKOS_CLIENT_ID env var. Ask brief support for the value.\n",
+    );
+    return EXIT_ARG_ERROR;
+  }
+  const authFlow = createAuthFlow({
+    clientId,
+    onCode: (info) => {
+      const display = info.verificationUriComplete ?? info.verificationUri;
+      process.stderr.write(
+        `\nTo sign in, visit:\n  ${display}\n\nAnd enter the code:\n  ${info.userCode}\n\nWaiting for authorization...\n\n`,
+      );
+    },
+  });
+  const credentials = createFilesystemStore();
+  return writeResult(await runLogin({ authFlow, credentials }));
+}
+
+async function dispatchLogout(): Promise<number> {
+  const credentials = createFilesystemStore();
+  const hostedClient = createHostedClient({ baseUrl: getApiBase(), credentials });
+  return writeResult(await runLogout({ hostedClient, credentials }));
+}
+
+async function dispatchWhoami(argv: string[]): Promise<number> {
+  let json = false;
   try {
-    parsed = parse(process.argv.slice(2));
+    const parsed = parseArgs({
+      args: argv,
+      options: { json: { type: "boolean" } },
+    });
+    json = !!parsed.values.json;
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    return EXIT_ARG_ERROR;
+  }
+  const credentials = createFilesystemStore();
+  const hostedClient = createHostedClient({ baseUrl: getApiBase(), credentials });
+  return writeResult(await runWhoami({ hostedClient }, { json }));
+}
+
+async function dispatchLegacyTranscript(argv: string[]): Promise<number> {
+  let parsed: ParsedTranscript;
+  try {
+    parsed = parseTranscriptArgs(argv);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     process.stderr.write(`${msg}\n\n${USAGE}\n`);
-    return 1;
+    return EXIT_ARG_ERROR;
   }
 
   if (parsed.values.help) {
     process.stdout.write(`${USAGE}\n`);
-    return 1;
+    return EXIT_ARG_ERROR;
   }
 
   const positional = parsed.positionals[0];
   if (!positional) {
     process.stderr.write(`Missing positional argument <url-or-id>\n\n${USAGE}\n`);
-    return 1;
+    return EXIT_ARG_ERROR;
   }
 
   let sources: SourceName[] | undefined;
@@ -93,7 +166,7 @@ async function main(): Promise<number> {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     process.stderr.write(`${msg}\n`);
-    return 1;
+    return EXIT_ARG_ERROR;
   }
 
   const supadataKey = parsed.values["supadata-key"] ?? process.env.SUPADATA_API_KEY;
@@ -101,9 +174,9 @@ async function main(): Promise<number> {
 
   if (parsed.values.source === "supadata" && !supadataKey) {
     process.stderr.write(
-      `--source=supadata requires SUPADATA_API_KEY or --supadata-key\n`
+      `--source=supadata requires SUPADATA_API_KEY or --supadata-key\n`,
     );
-    return 1;
+    return EXIT_ARG_ERROR;
   }
 
   let signal: AbortSignal | undefined;
@@ -111,21 +184,18 @@ async function main(): Promise<number> {
     const ms = Number(parsed.values.timeout);
     if (!Number.isFinite(ms) || ms <= 0) {
       process.stderr.write(`--timeout must be a positive number of ms\n`);
-      return 1;
+      return EXIT_ARG_ERROR;
     }
     signal = AbortSignal.timeout(ms);
   }
 
   const wantMetadata = !parsed.values["no-metadata"] && !!youtubeKey;
 
-  const transcriptPromise: Promise<TranscriptResult> = fetchTranscript(
-    positional,
-    {
-      ...(supadataKey ? { supadataApiKey: supadataKey } : {}),
-      ...(sources ? { sources } : {}),
-      ...(signal ? { signal } : {}),
-    }
-  );
+  const transcriptPromise: Promise<TranscriptResult> = fetchTranscript(positional, {
+    ...(supadataKey ? { supadataApiKey: supadataKey } : {}),
+    ...(sources ? { sources } : {}),
+    ...(signal ? { signal } : {}),
+  });
   const metadataPromise: Promise<MetadataResult | null> = wantMetadata
     ? fetchMetadata(positional, {
         youtubeApiKey: youtubeKey!,
@@ -133,10 +203,7 @@ async function main(): Promise<number> {
       })
     : Promise.resolve(null);
 
-  const [transcript, metadata] = await Promise.all([
-    transcriptPromise,
-    metadataPromise,
-  ]);
+  const [transcript, metadata] = await Promise.all([transcriptPromise, metadataPromise]);
 
   const combined: CombinedResult = {
     videoIdOrUrl: positional,
@@ -152,11 +219,27 @@ async function main(): Promise<number> {
   return mapExitCode(transcript);
 }
 
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2);
+  const subcommand = argv[0];
+
+  switch (subcommand) {
+    case "login":
+      return dispatchLogin();
+    case "logout":
+      return dispatchLogout();
+    case "whoami":
+      return dispatchWhoami(argv.slice(1));
+    default:
+      return dispatchLegacyTranscript(argv);
+  }
+}
+
 main().then(
   (code) => process.exit(code),
   (err) => {
     const msg = err instanceof Error ? err.message : String(err);
     process.stderr.write(`Unexpected error: ${msg}\n`);
-    process.exit(1);
-  }
+    process.exit(EXIT_ARG_ERROR);
+  },
 );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "migrate": "tsx scripts/migrate.ts",
     "backfill-search": "tsx scripts/backfill-search.ts",
     "query": "tsx scripts/query.ts",
@@ -52,6 +55,7 @@
     "dotenv": "^17.2.3",
     "geist": "^1.5.1",
     "get-youtube-chapters": "^2.0.0",
+    "jose": "^5.9.6",
     "lucide-react": "^0.468.0",
     "next": "16.1.3",
     "next-themes": "^0.4.4",
@@ -73,6 +77,7 @@
     "tailwindcss": "^4.0.0",
     "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.9"
   }
 }

--- a/apps/web/src/app/api/brief/intake/route.ts
+++ b/apps/web/src/app/api/brief/intake/route.ts
@@ -3,6 +3,7 @@ import { TranscriptSubmissionSchema } from "@brief/core";
 import { extractBearer } from "@/lib/cli-auth";
 import { createWorkosTokenVerifier } from "@/lib/cli-auth-workos";
 import { handleIntake, type IntakeDeps } from "@/lib/cli-intake";
+import { fetchVideoMetadata } from "@/lib/metadata";
 import { generateBrief } from "@/lib/summarize";
 import { saveBrief } from "@/lib/db";
 
@@ -33,17 +34,19 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const apiKey = process.env.OPENROUTER_API_KEY ?? "";
+  const llmApiKey = process.env.OPENROUTER_API_KEY ?? "";
+  const youtubeApiKey = process.env.YOUTUBE_API_KEY ?? "";
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://brief.niftymonkey.dev";
 
   const deps: IntakeDeps = {
+    fetchVideoMetadata: (videoId) => fetchVideoMetadata(videoId, youtubeApiKey),
     generateBrief: (transcript, metadata, key) => generateBrief(transcript, metadata, key),
-    // TODO(chunk-7/8): persist frames discriminator + frames_status. v1 writes 'not-requested' default.
+    // TODO(chunk-8): persist frames discriminator + frames_status. v1 writes 'not-requested' default via saveBrief.
     saveSubmission: async ({ userId, metadata, brief, briefMetrics }) => {
       const dbBrief = await saveBrief(userId, metadata, brief, false, null, briefMetrics);
       return { briefId: dbBrief.id };
     },
-    llmApiKey: apiKey,
+    llmApiKey,
     buildBriefUrl: (briefId) => `${appUrl}/brief/${briefId}`,
   };
 

--- a/apps/web/src/app/api/brief/intake/route.ts
+++ b/apps/web/src/app/api/brief/intake/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: NextRequest) {
 
   const llmApiKey = process.env.OPENROUTER_API_KEY ?? "";
   const youtubeApiKey = process.env.YOUTUBE_API_KEY ?? "";
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://brief.niftymonkey.dev";
+  const origin = req.nextUrl.origin;
 
   const deps: IntakeDeps = {
     fetchVideoMetadata: (videoId) => fetchVideoMetadata(videoId, youtubeApiKey),
@@ -47,7 +47,7 @@ export async function POST(req: NextRequest) {
       return { briefId: dbBrief.id };
     },
     llmApiKey,
-    buildBriefUrl: (briefId) => `${appUrl}/brief/${briefId}`,
+    buildBriefUrl: (briefId) => `${origin}/brief/${briefId}`,
   };
 
   const result = await handleIntake(parsed.data, { userId: verified.userId }, deps);

--- a/apps/web/src/app/api/brief/intake/route.ts
+++ b/apps/web/src/app/api/brief/intake/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { TranscriptSubmissionSchema } from "@brief/core";
+import { extractBearer } from "@/lib/cli-auth";
+import { createWorkosTokenVerifier } from "@/lib/cli-auth-workos";
+import { handleIntake, type IntakeDeps } from "@/lib/cli-intake";
+import { generateBrief } from "@/lib/summarize";
+import { saveBrief } from "@/lib/db";
+
+function unauthorized(reason: string) {
+  return NextResponse.json(
+    { error: reason },
+    { status: 401, headers: { "www-authenticate": 'Bearer realm="brief"' } },
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const token = extractBearer(req.headers.get("authorization"));
+  if (!token) return unauthorized("missing-auth");
+
+  const verifier = createWorkosTokenVerifier();
+  const verified = await verifier.verify(token);
+  if (verified.kind !== "ok") return unauthorized(verified.kind);
+
+  const rawBody = await req.json().catch(() => null);
+  if (rawBody === null) {
+    return NextResponse.json({ error: "invalid-json" }, { status: 400 });
+  }
+  const parsed = TranscriptSubmissionSchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "invalid-body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  const apiKey = process.env.OPENROUTER_API_KEY ?? "";
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://brief.niftymonkey.dev";
+
+  const deps: IntakeDeps = {
+    generateBrief: (transcript, metadata, key) => generateBrief(transcript, metadata, key),
+    // TODO(chunk-7/8): persist frames discriminator + frames_status. v1 writes 'not-requested' default.
+    saveSubmission: async ({ userId, metadata, brief, briefMetrics }) => {
+      const dbBrief = await saveBrief(userId, metadata, brief, false, null, briefMetrics);
+      return { briefId: dbBrief.id };
+    },
+    llmApiKey: apiKey,
+    buildBriefUrl: (briefId) => `${appUrl}/brief/${briefId}`,
+  };
+
+  const result = await handleIntake(parsed.data, { userId: verified.userId }, deps);
+
+  if (result.kind === "transient") {
+    return NextResponse.json(
+      { error: "transient", cause: result.cause, message: result.message },
+      { status: 503 },
+    );
+  }
+  return NextResponse.json(result.response);
+}

--- a/apps/web/src/app/api/brief/intake/route.ts
+++ b/apps/web/src/app/api/brief/intake/route.ts
@@ -14,7 +14,23 @@ function unauthorized(reason: string) {
   );
 }
 
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}
+
 export async function POST(req: NextRequest) {
+  let llmApiKey: string;
+  let youtubeApiKey: string;
+  try {
+    llmApiKey = requireEnv("OPENROUTER_API_KEY");
+    youtubeApiKey = requireEnv("YOUTUBE_API_KEY");
+  } catch (err) {
+    console.error("[intake] env-misconfig:", err);
+    return NextResponse.json({ error: "server-misconfigured" }, { status: 500 });
+  }
+
   const token = extractBearer(req.headers.get("authorization"));
   if (!token) return unauthorized("missing-auth");
 
@@ -34,8 +50,6 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const llmApiKey = process.env.OPENROUTER_API_KEY ?? "";
-  const youtubeApiKey = process.env.YOUTUBE_API_KEY ?? "";
   const origin = req.nextUrl.origin;
 
   const deps: IntakeDeps = {
@@ -53,10 +67,12 @@ export async function POST(req: NextRequest) {
   const result = await handleIntake(parsed.data, { userId: verified.userId }, deps);
 
   if (result.kind === "transient") {
-    return NextResponse.json(
-      { error: "transient", cause: result.cause, message: result.message },
-      { status: 503 },
+    console.error(
+      `[intake] transient failure for user ${verified.userId}:`,
+      result.cause,
+      result.message,
     );
+    return NextResponse.json({ error: "transient" }, { status: 503 });
   }
   return NextResponse.json(result.response);
 }

--- a/apps/web/src/app/api/cli/logout/route.ts
+++ b/apps/web/src/app/api/cli/logout/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { extractBearer } from "@/lib/cli-auth";
+
+export async function POST(req: NextRequest) {
+  const token = extractBearer(req.headers.get("authorization"));
+  if (!token) {
+    return NextResponse.json(
+      { error: "missing-auth" },
+      { status: 401, headers: { "www-authenticate": 'Bearer realm="brief"' } },
+    );
+  }
+  // Best-effort revoke: v1 does not maintain a server-side refresh-token store,
+  // so there is nothing to invalidate beyond ack'ing the request. The CLI clears
+  // its local credentials regardless of this endpoint's response. A future
+  // change can plug in WorkOS session revocation here when it ships.
+  return new NextResponse(null, { status: 204 });
+}

--- a/apps/web/src/app/api/cli/whoami/route.ts
+++ b/apps/web/src/app/api/cli/whoami/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { extractBearer } from "@/lib/cli-auth";
+import { createWorkosTokenVerifier, lookupWorkosUserEmail } from "@/lib/cli-auth-workos";
+
+function unauthorized(reason: string) {
+  return NextResponse.json(
+    { error: reason },
+    { status: 401, headers: { "www-authenticate": 'Bearer realm="brief"' } },
+  );
+}
+
+export async function GET(req: NextRequest) {
+  const token = extractBearer(req.headers.get("authorization"));
+  if (!token) return unauthorized("missing-auth");
+
+  const verifier = createWorkosTokenVerifier();
+  const verified = await verifier.verify(token);
+  if (verified.kind !== "ok") return unauthorized(verified.kind);
+
+  try {
+    const userInfo = await lookupWorkosUserEmail(verified.userId);
+    if (!userInfo) {
+      return NextResponse.json({ error: "user-not-found" }, { status: 503 });
+    }
+    return NextResponse.json({ userId: verified.userId, email: userInfo.email });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: "transient", message }, { status: 503 });
+  }
+}

--- a/apps/web/src/app/api/cli/whoami/route.ts
+++ b/apps/web/src/app/api/cli/whoami/route.ts
@@ -20,11 +20,12 @@ export async function GET(req: NextRequest) {
   try {
     const userInfo = await lookupWorkosUserEmail(verified.userId);
     if (!userInfo) {
+      console.error(`[whoami] user not found in WorkOS: ${verified.userId}`);
       return NextResponse.json({ error: "user-not-found" }, { status: 503 });
     }
     return NextResponse.json({ userId: verified.userId, email: userInfo.email });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: "transient", message }, { status: 503 });
+    console.error(`[whoami] lookup failed for ${verified.userId}:`, err);
+    return NextResponse.json({ error: "transient" }, { status: 503 });
   }
 }

--- a/apps/web/src/lib/cli-auth-workos.ts
+++ b/apps/web/src/lib/cli-auth-workos.ts
@@ -2,22 +2,32 @@ import { createRemoteJWKSet, jwtVerify } from "jose";
 import { createTokenVerifier, type TokenVerifier } from "./cli-auth";
 
 const WORKOS_API_BASE = "https://api.workos.com";
+const WORKOS_ISSUER = "https://api.workos.com";
+const USER_LOOKUP_TIMEOUT_MS = 10_000;
 
 let cachedJwks: ReturnType<typeof createRemoteJWKSet> | null = null;
 
-function getJwks() {
-  if (cachedJwks) return cachedJwks;
+function requireClientId(): string {
   const clientId = process.env.WORKOS_CLIENT_ID;
   if (!clientId) {
     throw new Error("WORKOS_CLIENT_ID env var is required for CLI token verification");
   }
+  return clientId;
+}
+
+function getJwks() {
+  if (cachedJwks) return cachedJwks;
+  const clientId = requireClientId();
   cachedJwks = createRemoteJWKSet(new URL(`${WORKOS_API_BASE}/sso/jwks/${clientId}`));
   return cachedJwks;
 }
 
 export function createWorkosTokenVerifier(): TokenVerifier {
   return createTokenVerifier(async (token) => {
-    return jwtVerify(token, getJwks());
+    return jwtVerify(token, getJwks(), {
+      issuer: WORKOS_ISSUER,
+      audience: requireClientId(),
+    });
   });
 }
 
@@ -32,6 +42,7 @@ export async function lookupWorkosUserEmail(userId: string): Promise<WorkosUserL
   }
   const res = await fetch(`${WORKOS_API_BASE}/user_management/users/${userId}`, {
     headers: { authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(USER_LOOKUP_TIMEOUT_MS),
   });
   if (!res.ok) return null;
   const body = (await res.json()) as { email?: string };

--- a/apps/web/src/lib/cli-auth-workos.ts
+++ b/apps/web/src/lib/cli-auth-workos.ts
@@ -40,11 +40,17 @@ export async function lookupWorkosUserEmail(userId: string): Promise<WorkosUserL
   if (!apiKey) {
     throw new Error("WORKOS_API_KEY env var is required for CLI user lookup");
   }
-  const res = await fetch(`${WORKOS_API_BASE}/user_management/users/${userId}`, {
-    headers: { authorization: `Bearer ${apiKey}` },
-    signal: AbortSignal.timeout(USER_LOOKUP_TIMEOUT_MS),
-  });
-  if (!res.ok) return null;
+  const res = await fetch(
+    `${WORKOS_API_BASE}/user_management/users/${encodeURIComponent(userId)}`,
+    {
+      headers: { authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(USER_LOOKUP_TIMEOUT_MS),
+    },
+  );
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`WorkOS user lookup failed with status ${res.status}`);
+  }
   const body = (await res.json()) as { email?: string };
   if (!body.email) return null;
   return { email: body.email };

--- a/apps/web/src/lib/cli-auth-workos.ts
+++ b/apps/web/src/lib/cli-auth-workos.ts
@@ -1,0 +1,40 @@
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import { createTokenVerifier, type TokenVerifier } from "./cli-auth";
+
+const WORKOS_API_BASE = "https://api.workos.com";
+
+let cachedJwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+
+function getJwks() {
+  if (cachedJwks) return cachedJwks;
+  const clientId = process.env.WORKOS_CLIENT_ID;
+  if (!clientId) {
+    throw new Error("WORKOS_CLIENT_ID env var is required for CLI token verification");
+  }
+  cachedJwks = createRemoteJWKSet(new URL(`${WORKOS_API_BASE}/sso/jwks/${clientId}`));
+  return cachedJwks;
+}
+
+export function createWorkosTokenVerifier(): TokenVerifier {
+  return createTokenVerifier(async (token) => {
+    return jwtVerify(token, getJwks());
+  });
+}
+
+export interface WorkosUserLookupResult {
+  email: string;
+}
+
+export async function lookupWorkosUserEmail(userId: string): Promise<WorkosUserLookupResult | null> {
+  const apiKey = process.env.WORKOS_API_KEY;
+  if (!apiKey) {
+    throw new Error("WORKOS_API_KEY env var is required for CLI user lookup");
+  }
+  const res = await fetch(`${WORKOS_API_BASE}/user_management/users/${userId}`, {
+    headers: { authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) return null;
+  const body = (await res.json()) as { email?: string };
+  if (!body.email) return null;
+  return { email: body.email };
+}

--- a/apps/web/src/lib/cli-auth.test.ts
+++ b/apps/web/src/lib/cli-auth.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import {
+  createTokenVerifier,
+  extractBearer,
+  type JwtVerifyFn,
+} from "./cli-auth";
+
+describe("extractBearer", () => {
+  it("extracts the token from a Bearer prefix", () => {
+    expect(extractBearer("Bearer abc.def.ghi")).toBe("abc.def.ghi");
+  });
+
+  it("is case-insensitive on the scheme", () => {
+    expect(extractBearer("bearer abc")).toBe("abc");
+    expect(extractBearer("BEARER abc")).toBe("abc");
+  });
+
+  it("returns null for a null header", () => {
+    expect(extractBearer(null)).toBe(null);
+  });
+
+  it("returns null for an empty header", () => {
+    expect(extractBearer("")).toBe(null);
+  });
+
+  it("returns null for a non-Bearer scheme", () => {
+    expect(extractBearer("Basic dXNlcjpwYXNz")).toBe(null);
+  });
+
+  it("returns null for a Bearer prefix with no token", () => {
+    expect(extractBearer("Bearer ")).toBe(null);
+    expect(extractBearer("Bearer")).toBe(null);
+  });
+});
+
+function jwtError(code: string, message = code): Error & { code: string } {
+  const err = new Error(message) as Error & { code: string };
+  err.code = code;
+  return err;
+}
+
+describe("createTokenVerifier", () => {
+  it("returns ok with userId when JWT verifies and carries a sub claim", async () => {
+    const stub: JwtVerifyFn = async () => ({ payload: { sub: "user_01H" } });
+    const verifier = createTokenVerifier(stub);
+    const result = await verifier.verify("any.token.here");
+    expect(result).toEqual({ kind: "ok", userId: "user_01H" });
+  });
+
+  it("returns malformed when JWT verifies but has no sub claim", async () => {
+    const stub: JwtVerifyFn = async () => ({ payload: {} });
+    const verifier = createTokenVerifier(stub);
+    const result = await verifier.verify("token");
+    expect(result).toEqual({ kind: "malformed" });
+  });
+
+  it("returns expired when jose throws ERR_JWT_EXPIRED", async () => {
+    const stub: JwtVerifyFn = async () => {
+      throw jwtError("ERR_JWT_EXPIRED");
+    };
+    const verifier = createTokenVerifier(stub);
+    const result = await verifier.verify("token");
+    expect(result).toEqual({ kind: "expired" });
+  });
+
+  it("returns invalid when jose throws ERR_JWS_SIGNATURE_VERIFICATION_FAILED", async () => {
+    const stub: JwtVerifyFn = async () => {
+      throw jwtError("ERR_JWS_SIGNATURE_VERIFICATION_FAILED");
+    };
+    const verifier = createTokenVerifier(stub);
+    const result = await verifier.verify("token");
+    expect(result).toEqual({ kind: "invalid" });
+  });
+
+  it("returns invalid when jose throws ERR_JWT_CLAIM_VALIDATION_FAILED", async () => {
+    const stub: JwtVerifyFn = async () => {
+      throw jwtError("ERR_JWT_CLAIM_VALIDATION_FAILED");
+    };
+    const verifier = createTokenVerifier(stub);
+    const result = await verifier.verify("token");
+    expect(result).toEqual({ kind: "invalid" });
+  });
+
+  it("returns invalid when jose throws ERR_JWS_INVALID", async () => {
+    const stub: JwtVerifyFn = async () => {
+      throw jwtError("ERR_JWS_INVALID");
+    };
+    const verifier = createTokenVerifier(stub);
+    const result = await verifier.verify("not-a-jwt");
+    expect(result).toEqual({ kind: "invalid" });
+  });
+
+  it("returns transient on unknown errors (e.g., JWKS fetch failure)", async () => {
+    const stub: JwtVerifyFn = async () => {
+      throw new Error("Connection refused to JWKS endpoint");
+    };
+    const verifier = createTokenVerifier(stub);
+    const result = await verifier.verify("token");
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") {
+      expect(result.cause).toMatch(/Connection refused/);
+    }
+  });
+});

--- a/apps/web/src/lib/cli-auth.ts
+++ b/apps/web/src/lib/cli-auth.ts
@@ -1,0 +1,50 @@
+export interface VerifiedUser {
+  userId: string;
+}
+
+export type TokenVerificationResult =
+  | { kind: "ok"; userId: string }
+  | { kind: "malformed" }
+  | { kind: "expired" }
+  | { kind: "invalid" }
+  | { kind: "transient"; cause: string };
+
+export type JwtVerifyFn = (token: string) => Promise<{ payload: { sub?: string } }>;
+
+export interface TokenVerifier {
+  verify(token: string): Promise<TokenVerificationResult>;
+}
+
+export function extractBearer(authorizationHeader: string | null): string | null {
+  if (!authorizationHeader) return null;
+  const match = authorizationHeader.match(/^Bearer\s+(.+)$/i);
+  if (!match) return null;
+  const token = match[1].trim();
+  return token.length > 0 ? token : null;
+}
+
+const INVALID_CODES = new Set([
+  "ERR_JWS_SIGNATURE_VERIFICATION_FAILED",
+  "ERR_JWT_CLAIM_VALIDATION_FAILED",
+  "ERR_JWS_INVALID",
+  "ERR_JWT_INVALID",
+  "ERR_JOSE_NOT_SUPPORTED",
+]);
+
+export function createTokenVerifier(jwtVerify: JwtVerifyFn): TokenVerifier {
+  return {
+    async verify(token) {
+      try {
+        const { payload } = await jwtVerify(token);
+        if (!payload.sub) return { kind: "malformed" };
+        return { kind: "ok", userId: payload.sub };
+      } catch (err) {
+        const code = (err as { code?: string }).code;
+        if (code === "ERR_JWT_EXPIRED") return { kind: "expired" };
+        if (code && INVALID_CODES.has(code)) return { kind: "invalid" };
+        const message = err instanceof Error ? err.message : String(err);
+        return { kind: "transient", cause: message };
+      }
+    },
+  };
+}

--- a/apps/web/src/lib/cli-intake.test.ts
+++ b/apps/web/src/lib/cli-intake.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi } from "vitest";
+import type { TranscriptSubmission } from "@brief/core";
+import {
+  handleIntake,
+  toFlatSpeechEntries,
+  type IntakeDeps,
+} from "./cli-intake";
+
+const sampleMetadata = {
+  videoId: "abc123XYZAB",
+  title: "Test video",
+  channelTitle: "Test channel",
+  channelId: "UC_abc",
+  duration: "PT3M30S",
+  publishedAt: "2024-01-01T00:00:00Z",
+  description: "A test description",
+};
+
+const sampleSpeech = {
+  kind: "speech" as const,
+  offsetSec: 0,
+  durationSec: 5.2,
+  text: "Hello world",
+};
+
+const sampleVisual = {
+  kind: "visual" as const,
+  offsetSec: 30,
+  mode: "verbatim" as const,
+  text: "[VISUAL] Pricing: $19/mo",
+};
+
+const sampleBrief = {
+  summary: "Generated summary",
+  sections: [],
+  relatedLinks: [],
+  otherLinks: [],
+};
+
+const sampleBriefMetrics = {
+  inputTokens: 1000,
+  outputTokens: 200,
+  model: "openai/gpt-5.5",
+  latencyMs: 1234,
+};
+
+const transcriptOnlySubmission: TranscriptSubmission = {
+  schemaVersion: "2.0.0",
+  videoId: "abc123XYZAB",
+  metadata: sampleMetadata,
+  transcript: [sampleSpeech],
+  frames: { kind: "not-requested" },
+};
+
+const augmentedSubmission: TranscriptSubmission = {
+  schemaVersion: "2.0.0",
+  videoId: "abc123XYZAB",
+  metadata: sampleMetadata,
+  transcript: [sampleSpeech, sampleVisual],
+  frames: {
+    kind: "included",
+    metrics: {
+      videoDurationSec: 210,
+      candidatesGenerated: 80,
+      candidatesAfterDedup: 50,
+      classifierYes: 15,
+      classifierNo: 35,
+      visionCalls: 15,
+      inputTokens: 27000,
+      outputTokens: 4000,
+      classifierModel: "openai/gpt-5.4-nano",
+      visionModel: "openai/gpt-5.5",
+      wallClockMs: 250000,
+      costSource: "cli-reported",
+    },
+  },
+};
+
+function makeDeps(overrides: Partial<IntakeDeps> = {}): IntakeDeps {
+  return {
+    generateBrief: vi.fn().mockResolvedValue({
+      brief: sampleBrief,
+      metrics: sampleBriefMetrics,
+    }),
+    saveSubmission: vi.fn().mockResolvedValue({ briefId: "brief_01abc" }),
+    llmApiKey: "test-key",
+    buildBriefUrl: (id: string) => `https://brief.test/brief/${id}`,
+    ...overrides,
+  };
+}
+
+describe("toFlatSpeechEntries", () => {
+  it("converts speech entries to the legacy flat shape", () => {
+    const result = toFlatSpeechEntries([sampleSpeech]);
+    expect(result).toEqual([
+      { text: "Hello world", offset: 0, duration: 5.2 },
+    ]);
+  });
+
+  it("filters out visual entries", () => {
+    const result = toFlatSpeechEntries([sampleSpeech, sampleVisual]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.text).toBe("Hello world");
+  });
+
+  it("preserves lang on speech entries when present", () => {
+    const withLang = { ...sampleSpeech, lang: "en" };
+    const result = toFlatSpeechEntries([withLang]);
+    expect(result[0]?.lang).toBe("en");
+  });
+
+  it("omits lang on entries that don't have it", () => {
+    const result = toFlatSpeechEntries([sampleSpeech]);
+    expect(result[0]).not.toHaveProperty("lang");
+  });
+});
+
+describe("handleIntake", () => {
+  it("returns ok with briefUrl + brief on a speech-only submission", async () => {
+    const deps = makeDeps();
+    const result = await handleIntake(transcriptOnlySubmission, { userId: "user_01" }, deps);
+
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.response.briefId).toBe("brief_01abc");
+      expect(result.response.briefUrl).toBe("https://brief.test/brief/brief_01abc");
+      expect(result.response.brief).toEqual(sampleBrief);
+      expect(result.response.metadata).toEqual(sampleMetadata);
+      expect(result.response.schemaVersion).toBe("2.0.0");
+    }
+  });
+
+  it("calls generateBrief with speech-only entries in the legacy web shape", async () => {
+    const deps = makeDeps();
+    await handleIntake(augmentedSubmission, { userId: "user_01" }, deps);
+
+    expect(deps.generateBrief).toHaveBeenCalledTimes(1);
+    const [transcript, metadata, apiKey] = vi.mocked(deps.generateBrief).mock.calls[0];
+    expect(transcript).toEqual([{ text: "Hello world", offset: 0, duration: 5.2 }]);
+    expect(metadata).toEqual(sampleMetadata);
+    expect(apiKey).toBe("test-key");
+  });
+
+  it("persists the row with sum-type entries (preserves visual)", async () => {
+    const deps = makeDeps();
+    await handleIntake(augmentedSubmission, { userId: "user_01" }, deps);
+
+    expect(deps.saveSubmission).toHaveBeenCalledTimes(1);
+    const [args] = vi.mocked(deps.saveSubmission).mock.calls[0];
+    expect(args.userId).toBe("user_01");
+    expect(args.videoId).toBe("abc123XYZAB");
+    expect(args.metadata).toEqual(sampleMetadata);
+    expect(args.transcript).toHaveLength(2);
+    expect(args.transcript[0]).toEqual(sampleSpeech);
+    expect(args.transcript[1]).toEqual(sampleVisual);
+  });
+
+  it("passes frames discriminator + metrics to saveSubmission", async () => {
+    const deps = makeDeps();
+    await handleIntake(augmentedSubmission, { userId: "user_01" }, deps);
+    const [args] = vi.mocked(deps.saveSubmission).mock.calls[0];
+    expect(args.frames).toEqual(augmentedSubmission.frames);
+  });
+
+  it("persists brief generation metrics from generateBrief", async () => {
+    const deps = makeDeps();
+    await handleIntake(transcriptOnlySubmission, { userId: "user_01" }, deps);
+    const [args] = vi.mocked(deps.saveSubmission).mock.calls[0];
+    expect(args.briefMetrics).toEqual(sampleBriefMetrics);
+    expect(args.brief).toEqual(sampleBrief);
+  });
+
+  it("returns transient when generateBrief throws", async () => {
+    const deps = makeDeps({
+      generateBrief: vi.fn().mockRejectedValue(new Error("LLM down")),
+    });
+    const result = await handleIntake(transcriptOnlySubmission, { userId: "user_01" }, deps);
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") {
+      expect(result.cause).toMatch(/LLM down/);
+    }
+  });
+
+  it("returns transient when saveSubmission throws", async () => {
+    const deps = makeDeps({
+      saveSubmission: vi.fn().mockRejectedValue(new Error("DB unavailable")),
+    });
+    const result = await handleIntake(transcriptOnlySubmission, { userId: "user_01" }, deps);
+    expect(result.kind).toBe("transient");
+  });
+
+  it("does not call saveSubmission when generateBrief fails", async () => {
+    const deps = makeDeps({
+      generateBrief: vi.fn().mockRejectedValue(new Error("LLM down")),
+    });
+    await handleIntake(transcriptOnlySubmission, { userId: "user_01" }, deps);
+    expect(deps.saveSubmission).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/cli-intake.test.ts
+++ b/apps/web/src/lib/cli-intake.test.ts
@@ -6,6 +6,8 @@ import {
   type IntakeDeps,
 } from "./cli-intake";
 
+// Shared base fixtures: extend with `...spread` overrides per-test.
+
 const sampleMetadata = {
   videoId: "abc123XYZAB",
   title: "Test video",
@@ -44,40 +46,33 @@ const sampleBriefMetrics = {
   latencyMs: 1234,
 };
 
-const transcriptOnlySubmission: TranscriptSubmission = {
+const sampleMetrics = {
+  videoDurationSec: 210,
+  candidatesGenerated: 80,
+  candidatesAfterDedup: 50,
+  classifierYes: 15,
+  classifierNo: 35,
+  visionCalls: 15,
+  inputTokens: 27000,
+  outputTokens: 4000,
+  classifierModel: "openai/gpt-5.4-nano",
+  visionModel: "openai/gpt-5.5",
+  wallClockMs: 250000,
+  costSource: "cli-reported" as const,
+};
+
+const baseSubmission: TranscriptSubmission = {
   schemaVersion: "2.0.0",
   videoId: "abc123XYZAB",
-  metadata: sampleMetadata,
   transcript: [sampleSpeech],
   frames: { kind: "not-requested" },
 };
 
-const augmentedSubmission: TranscriptSubmission = {
-  schemaVersion: "2.0.0",
-  videoId: "abc123XYZAB",
-  metadata: sampleMetadata,
-  transcript: [sampleSpeech, sampleVisual],
-  frames: {
-    kind: "included",
-    metrics: {
-      videoDurationSec: 210,
-      candidatesGenerated: 80,
-      candidatesAfterDedup: 50,
-      classifierYes: 15,
-      classifierNo: 35,
-      visionCalls: 15,
-      inputTokens: 27000,
-      outputTokens: 4000,
-      classifierModel: "openai/gpt-5.4-nano",
-      visionModel: "openai/gpt-5.5",
-      wallClockMs: 250000,
-      costSource: "cli-reported",
-    },
-  },
-};
+const baseCtx = { userId: "user_01" };
 
 function makeDeps(overrides: Partial<IntakeDeps> = {}): IntakeDeps {
   return {
+    fetchVideoMetadata: vi.fn().mockResolvedValue(sampleMetadata),
     generateBrief: vi.fn().mockResolvedValue({
       brief: sampleBrief,
       metrics: sampleBriefMetrics,
@@ -91,8 +86,7 @@ function makeDeps(overrides: Partial<IntakeDeps> = {}): IntakeDeps {
 
 describe("toFlatSpeechEntries", () => {
   it("converts speech entries to the legacy flat shape", () => {
-    const result = toFlatSpeechEntries([sampleSpeech]);
-    expect(result).toEqual([
+    expect(toFlatSpeechEntries([sampleSpeech])).toEqual([
       { text: "Hello world", offset: 0, duration: 5.2 },
     ]);
   });
@@ -104,21 +98,19 @@ describe("toFlatSpeechEntries", () => {
   });
 
   it("preserves lang on speech entries when present", () => {
-    const withLang = { ...sampleSpeech, lang: "en" };
-    const result = toFlatSpeechEntries([withLang]);
+    const result = toFlatSpeechEntries([{ ...sampleSpeech, lang: "en" }]);
     expect(result[0]?.lang).toBe("en");
   });
 
   it("omits lang on entries that don't have it", () => {
-    const result = toFlatSpeechEntries([sampleSpeech]);
-    expect(result[0]).not.toHaveProperty("lang");
+    expect(toFlatSpeechEntries([sampleSpeech])[0]).not.toHaveProperty("lang");
   });
 });
 
 describe("handleIntake", () => {
   it("returns ok with briefUrl + brief on a speech-only submission", async () => {
     const deps = makeDeps();
-    const result = await handleIntake(transcriptOnlySubmission, { userId: "user_01" }, deps);
+    const result = await handleIntake(baseSubmission, baseCtx, deps);
 
     expect(result.kind).toBe("ok");
     if (result.kind === "ok") {
@@ -130,9 +122,19 @@ describe("handleIntake", () => {
     }
   });
 
+  it("fetches metadata server-side from videoId", async () => {
+    const deps = makeDeps();
+    await handleIntake(baseSubmission, baseCtx, deps);
+    expect(deps.fetchVideoMetadata).toHaveBeenCalledWith("abc123XYZAB");
+  });
+
   it("calls generateBrief with speech-only entries in the legacy web shape", async () => {
     const deps = makeDeps();
-    await handleIntake(augmentedSubmission, { userId: "user_01" }, deps);
+    await handleIntake(
+      { ...baseSubmission, transcript: [sampleSpeech, sampleVisual] },
+      baseCtx,
+      deps,
+    );
 
     expect(deps.generateBrief).toHaveBeenCalledTimes(1);
     const [transcript, metadata, apiKey] = vi.mocked(deps.generateBrief).mock.calls[0];
@@ -143,7 +145,11 @@ describe("handleIntake", () => {
 
   it("persists the row with sum-type entries (preserves visual)", async () => {
     const deps = makeDeps();
-    await handleIntake(augmentedSubmission, { userId: "user_01" }, deps);
+    await handleIntake(
+      { ...baseSubmission, transcript: [sampleSpeech, sampleVisual] },
+      baseCtx,
+      deps,
+    );
 
     expect(deps.saveSubmission).toHaveBeenCalledTimes(1);
     const [args] = vi.mocked(deps.saveSubmission).mock.calls[0];
@@ -157,43 +163,57 @@ describe("handleIntake", () => {
 
   it("passes frames discriminator + metrics to saveSubmission", async () => {
     const deps = makeDeps();
-    await handleIntake(augmentedSubmission, { userId: "user_01" }, deps);
+    const augmentedFrames = {
+      kind: "included" as const,
+      metrics: sampleMetrics,
+    };
+    await handleIntake(
+      { ...baseSubmission, frames: augmentedFrames },
+      baseCtx,
+      deps,
+    );
     const [args] = vi.mocked(deps.saveSubmission).mock.calls[0];
-    expect(args.frames).toEqual(augmentedSubmission.frames);
+    expect(args.frames).toEqual(augmentedFrames);
   });
 
   it("persists brief generation metrics from generateBrief", async () => {
     const deps = makeDeps();
-    await handleIntake(transcriptOnlySubmission, { userId: "user_01" }, deps);
+    await handleIntake(baseSubmission, baseCtx, deps);
     const [args] = vi.mocked(deps.saveSubmission).mock.calls[0];
     expect(args.briefMetrics).toEqual(sampleBriefMetrics);
     expect(args.brief).toEqual(sampleBrief);
+  });
+
+  it("returns transient when fetchVideoMetadata throws", async () => {
+    const deps = makeDeps({
+      fetchVideoMetadata: vi.fn().mockRejectedValue(new Error("Video not found")),
+    });
+    const result = await handleIntake(baseSubmission, baseCtx, deps);
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") {
+      expect(result.cause).toMatch(/Video not found/);
+    }
+    expect(deps.generateBrief).not.toHaveBeenCalled();
+    expect(deps.saveSubmission).not.toHaveBeenCalled();
   });
 
   it("returns transient when generateBrief throws", async () => {
     const deps = makeDeps({
       generateBrief: vi.fn().mockRejectedValue(new Error("LLM down")),
     });
-    const result = await handleIntake(transcriptOnlySubmission, { userId: "user_01" }, deps);
+    const result = await handleIntake(baseSubmission, baseCtx, deps);
     expect(result.kind).toBe("transient");
     if (result.kind === "transient") {
       expect(result.cause).toMatch(/LLM down/);
     }
+    expect(deps.saveSubmission).not.toHaveBeenCalled();
   });
 
   it("returns transient when saveSubmission throws", async () => {
     const deps = makeDeps({
       saveSubmission: vi.fn().mockRejectedValue(new Error("DB unavailable")),
     });
-    const result = await handleIntake(transcriptOnlySubmission, { userId: "user_01" }, deps);
+    const result = await handleIntake(baseSubmission, baseCtx, deps);
     expect(result.kind).toBe("transient");
-  });
-
-  it("does not call saveSubmission when generateBrief fails", async () => {
-    const deps = makeDeps({
-      generateBrief: vi.fn().mockRejectedValue(new Error("LLM down")),
-    });
-    await handleIntake(transcriptOnlySubmission, { userId: "user_01" }, deps);
-    expect(deps.saveSubmission).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/cli-intake.ts
+++ b/apps/web/src/lib/cli-intake.ts
@@ -28,6 +28,7 @@ export interface SaveSubmissionArgs {
 }
 
 export interface IntakeDeps {
+  fetchVideoMetadata(videoId: string): Promise<VideoMetadata>;
   generateBrief(
     transcript: WebTranscriptEntry[],
     metadata: VideoMetadata,
@@ -62,11 +63,19 @@ export async function handleIntake(
   ctx: IntakeContext,
   deps: IntakeDeps,
 ): Promise<IntakeResult> {
+  let metadata: VideoMetadata;
+  try {
+    metadata = await deps.fetchVideoMetadata(submission.videoId);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { kind: "transient", cause: message, message: `Failed to fetch metadata: ${message}` };
+  }
+
   const flatTranscript = toFlatSpeechEntries(submission.transcript);
 
   let briefResult: { brief: StructuredBrief; metrics: BriefMetrics };
   try {
-    briefResult = await deps.generateBrief(flatTranscript, submission.metadata, deps.llmApiKey);
+    briefResult = await deps.generateBrief(flatTranscript, metadata, deps.llmApiKey);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { kind: "transient", cause: message, message: `Failed to generate brief: ${message}` };
@@ -77,7 +86,7 @@ export async function handleIntake(
     saved = await deps.saveSubmission({
       userId: ctx.userId,
       videoId: submission.videoId,
-      metadata: submission.metadata,
+      metadata,
       transcript: submission.transcript,
       brief: briefResult.brief,
       briefMetrics: briefResult.metrics,
@@ -95,7 +104,7 @@ export async function handleIntake(
       briefId: saved.briefId,
       briefUrl: deps.buildBriefUrl(saved.briefId),
       brief: briefResult.brief,
-      metadata: submission.metadata,
+      metadata,
     },
   };
 }

--- a/apps/web/src/lib/cli-intake.ts
+++ b/apps/web/src/lib/cli-intake.ts
@@ -1,0 +1,101 @@
+import type { z } from "zod";
+import {
+  TranscriptEntrySchema,
+  type IntakeResponse,
+  type TranscriptSubmission,
+} from "@brief/core";
+import type {
+  BriefMetrics,
+  StructuredBrief,
+  TranscriptEntry as WebTranscriptEntry,
+  VideoMetadata,
+} from "./types";
+
+type SubmissionTranscriptEntry = z.infer<typeof TranscriptEntrySchema>;
+
+export interface IntakeContext {
+  userId: string;
+}
+
+export interface SaveSubmissionArgs {
+  userId: string;
+  videoId: string;
+  metadata: VideoMetadata;
+  transcript: SubmissionTranscriptEntry[];
+  brief: StructuredBrief;
+  briefMetrics: BriefMetrics;
+  frames: TranscriptSubmission["frames"];
+}
+
+export interface IntakeDeps {
+  generateBrief(
+    transcript: WebTranscriptEntry[],
+    metadata: VideoMetadata,
+    apiKey: string,
+  ): Promise<{ brief: StructuredBrief; metrics: BriefMetrics }>;
+  saveSubmission(args: SaveSubmissionArgs): Promise<{ briefId: string }>;
+  llmApiKey: string;
+  buildBriefUrl(briefId: string): string;
+}
+
+export type IntakeResult =
+  | { kind: "ok"; response: IntakeResponse }
+  | { kind: "transient"; cause: string; message: string };
+
+export function toFlatSpeechEntries(entries: SubmissionTranscriptEntry[]): WebTranscriptEntry[] {
+  const out: WebTranscriptEntry[] = [];
+  for (const entry of entries) {
+    if (entry.kind !== "speech") continue;
+    const flat: WebTranscriptEntry = {
+      text: entry.text,
+      offset: entry.offsetSec,
+      duration: entry.durationSec,
+    };
+    if (entry.lang !== undefined) flat.lang = entry.lang;
+    out.push(flat);
+  }
+  return out;
+}
+
+export async function handleIntake(
+  submission: TranscriptSubmission,
+  ctx: IntakeContext,
+  deps: IntakeDeps,
+): Promise<IntakeResult> {
+  const flatTranscript = toFlatSpeechEntries(submission.transcript);
+
+  let briefResult: { brief: StructuredBrief; metrics: BriefMetrics };
+  try {
+    briefResult = await deps.generateBrief(flatTranscript, submission.metadata, deps.llmApiKey);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { kind: "transient", cause: message, message: `Failed to generate brief: ${message}` };
+  }
+
+  let saved: { briefId: string };
+  try {
+    saved = await deps.saveSubmission({
+      userId: ctx.userId,
+      videoId: submission.videoId,
+      metadata: submission.metadata,
+      transcript: submission.transcript,
+      brief: briefResult.brief,
+      briefMetrics: briefResult.metrics,
+      frames: submission.frames,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { kind: "transient", cause: message, message: `Failed to persist submission: ${message}` };
+  }
+
+  return {
+    kind: "ok",
+    response: {
+      schemaVersion: submission.schemaVersion,
+      briefId: saved.briefId,
+      briefUrl: deps.buildBriefUrl(saved.briefId),
+      brief: briefResult.brief,
+      metadata: submission.metadata,
+    },
+  };
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    passWithNoTests: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "pnpm --filter @brief/web start",
     "lint": "pnpm --filter @brief/web lint",
     "cli": "node apps/cli/dist/main.cjs",
+    "cli:local": "BRIEF_API_URL=http://localhost:3000 pnpm --filter @brief/cli dev",
     "migrate": "pnpm --filter @brief/web migrate",
     "backfill-search": "pnpm --filter @brief/web backfill-search",
     "security": "pnpm --filter @brief/web security",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,9 +24,21 @@ export type {
   VideoMetadata,
 } from "./types";
 export {
+  BriefBodySchema,
+  ContentSectionSchema,
   FramesMetricsSchema,
+  IntakeResponseSchema,
+  KeyPointSchema,
+  LinkSchema,
+  SchemaMismatchResponseSchema,
   TranscriptEntrySchema,
   TranscriptSubmissionSchema,
   VideoMetadataSchema,
+  WhoamiResponseSchema,
 } from "./submission";
-export type { TranscriptSubmission } from "./submission";
+export type {
+  BriefBody,
+  IntakeResponse,
+  TranscriptSubmission,
+  WhoamiResponse,
+} from "./submission";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,3 +23,10 @@ export type {
   UnavailableReason,
   VideoMetadata,
 } from "./types";
+export {
+  FramesMetricsSchema,
+  TranscriptEntrySchema,
+  TranscriptSubmissionSchema,
+  VideoMetadataSchema,
+} from "./submission";
+export type { TranscriptSubmission } from "./submission";

--- a/packages/core/src/submission.test.ts
+++ b/packages/core/src/submission.test.ts
@@ -166,7 +166,6 @@ describe("TranscriptSubmissionSchema", () => {
   const validTranscriptOnly = {
     schemaVersion: "2.0.0",
     videoId: "abc123XYZAB",
-    metadata: validMetadata,
     transcript: [validSpeech],
     frames: { kind: "not-requested" },
   };
@@ -234,7 +233,6 @@ describe("TranscriptSubmissionSchema", () => {
     const submission: TranscriptSubmission = {
       schemaVersion: "2.0.0",
       videoId: "abc",
-      metadata: validMetadata,
       transcript: [{ kind: "speech", offsetSec: 0, durationSec: 1, text: "x" }],
       frames: { kind: "not-requested" },
     };

--- a/packages/core/src/submission.test.ts
+++ b/packages/core/src/submission.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "vitest";
+import {
+  SCHEMA_VERSION,
+  TranscriptEntrySchema,
+  VideoMetadataSchema,
+  FramesMetricsSchema,
+  TranscriptSubmissionSchema,
+  type TranscriptSubmission,
+} from "./submission";
+
+const validSpeech = {
+  kind: "speech",
+  offsetSec: 0,
+  durationSec: 5.2,
+  text: "Hello world",
+};
+
+const validVisual = {
+  kind: "visual",
+  offsetSec: 30,
+  mode: "verbatim",
+  text: "Pricing: $19/mo",
+};
+
+const validMetadata = {
+  videoId: "abc123XYZAB",
+  title: "Test video",
+  channelTitle: "Test channel",
+  channelId: "UC_abc",
+  duration: "PT3M30S",
+  publishedAt: "2024-01-01T00:00:00Z",
+  description: "A test description",
+};
+
+const validMetrics = {
+  videoDurationSec: 210,
+  candidatesGenerated: 80,
+  candidatesAfterDedup: 50,
+  classifierYes: 15,
+  classifierNo: 35,
+  visionCalls: 15,
+  inputTokens: 27000,
+  outputTokens: 4000,
+  classifierModel: "openai/gpt-5.4-nano",
+  visionModel: "openai/gpt-5.5",
+  wallClockMs: 250000,
+  costSource: "cli-reported",
+};
+
+describe("SCHEMA_VERSION", () => {
+  it("is the v2 literal", () => {
+    expect(SCHEMA_VERSION).toBe("2.0.0");
+  });
+});
+
+describe("TranscriptEntrySchema", () => {
+  it("accepts a speech entry", () => {
+    const result = TranscriptEntrySchema.safeParse(validSpeech);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a visual entry with verbatim mode", () => {
+    const result = TranscriptEntrySchema.safeParse(validVisual);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a visual entry with summary mode", () => {
+    const result = TranscriptEntrySchema.safeParse({
+      ...validVisual,
+      mode: "summary",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a speech entry with optional lang", () => {
+    const result = TranscriptEntrySchema.safeParse({
+      ...validSpeech,
+      lang: "en",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an entry without kind", () => {
+    const { kind: _kind, ...withoutKind } = validSpeech;
+    const result = TranscriptEntrySchema.safeParse(withoutKind);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an entry with unknown kind", () => {
+    const result = TranscriptEntrySchema.safeParse({
+      ...validSpeech,
+      kind: "rumor",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a speech entry missing required offsetSec", () => {
+    const { offsetSec: _o, ...withoutOffset } = validSpeech;
+    const result = TranscriptEntrySchema.safeParse(withoutOffset);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a visual entry with invalid mode", () => {
+    const result = TranscriptEntrySchema.safeParse({
+      ...validVisual,
+      mode: "guesswork",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("VideoMetadataSchema", () => {
+  it("accepts complete metadata", () => {
+    const result = VideoMetadataSchema.safeParse(validMetadata);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts metadata with pinnedComment", () => {
+    const result = VideoMetadataSchema.safeParse({
+      ...validMetadata,
+      pinnedComment: "Read this first",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects metadata missing videoId", () => {
+    const { videoId: _v, ...withoutId } = validMetadata;
+    const result = VideoMetadataSchema.safeParse(withoutId);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects metadata missing duration", () => {
+    const { duration: _d, ...withoutDuration } = validMetadata;
+    const result = VideoMetadataSchema.safeParse(withoutDuration);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("FramesMetricsSchema", () => {
+  it("accepts metrics with costSource cli-reported", () => {
+    const result = FramesMetricsSchema.safeParse(validMetrics);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects metrics with costSource other than cli-reported", () => {
+    const result = FramesMetricsSchema.safeParse({
+      ...validMetrics,
+      costSource: "server-issued",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects metrics missing costSource", () => {
+    const { costSource: _c, ...withoutCostSource } = validMetrics;
+    const result = FramesMetricsSchema.safeParse(withoutCostSource);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects metrics missing required fields", () => {
+    const result = FramesMetricsSchema.safeParse({ costSource: "cli-reported" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("TranscriptSubmissionSchema", () => {
+  const validTranscriptOnly = {
+    schemaVersion: "2.0.0",
+    videoId: "abc123XYZAB",
+    metadata: validMetadata,
+    transcript: [validSpeech],
+    frames: { kind: "not-requested" },
+  };
+
+  it("accepts a transcript-only submission", () => {
+    const result = TranscriptSubmissionSchema.safeParse(validTranscriptOnly);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an augmented submission with frames.kind included", () => {
+    const result = TranscriptSubmissionSchema.safeParse({
+      ...validTranscriptOnly,
+      transcript: [validSpeech, validVisual],
+      frames: { kind: "included", metrics: validMetrics },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a submission with frames.kind attempted-failed", () => {
+    const result = TranscriptSubmissionSchema.safeParse({
+      ...validTranscriptOnly,
+      frames: {
+        kind: "attempted-failed",
+        reason: "download-blocked-bot-detection",
+        phase: "download",
+        metrics: validMetrics,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects wrong schemaVersion literal", () => {
+    const result = TranscriptSubmissionSchema.safeParse({
+      ...validTranscriptOnly,
+      schemaVersion: "1.0.0",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown frames.kind", () => {
+    const result = TranscriptSubmissionSchema.safeParse({
+      ...validTranscriptOnly,
+      frames: { kind: "shipped-it" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects frames.kind=included without metrics", () => {
+    const result = TranscriptSubmissionSchema.safeParse({
+      ...validTranscriptOnly,
+      frames: { kind: "included" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects frames.kind=attempted-failed without reason/phase", () => {
+    const result = TranscriptSubmissionSchema.safeParse({
+      ...validTranscriptOnly,
+      frames: { kind: "attempted-failed", metrics: validMetrics },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("inferred type matches expected discriminated-union shape", () => {
+    const submission: TranscriptSubmission = {
+      schemaVersion: "2.0.0",
+      videoId: "abc",
+      metadata: validMetadata,
+      transcript: [{ kind: "speech", offsetSec: 0, durationSec: 1, text: "x" }],
+      frames: { kind: "not-requested" },
+    };
+    expect(submission.schemaVersion).toBe("2.0.0");
+  });
+});

--- a/packages/core/src/submission.ts
+++ b/packages/core/src/submission.ts
@@ -62,3 +62,51 @@ export const TranscriptSubmissionSchema = z.object({
 });
 
 export type TranscriptSubmission = z.infer<typeof TranscriptSubmissionSchema>;
+
+export const LinkSchema = z.object({
+  url: z.string(),
+  title: z.string(),
+  description: z.string(),
+});
+
+export const KeyPointSchema = z.object({
+  text: z.string(),
+  timestamp: z.string(),
+  isTangent: z.boolean().optional(),
+});
+
+export const ContentSectionSchema = z.object({
+  title: z.string(),
+  timestampStart: z.string(),
+  timestampEnd: z.string(),
+  keyPoints: z.array(z.union([KeyPointSchema, z.string()])),
+});
+
+export const BriefBodySchema = z.object({
+  summary: z.string(),
+  sections: z.array(ContentSectionSchema),
+  relatedLinks: z.array(LinkSchema),
+  otherLinks: z.array(LinkSchema),
+});
+
+export const IntakeResponseSchema = z.object({
+  schemaVersion: z.literal(SCHEMA_VERSION),
+  briefId: z.string(),
+  briefUrl: z.string(),
+  brief: BriefBodySchema,
+  metadata: VideoMetadataSchema,
+});
+
+export const WhoamiResponseSchema = z.object({
+  email: z.string(),
+  userId: z.string(),
+});
+
+export const SchemaMismatchResponseSchema = z.object({
+  error: z.literal("schema-mismatch"),
+  serverAccepts: z.array(z.string()),
+});
+
+export type BriefBody = z.infer<typeof BriefBodySchema>;
+export type IntakeResponse = z.infer<typeof IntakeResponseSchema>;
+export type WhoamiResponse = z.infer<typeof WhoamiResponseSchema>;

--- a/packages/core/src/submission.ts
+++ b/packages/core/src/submission.ts
@@ -47,7 +47,6 @@ export const FramesMetricsSchema = z.object({
 export const TranscriptSubmissionSchema = z.object({
   schemaVersion: z.literal(SCHEMA_VERSION),
   videoId: z.string(),
-  metadata: VideoMetadataSchema,
   transcript: z.array(TranscriptEntrySchema),
   frames: z.discriminatedUnion("kind", [
     z.object({ kind: z.literal("not-requested") }),

--- a/packages/core/src/submission.ts
+++ b/packages/core/src/submission.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+
+export const SCHEMA_VERSION = "2.0.0" as const;
+
+export const TranscriptEntrySchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("speech"),
+    offsetSec: z.number(),
+    durationSec: z.number(),
+    text: z.string(),
+    lang: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("visual"),
+    offsetSec: z.number(),
+    mode: z.enum(["verbatim", "summary"]),
+    text: z.string(),
+  }),
+]);
+
+export const VideoMetadataSchema = z.object({
+  videoId: z.string(),
+  title: z.string(),
+  channelTitle: z.string(),
+  channelId: z.string(),
+  duration: z.string(),
+  publishedAt: z.string(),
+  description: z.string(),
+  pinnedComment: z.string().optional(),
+});
+
+export const FramesMetricsSchema = z.object({
+  videoDurationSec: z.number(),
+  candidatesGenerated: z.number(),
+  candidatesAfterDedup: z.number(),
+  classifierYes: z.number(),
+  classifierNo: z.number(),
+  visionCalls: z.number(),
+  inputTokens: z.number(),
+  outputTokens: z.number(),
+  classifierModel: z.string(),
+  visionModel: z.string(),
+  wallClockMs: z.number(),
+  costSource: z.literal("cli-reported"),
+});
+
+export const TranscriptSubmissionSchema = z.object({
+  schemaVersion: z.literal(SCHEMA_VERSION),
+  videoId: z.string(),
+  metadata: VideoMetadataSchema,
+  transcript: z.array(TranscriptEntrySchema),
+  frames: z.discriminatedUnion("kind", [
+    z.object({ kind: z.literal("not-requested") }),
+    z.object({ kind: z.literal("included"), metrics: FramesMetricsSchema }),
+    z.object({
+      kind: z.literal("attempted-failed"),
+      reason: z.string(),
+      phase: z.string(),
+      metrics: FramesMetricsSchema,
+    }),
+  ]),
+});
+
+export type TranscriptSubmission = z.infer<typeof TranscriptSubmissionSchema>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,6 +6,11 @@ export type UnavailableReason =
   | "video-private"
   | "invalid-id";
 
+// Legacy flat shape — predates the CLI→server submission's discriminated-union
+// `TranscriptEntrySchema` (kind: "speech" | "visual") in `./submission`. The
+// unification across consumers (format.ts, fetcher.ts, sources/*, web's
+// transcript path) lands alongside #87's visual-entry producer, since that's
+// when a sum-type carries weight downstream.
 export type TranscriptEntry = {
   offsetSec: number;
   durationSec: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@brief/core':
         specifier: workspace:*
         version: link:../../packages/core
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^20.19.26

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       get-youtube-chapters:
         specifier: ^2.0.0
         version: 2.0.0
+      jose:
+        specifier: ^5.9.6
+        version: 5.10.0
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@19.2.3)
@@ -203,6 +206,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.19.30)(lightningcss@1.30.2)
 
   packages/core:
     dependencies:


### PR DESCRIPTION
## Summary

- Implements the CLI thin-client transition (#88) end-to-end. Subcommand surface: `login`, `logout`, `whoami`, `transcript`, `generate`. Auth via WorkOS CLI Auth (OAuth 2.0 Device Authorization Grant, RFC 8628). Server-side intake at `POST /api/brief/intake` validates Zod-typed submissions, fetches metadata, runs `generateBrief()`, returns a brief URL.
- All transport types live as shared Zod schemas in `@brief/core/submission` — single source of truth for the CLI/server wire format. Server validates with `Submission.parse(...)`; CLI imports the same schema and gets request types via `z.infer`. No tRPC, no Hono, no codegen.
- Bearer-token verification on the server uses `jose` + WorkOS JWKS, the same pattern `@workos-inc/authkit-nextjs` uses internally for cookies. New routes: `/api/brief/intake`, `/api/cli/whoami`, `/api/cli/logout`.
- Server fetches video metadata (CLI no longer needs its own YouTube Data API key for `generate`). One less account for CLI users to configure.
- Manually verified end-to-end against the local web server: `brief login` → tokens persist at `~/.config/brief/credentials.json` (0600) → `brief whoami` returns email → `brief generate <youtube-url>` returns a real brief URL → brief renders correctly → `brief logout` clears local creds.

## What's deferred

- **chunk 8 — `TranscriptEntry` sum-type unification across legacy consumers.** Comment added in `packages/core/src/types.ts`. The sum-type already lives at the wire boundary where it matters; unifying internal types pairs more cleanly with #87's visual-entry producer.
- **#94 — server-issued ephemeral LLM tokens.** v1 has the CLI use the user's own OpenRouter key for any local LLM work (matters for #87, not for this PR).
- **#69 — auth landing-page bug.** Same WorkOS code area but separate scope per the issue audit.

## Test posture

- `@brief/cli`: 99 tests, all green. TDD throughout (red-green-interleaved per CLAUDE.md memory).
- `@brief/web`: 26 tests (vitest infra added in this PR). All green.
- `@brief/core`: 143 tests, all green.
- Typecheck clean in all three packages.

## Prod deployment notes

- **No new env vars required.** The intake endpoint reuses the same `YOUTUBE_API_KEY`, `WORKOS_API_KEY`, `WORKOS_CLIENT_ID`, and `OPENROUTER_API_KEY` the existing brief route already consumes. Verified present in prod.
- CLI auto-points at `brief.niftymonkey.dev`; `BRIEF_API_URL` overrides for local dev (a `pnpm cli:local` script at the repo root wraps that override).

Closes most of #88. Remaining scope (chunk 8, #69 fix, #94 follow-up) tracked in their own issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: added login, logout, whoami, transcript, and generate subcommands (device-code auth, progress/status reporting, --with-frames note)
  * Web: new intake and CLI whoami/logout endpoints for brief submission and auth checks
  * Improved schema/versioned submission and brief generation support across CLI and web

* **Tests**
  * Extensive Vitest coverage for auth flows, credential storage, hosted-client, handlers, intake logic, and schemas
<!-- end of auto-generated comment: release notes by coderabbit.ai -->