### PR TITLE
fix: align JWT verification to actual WorkOS token format

### DIFF
--- a/apps/cli/src/handlers/run-whoami.ts
+++ b/apps/cli/src/handlers/run-whoami.ts
@@ -1,6 +1,19 @@
-import type { HostedClient } from "../hosted-client";
+import type { AuthRequiredReason, HostedClient } from "../hosted-client";
 import { EXIT_AUTH_REQUIRED, EXIT_OK, EXIT_TRANSIENT } from "../exit-codes";
 import type { HandlerResult } from "./run-login";
+
+function authRequiredMessage(reason: AuthRequiredReason): string {
+  switch (reason) {
+    case "missing":
+      return "Not signed in. Run `brief login`.\n";
+    case "expired":
+      return "Your session has expired. Run `brief login`.\n";
+    case "invalid":
+      return "Your credentials weren't accepted by brief (likely a server-side WorkOS config issue). Run `brief login` to retry; if it persists, contact brief support.\n";
+    case "revoked":
+      return "Your session was revoked. Run `brief login`.\n";
+  }
+}
 
 export interface RunWhoamiDeps {
   hostedClient: HostedClient;
@@ -43,10 +56,7 @@ export async function runWhoami(
     case "auth-required":
       return {
         stdout: "",
-        stderr:
-          result.reason === "expired"
-            ? "Your session has expired. Run `brief login`.\n"
-            : "Not signed in. Run `brief login`.\n",
+        stderr: authRequiredMessage(result.reason),
         exitCode: EXIT_AUTH_REQUIRED,
       };
     case "transient":

--- a/apps/cli/src/hosted-client.ts
+++ b/apps/cli/src/hosted-client.ts
@@ -17,7 +17,20 @@ export const defaultTransport: Transport = {
   fetch: (input, init) => globalThis.fetch(input, init),
 };
 
-export type AuthRequiredReason = "missing" | "expired" | "revoked";
+export type AuthRequiredReason = "missing" | "expired" | "invalid" | "revoked";
+
+async function authRequiredReasonFromResponse(res: Response): Promise<AuthRequiredReason> {
+  try {
+    const body = (await res.clone().json()) as { error?: string };
+    if (body.error === "expired") return "expired";
+    if (body.error === "invalid") return "invalid";
+    if (body.error === "malformed") return "invalid";
+    if (body.error === "revoked") return "revoked";
+  } catch {
+    // fall through to default
+  }
+  return "expired";
+}
 
 export type BriefResult =
   | {
@@ -124,7 +137,9 @@ export function createHostedClient(opts: HostedClientOptions): HostedClient {
       if (call.kind === "throw") return transientFromThrow(call.err);
       const res = call.res;
 
-      if (res.status === 401) return { kind: "auth-required", reason: "expired" };
+      if (res.status === 401) {
+        return { kind: "auth-required", reason: await authRequiredReasonFromResponse(res) };
+      }
       if (res.status === 409) {
         const body = await safeJson(res);
         const parsed = SchemaMismatchResponseSchema.safeParse(body);
@@ -167,7 +182,9 @@ export function createHostedClient(opts: HostedClientOptions): HostedClient {
         return { kind: "transient", cause: message, message: `Network error: ${message}` };
       }
       const res = call.res;
-      if (res.status === 401) return { kind: "auth-required", reason: "expired" };
+      if (res.status === 401) {
+        return { kind: "auth-required", reason: await authRequiredReasonFromResponse(res) };
+      }
       if (!res.ok) {
         return { kind: "transient", cause: `http-${res.status}`, message: `Unexpected status ${res.status}` };
       }

--- a/apps/web/src/lib/cli-auth-workos.ts
+++ b/apps/web/src/lib/cli-auth-workos.ts
@@ -2,7 +2,6 @@ import { createRemoteJWKSet, jwtVerify } from "jose";
 import { createTokenVerifier, type TokenVerifier } from "./cli-auth";
 
 const WORKOS_API_BASE = "https://api.workos.com";
-const WORKOS_ISSUER = "https://api.workos.com";
 const USER_LOOKUP_TIMEOUT_MS = 10_000;
 
 let cachedJwks: ReturnType<typeof createRemoteJWKSet> | null = null;
@@ -22,11 +21,15 @@ function getJwks() {
   return cachedJwks;
 }
 
+// Note on tenant isolation: the JWKS URL itself is scoped to `${WORKOS_API_BASE}/sso/jwks/<clientId>`,
+// so a token signed by a different WorkOS client won't have a matching JWK and signature verification
+// fails. We additionally pin the `iss` claim to this client's per-tenant issuer URL as defense in depth.
+// We do NOT validate `aud` — WorkOS AuthKit access tokens don't carry an `aud` claim today.
 export function createWorkosTokenVerifier(): TokenVerifier {
   return createTokenVerifier(async (token) => {
+    const clientId = requireClientId();
     return jwtVerify(token, getJwks(), {
-      issuer: WORKOS_ISSUER,
-      audience: requireClientId(),
+      issuer: `${WORKOS_API_BASE}/user_management/${clientId}`,
     });
   });
 }


### PR DESCRIPTION
## Summary

- Fixes a broken JWT-claim-validation path introduced in PR #97's round-2 review fixes. The validator was checking against `iss = "https://api.workos.com"` and a required `aud` claim, but actual WorkOS user-management access tokens have `iss = "https://api.workos.com/user_management/<client_id>"` and no `aud` claim. Every `brief whoami` / `brief generate` call after login returned 401, surfacing in the CLI as "Your session has expired" — even immediately after a successful login.
- Diagnosed by decoding the local credentials JWT (`cat ~/.config/brief/credentials.json | jq -r .accessToken | cut -d. -f2 | base64 -d | jq .`) — the live token shape is what we have to verify against.
- Server-side fix: align `jwtVerify` options to the actual token format. Drop the `audience` option (WorkOS doesn't set it for this flow); pin `issuer` to the per-tenant URL. Tenant isolation is still provided by the JWKS URL itself being scoped to the client_id — a token signed by a different WorkOS client wouldn't have a matching JWK and signature verification fails.
- CLI-side fix: the hosted client was hard-coding `reason: "expired"` for every 401 response, hiding the actual cause (`"invalid"`, `"malformed"`, etc.). Now it parses the response body and surfaces the real reason. `runWhoami` gets a per-reason error message so `"invalid"` doesn't look like "session expired."

## Test posture

- `@brief/cli`: 116 tests, green. Typecheck clean.
- `@brief/web`: typecheck clean.

## Deployment

This needs to deploy before `brief whoami`/`brief generate` work in prod. Existing user credentials don't need to be refreshed — they were valid all along; only the server's verification logic was wrong.

Origin: PR #97 round-2 fix (commit `c74f57294d`'s sibling — the iss/aud one).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication error messages to provide clearer feedback on different failure types (missing credentials, expired tokens, invalid tokens, revoked access).

* **Security**
  * Improved JWT verification with better tenant isolation and issuer claim validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niftymonkey/brief/pull/99)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->