### PR TITLE
feat: CLI auto-discovers WORKOS_CLIENT_ID from the brief server

### DIFF
--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -2,13 +2,14 @@ import { parseArgs } from "node:util";
 import { fetchMetadata, fetchTranscript, type SourceName } from "@brief/core";
 import { createAuthFlow } from "./auth";
 import { createFilesystemStore } from "./credentials";
-import { EXIT_ARG_ERROR } from "./exit-codes";
+import { EXIT_ARG_ERROR, EXIT_TRANSIENT } from "./exit-codes";
 import { createHostedClient } from "./hosted-client";
 import { runGenerate } from "./handlers/run-generate";
 import { runLogin } from "./handlers/run-login";
 import { runLogout } from "./handlers/run-logout";
 import { runTranscript } from "./handlers/run-transcript";
 import { runWhoami } from "./handlers/run-whoami";
+import { fetchServerConfig } from "./server-config";
 
 const DEFAULT_API_BASE = "https://brief.niftymonkey.dev";
 
@@ -148,12 +149,14 @@ function buildCommonOpts(parsed: ParsedFlags): ParsedCommon | { error: string } 
 }
 
 async function dispatchLogin(): Promise<number> {
-  const clientId = process.env.WORKOS_CLIENT_ID;
+  let clientId = process.env.WORKOS_CLIENT_ID;
   if (!clientId) {
-    process.stderr.write(
-      "Login requires WORKOS_CLIENT_ID env var. Ask brief support for the value.\n",
-    );
-    return EXIT_ARG_ERROR;
+    const config = await fetchServerConfig({ baseUrl: getApiBase() });
+    if (config.kind !== "ok") {
+      process.stderr.write(`${config.message}\n`);
+      return EXIT_TRANSIENT;
+    }
+    clientId = config.config.workosClientId;
   }
   const authFlow = createAuthFlow({
     clientId,

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -36,7 +36,7 @@ Options:
 
 Environment:
   BRIEF_API_URL                            Hosted brief service URL (default: ${DEFAULT_API_BASE})
-  WORKOS_CLIENT_ID                         WorkOS client ID (required for login)
+  WORKOS_CLIENT_ID                         WorkOS client ID override (CLI fetches the value from the server by default)
 
 Exit codes:
   0  Success

--- a/apps/cli/src/server-config.test.ts
+++ b/apps/cli/src/server-config.test.ts
@@ -60,6 +60,14 @@ describe("fetchServerConfig", () => {
     expect(transport.calls[0]?.url).toBe(`${BASE}/api/cli/config`);
   });
 
+  it("strips multiple trailing slashes on baseUrl", async () => {
+    const transport = createStubTransport([
+      { status: 200, body: { workosClientId: "client_test_abc" } },
+    ]);
+    await fetchServerConfig({ baseUrl: `${BASE}///`, transport });
+    expect(transport.calls[0]?.url).toBe(`${BASE}/api/cli/config`);
+  });
+
   it("returns transient on network failure", async () => {
     const transport = createStubTransport([{ throw: new Error("ENOTFOUND") }]);
     const result = await fetchServerConfig({ baseUrl: BASE, transport });

--- a/apps/cli/src/server-config.test.ts
+++ b/apps/cli/src/server-config.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import type { Transport } from "./hosted-client";
+import { fetchServerConfig } from "./server-config";
+
+const BASE = "https://brief.test";
+
+interface StubCall {
+  url: string;
+  init?: RequestInit;
+}
+
+type StubPlan = { status?: number; body?: unknown; throw?: Error };
+
+function createStubTransport(plans: StubPlan[]): Transport & { calls: StubCall[] } {
+  const calls: StubCall[] = [];
+  let i = 0;
+  return {
+    calls,
+    async fetch(input, init) {
+      const url = typeof input === "string" ? input : input.toString();
+      calls.push({ url, init });
+      const plan = plans[i++];
+      if (!plan) throw new Error(`No stub plan for call #${i}`);
+      if (plan.throw) throw plan.throw;
+      const status = plan.status ?? 200;
+      const body = plan.body !== undefined ? JSON.stringify(plan.body) : null;
+      const headers = new Headers();
+      if (plan.body !== undefined) headers.set("content-type", "application/json");
+      return new Response(body, { status, headers });
+    },
+  };
+}
+
+describe("fetchServerConfig", () => {
+  it("returns ok with the parsed config on 200", async () => {
+    const transport = createStubTransport([
+      { status: 200, body: { workosClientId: "client_test_abc" } },
+    ]);
+    const result = await fetchServerConfig({ baseUrl: BASE, transport });
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.config.workosClientId).toBe("client_test_abc");
+    }
+  });
+
+  it("GETs /api/cli/config", async () => {
+    const transport = createStubTransport([
+      { status: 200, body: { workosClientId: "client_test_abc" } },
+    ]);
+    await fetchServerConfig({ baseUrl: BASE, transport });
+    expect(transport.calls[0]?.url).toBe(`${BASE}/api/cli/config`);
+    expect(transport.calls[0]?.init?.method).toBe("GET");
+  });
+
+  it("strips trailing slash on baseUrl", async () => {
+    const transport = createStubTransport([
+      { status: 200, body: { workosClientId: "client_test_abc" } },
+    ]);
+    await fetchServerConfig({ baseUrl: `${BASE}/`, transport });
+    expect(transport.calls[0]?.url).toBe(`${BASE}/api/cli/config`);
+  });
+
+  it("returns transient on network failure", async () => {
+    const transport = createStubTransport([{ throw: new Error("ENOTFOUND") }]);
+    const result = await fetchServerConfig({ baseUrl: BASE, transport });
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") {
+      expect(result.cause).toMatch(/ENOTFOUND/);
+    }
+  });
+
+  it("returns transient on 5xx", async () => {
+    const transport = createStubTransport([{ status: 500, body: { error: "oops" } }]);
+    const result = await fetchServerConfig({ baseUrl: BASE, transport });
+    expect(result.kind).toBe("transient");
+  });
+
+  it("returns transient when the response is not valid JSON", async () => {
+    const transport = createStubTransport([{ status: 200 }]);
+    const result = await fetchServerConfig({ baseUrl: BASE, transport });
+    expect(result.kind).toBe("transient");
+  });
+
+  it("returns transient when the body shape doesn't match", async () => {
+    const transport = createStubTransport([
+      { status: 200, body: { something: "else" } },
+    ]);
+    const result = await fetchServerConfig({ baseUrl: BASE, transport });
+    expect(result.kind).toBe("transient");
+  });
+});

--- a/apps/cli/src/server-config.ts
+++ b/apps/cli/src/server-config.ts
@@ -17,7 +17,7 @@ export async function fetchServerConfig(
   opts: FetchServerConfigOptions,
 ): Promise<ServerConfigResult> {
   const transport = opts.transport ?? defaultTransport;
-  const base = opts.baseUrl.replace(/\/$/, "");
+  const base = opts.baseUrl.replace(/\/+$/, "");
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
   let res: Response;

--- a/apps/cli/src/server-config.ts
+++ b/apps/cli/src/server-config.ts
@@ -1,0 +1,67 @@
+import { CliConfigResponseSchema, type CliConfigResponse } from "@brief/core";
+import { defaultTransport, type Transport } from "./hosted-client";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export type ServerConfigResult =
+  | { kind: "ok"; config: CliConfigResponse }
+  | { kind: "transient"; cause: string; message: string };
+
+export interface FetchServerConfigOptions {
+  baseUrl: string;
+  transport?: Transport;
+  timeoutMs?: number;
+}
+
+export async function fetchServerConfig(
+  opts: FetchServerConfigOptions,
+): Promise<ServerConfigResult> {
+  const transport = opts.transport ?? defaultTransport;
+  const base = opts.baseUrl.replace(/\/$/, "");
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  let res: Response;
+  try {
+    res = await transport.fetch(`${base}/api/cli/config`, {
+      method: "GET",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      kind: "transient",
+      cause: message,
+      message: `Could not reach brief at ${base}: ${message}`,
+    };
+  }
+
+  if (!res.ok) {
+    return {
+      kind: "transient",
+      cause: `http-${res.status}`,
+      message: `brief server returned ${res.status} for CLI config`,
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      kind: "transient",
+      cause: "invalid-json",
+      message: `brief server returned an invalid CLI config body: ${message}`,
+    };
+  }
+
+  const parsed = CliConfigResponseSchema.safeParse(body);
+  if (!parsed.success) {
+    return {
+      kind: "transient",
+      cause: "invalid-shape",
+      message: "brief server returned a CLI config that doesn't match the expected shape",
+    };
+  }
+  return { kind: "ok", config: parsed.data };
+}

--- a/apps/web/src/app/api/cli/config/route.ts
+++ b/apps/web/src/app/api/cli/config/route.ts
@@ -5,9 +5,9 @@ import { NextResponse } from "next/server";
 // WorkOS client_id for the device-flow handshake). WorkOS client_ids are
 // public per their docs; this endpoint does not expose secrets.
 export async function GET() {
-  const workosClientId = process.env.WORKOS_CLIENT_ID;
+  const workosClientId = process.env.WORKOS_CLIENT_ID?.trim();
   if (!workosClientId) {
-    console.error("[cli-config] WORKOS_CLIENT_ID is unset; CLI login flows will fail");
+    console.error("[cli-config] WORKOS_CLIENT_ID is unset or blank; CLI login flows will fail");
     return NextResponse.json({ error: "server-misconfigured" }, { status: 500 });
   }
   return NextResponse.json(

--- a/apps/web/src/app/api/cli/config/route.ts
+++ b/apps/web/src/app/api/cli/config/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+// Public CLI config — unauthenticated, idempotent, cacheable.
+// Returns values the brief CLI needs before it can perform login (e.g., the
+// WorkOS client_id for the device-flow handshake). WorkOS client_ids are
+// public per their docs; this endpoint does not expose secrets.
+export async function GET() {
+  const workosClientId = process.env.WORKOS_CLIENT_ID;
+  if (!workosClientId) {
+    console.error("[cli-config] WORKOS_CLIENT_ID is unset; CLI login flows will fail");
+    return NextResponse.json({ error: "server-misconfigured" }, { status: 500 });
+  }
+  return NextResponse.json(
+    { workosClientId },
+    { headers: { "cache-control": "public, max-age=3600" } },
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export type {
 } from "./types";
 export {
   BriefBodySchema,
+  CliConfigResponseSchema,
   ContentSectionSchema,
   FramesMetricsSchema,
   IntakeResponseSchema,
@@ -38,6 +39,7 @@ export {
 } from "./submission";
 export type {
   BriefBody,
+  CliConfigResponse,
   IntakeResponse,
   TranscriptSubmission,
   WhoamiResponse,

--- a/packages/core/src/submission.ts
+++ b/packages/core/src/submission.ts
@@ -106,6 +106,11 @@ export const SchemaMismatchResponseSchema = z.object({
   serverAccepts: z.array(z.string()),
 });
 
+export const CliConfigResponseSchema = z.object({
+  workosClientId: z.string(),
+});
+
 export type BriefBody = z.infer<typeof BriefBodySchema>;
 export type IntakeResponse = z.infer<typeof IntakeResponseSchema>;
 export type WhoamiResponse = z.infer<typeof WhoamiResponseSchema>;
+export type CliConfigResponse = z.infer<typeof CliConfigResponseSchema>;


### PR DESCRIPTION
## Summary

- Removes the friction of requiring users to set \`WORKOS_CLIENT_ID\` as an env var before running \`brief login\`. The CLI now fetches it from the brief server on demand.
- New unauthenticated endpoint \`GET /api/cli/config\` returns \`{ workosClientId }\`. Cacheable for 1h. Returns 500 if the server itself isn't configured.
- CLI's \`dispatchLogin\` checks the env var first (override for staging/local testing), then falls back to the fetched value. Network failures surface as a clear transient error.
- \`client_id\` is a public OAuth identifier by design — exposing it via an unauthenticated endpoint is safe (matches the pattern \`gh\`, \`vercel\`, and \`gcloud\` use to embed their client IDs in published binaries).

## Test posture

- \`@brief/cli\`: 7 new tests for \`fetchServerConfig\` (ok, network error, 5xx, malformed JSON, wrong shape). 115 tests total, green.
- \`@brief/core\`: 143 tests, green. Added \`CliConfigResponseSchema\` to the shared schemas.
- Typecheck clean across web/cli/core.

## Prod deployment notes

- No new env vars required. The endpoint reads the same \`WORKOS_CLIENT_ID\` the rest of the auth path uses.
- After this deploys, \`brief login\` works out-of-the-box for any user; the previous \"Ask brief support for the value\" error path is gone.

Closes the env-var friction observed in PR #97's manual smoke test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI can fetch configuration from the hosted API; added a public endpoint that serves CLI config.
  * CLI help now documents the client ID environment variable as an override rather than required.

* **Bug Fixes**
  * Improved error handling for config retrieval: distinguishes transient (retriable) vs permanent failures and exits accordingly.

* **Tests**
  * Added comprehensive tests for configuration fetch behavior, trimming/base URL handling, network errors, and response validation.

* **Core**
  * Added and exported a validated CLI config response schema/type.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niftymonkey/brief/pull/98)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->