### PR TITLE
fix(cli): refresh WorkOS tokens on 401-expired; close #100 #101

### DIFF
--- a/apps/cli/src/auth.test.ts
+++ b/apps/cli/src/auth.test.ts
@@ -76,7 +76,9 @@ describe("AuthFlow.login", () => {
       expect(result.tokens.refreshToken).toBe("refresh_yyy");
       expect(result.tokens.userId).toBe("user_01H");
       expect(result.tokens.email).toBe("user@example.com");
-      expect(result.tokens.expiresAt).toBeGreaterThan(Date.now());
+      // expiresAt is seconds since epoch, on the same axis as JWT exp.
+      expect(result.tokens.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+      expect(result.tokens.expiresAt).toBeLessThan(1e10);
     }
   });
 
@@ -265,6 +267,98 @@ describe("AuthFlow.login", () => {
       sleep: sleepNoop,
     });
     const result = await flow.login();
+    expect(result.kind).toBe("transient");
+  });
+});
+
+describe("AuthFlow.refresh", () => {
+  it("returns fresh tokens on a successful redemption", async () => {
+    const transport = createStubTransport([{ status: 200, body: { ...sampleTokens, expires_in: 300 } }]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+    });
+    const result = await flow.refresh("refresh-old");
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.tokens.accessToken).toBe("access_xxx");
+      expect(result.tokens.refreshToken).toBe("refresh_yyy");
+      // expiresAt is seconds since epoch, on the same axis as JWT exp.
+      expect(result.tokens.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+      expect(result.tokens.expiresAt).toBeLessThan(1e10);
+    }
+  });
+
+  it("POSTs to /user_management/authenticate with grant_type=refresh_token", async () => {
+    const transport = createStubTransport([{ status: 200, body: sampleTokens }]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+    });
+    await flow.refresh("refresh-old");
+    expect(transport.calls).toHaveLength(1);
+    const call = transport.calls[0];
+    expect(call.url).toBe(`${WORKOS_URL}/user_management/authenticate`);
+    expect(call.init?.method).toBe("POST");
+    const body = JSON.parse(String(call.init?.body));
+    expect(body).toEqual({
+      grant_type: "refresh_token",
+      client_id: CLIENT_ID,
+      refresh_token: "refresh-old",
+    });
+  });
+
+  it("returns kind=expired when WorkOS rejects the refresh token with a 4xx", async () => {
+    const transport = createStubTransport([
+      { status: 400, body: { error: "invalid_grant" } },
+    ]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+    });
+    const result = await flow.refresh("refresh-dead");
+    expect(result.kind).toBe("expired");
+    if (result.kind === "expired") {
+      expect(result.message).toMatch(/invalid_grant/);
+    }
+  });
+
+  it("returns kind=transient on 5xx so the caller can retry later", async () => {
+    const transport = createStubTransport([{ status: 503, body: {} }]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+    });
+    const result = await flow.refresh("refresh-x");
+    expect(result.kind).toBe("transient");
+  });
+
+  it("returns kind=transient when the transport itself throws", async () => {
+    const transport = createStubTransport([{ throw: new Error("ECONNREFUSED") }]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+    });
+    const result = await flow.refresh("refresh-x");
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") {
+      expect(result.cause).toMatch(/ECONNREFUSED/);
+    }
+  });
+
+  it("returns kind=transient on a malformed 200 body so a stale refresh isn't treated as terminal", async () => {
+    const transport = createStubTransport([{ status: 200, body: { unrelated: true } }]);
+    const flow = createAuthFlow({
+      clientId: CLIENT_ID,
+      workosBaseUrl: WORKOS_URL,
+      transport,
+    });
+    const result = await flow.refresh("refresh-x");
     expect(result.kind).toBe("transient");
   });
 });

--- a/apps/cli/src/auth.ts
+++ b/apps/cli/src/auth.ts
@@ -26,6 +26,7 @@ const PollErrorSchema = z.object({
 });
 
 const DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+const REFRESH_GRANT_TYPE = "refresh_token";
 const DEFAULT_EXPIRES_IN_SEC = 5 * 60;
 const DEFAULT_WORKOS_BASE = "https://api.workos.com";
 const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
@@ -42,8 +43,20 @@ export type AuthFlowResult =
   | { kind: "denied"; message: string }
   | { kind: "transient"; cause: string; message: string };
 
+/**
+ * Outcome of redeeming a refresh token for fresh access/refresh tokens. The
+ * `expired` case means the refresh token itself is dead (revoked, expired,
+ * or otherwise rejected) — the caller must prompt for a full re-login.
+ * `transient` is recoverable on a future call.
+ */
+export type RefreshResult =
+  | { kind: "ok"; tokens: Tokens }
+  | { kind: "expired"; message: string }
+  | { kind: "transient"; cause: string; message: string };
+
 export interface AuthFlow {
   login(): Promise<AuthFlowResult>;
+  refresh(refreshToken: string): Promise<RefreshResult>;
 }
 
 export interface AuthFlowOptions {
@@ -184,7 +197,7 @@ export function createAuthFlow(opts: AuthFlowOptions): AuthFlow {
             tokens: {
               accessToken: t.access_token,
               refreshToken: t.refresh_token,
-              expiresAt: Date.now() + expiresInSec * 1000,
+              expiresAt: Math.floor(Date.now() / 1000) + expiresInSec,
               userId: t.user.id,
               email: t.user.email,
             },
@@ -207,6 +220,62 @@ export function createAuthFlow(opts: AuthFlowOptions): AuthFlow {
       }
 
       return { kind: "expired", message: "Device code expired before authorization" };
+    },
+
+    async refresh(refreshToken) {
+      let res: Response;
+      try {
+        res = await transport.fetch(`${base}/user_management/authenticate`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            grant_type: REFRESH_GRANT_TYPE,
+            client_id: opts.clientId,
+            refresh_token: refreshToken,
+          }),
+          signal: AbortSignal.timeout(requestTimeoutMs),
+        });
+      } catch (err) {
+        const cause = err instanceof Error ? err.message : String(err);
+        return { kind: "transient", cause, message: "Could not reach WorkOS to refresh tokens" };
+      }
+      const body = await safeJson(res);
+      if (res.ok) {
+        const parsed = TokenResponseSchema.safeParse(body);
+        if (!parsed.success) {
+          return {
+            kind: "transient",
+            cause: "malformed-response",
+            message: "WorkOS returned an unrecognized refresh response",
+          };
+        }
+        const t = parsed.data;
+        const expiresInSec = t.expires_in ?? DEFAULT_EXPIRES_IN_SEC;
+        return {
+          kind: "ok",
+          tokens: {
+            accessToken: t.access_token,
+            refreshToken: t.refresh_token,
+            expiresAt: Math.floor(Date.now() / 1000) + expiresInSec,
+            userId: t.user.id,
+            email: t.user.email,
+          },
+        };
+      }
+      if (res.status >= 500) {
+        return {
+          kind: "transient",
+          cause: `http-${res.status}`,
+          message: `WorkOS returned ${res.status} during refresh`,
+        };
+      }
+      // 4xx — treat as a dead refresh token. WorkOS uses `invalid_grant` for
+      // revoked/expired refresh tokens; we don't differentiate here because the
+      // caller's response is the same in every 4xx case: prompt the user to
+      // re-login.
+      const errParsed = PollErrorSchema.safeParse(body);
+      const reason = errParsed.success ? errParsed.data.error : `http-${res.status}`;
+      return { kind: "expired", message: `Refresh token rejected: ${reason}` };
     },
   };
 }

--- a/apps/cli/src/credentials.test.ts
+++ b/apps/cli/src/credentials.test.ts
@@ -12,7 +12,7 @@ import {
 const sampleTokens: Tokens = {
   accessToken: "access-abc",
   refreshToken: "refresh-xyz",
-  expiresAt: 1_700_000_000_000,
+  expiresAt: 1_700_000_000, // seconds since epoch (2023-11)
   userId: "user_01H7ZZZ",
   email: "user@example.com",
 };
@@ -130,6 +130,18 @@ describe("createFilesystemStore", () => {
     await writeFile(
       storePath,
       JSON.stringify({ ...sampleTokens, expiresAt: "not-a-number" }),
+      { mode: 0o600 },
+    );
+    const store = createFilesystemStore(storePath);
+    expect(await store.read()).toBeNull();
+  });
+
+  it("invalidates legacy credentials whose expiresAt was written in milliseconds", async () => {
+    // 1.7e12 = ms in 2023; interpreted as seconds it's year 55,830. The threshold
+    // catches anything clearly out of range so the user is prompted to re-login.
+    await writeFile(
+      storePath,
+      JSON.stringify({ ...sampleTokens, expiresAt: 1_700_000_000_000 }),
       { mode: 0o600 },
     );
     const store = createFilesystemStore(storePath);

--- a/apps/cli/src/credentials.ts
+++ b/apps/cli/src/credentials.ts
@@ -3,6 +3,13 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { z } from "zod";
 
+/**
+ * Persisted credentials. `expiresAt` is **seconds since the Unix epoch**, on the
+ * same axis as the JWT `exp` claim. Earlier builds wrote milliseconds here; that
+ * was wrong, and `createFilesystemStore` invalidates any cred whose `expiresAt`
+ * is clearly out-of-range (interpreted as seconds it would be centuries in the
+ * future) so the user is prompted to re-login cleanly.
+ */
 export const TokensSchema = z.object({
   accessToken: z.string(),
   refreshToken: z.string(),
@@ -10,6 +17,10 @@ export const TokensSchema = z.object({
   userId: z.string(),
   email: z.string(),
 });
+
+// Seconds-since-epoch values written this century are <~ 4.1e9. Anything past
+// 1e10 must have been written with the legacy ms-based formula; treat as invalid.
+const LEGACY_MS_EXPIRES_THRESHOLD = 1e10;
 
 export type Tokens = z.infer<typeof TokensSchema>;
 
@@ -43,7 +54,9 @@ export function createFilesystemStore(path: string = DEFAULT_PATH): CredentialSt
         const content = await readFile(path, "utf-8");
         const raw = JSON.parse(content);
         const parsed = TokensSchema.safeParse(raw);
-        return parsed.success ? parsed.data : null;
+        if (!parsed.success) return null;
+        if (parsed.data.expiresAt > LEGACY_MS_EXPIRES_THRESHOLD) return null;
+        return parsed.data;
       } catch {
         return null;
       }

--- a/apps/cli/src/handlers/run-login.test.ts
+++ b/apps/cli/src/handlers/run-login.test.ts
@@ -4,13 +4,16 @@ import { createInMemoryStore } from "../credentials";
 import { runLogin } from "./run-login";
 
 function stubAuthFlow(result: AuthFlowResult): AuthFlow {
-  return { login: vi.fn().mockResolvedValue(result) };
+  return {
+    login: vi.fn().mockResolvedValue(result),
+    refresh: vi.fn(),
+  };
 }
 
 const sampleTokens = {
   accessToken: "access-abc",
   refreshToken: "refresh-xyz",
-  expiresAt: Date.now() + 3_600_000,
+  expiresAt: Math.floor(Date.now() / 1000) + 3600, // seconds since epoch
   userId: "user_01",
   email: "user@example.com",
 };
@@ -69,6 +72,7 @@ describe("runLogin", () => {
     const credentials = createInMemoryStore();
     const authFlow: AuthFlow = {
       login: vi.fn().mockRejectedValue(new Error("unexpected")),
+      refresh: vi.fn(),
     };
     const result = await runLogin({ authFlow, credentials });
     expect(result.exitCode).toBe(4);

--- a/apps/cli/src/handlers/run-logout.test.ts
+++ b/apps/cli/src/handlers/run-logout.test.ts
@@ -6,7 +6,7 @@ import { runLogout } from "./run-logout";
 const sampleTokens: Tokens = {
   accessToken: "access-abc",
   refreshToken: "refresh-xyz",
-  expiresAt: Date.now() + 3_600_000,
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
   userId: "user_01",
   email: "user@example.com",
 };

--- a/apps/cli/src/hosted-client.test.ts
+++ b/apps/cli/src/hosted-client.test.ts
@@ -440,4 +440,76 @@ describe("HostedClient refresh-on-401", () => {
     expect(result.kind).toBe("ok");
     expect(transport.calls).toHaveLength(2);
   });
+
+  it("does not attempt refresh on a 401 whose body is ambiguous (no explicit error: expired)", async () => {
+    const credentials = createInMemoryStore();
+    await credentials.write(sampleTokens);
+    // Legacy/unparseable bodies still surface as auth-required:expired to the
+    // caller, but must NOT trigger refresh-token redemption.
+    const transport = createStubTransport([{ status: 401, body: { error: "token-expired" } }]);
+    const refreshTokens = vi.fn();
+    const client = createHostedClient({
+      baseUrl: BASE_URL,
+      credentials,
+      transport,
+      refreshTokens,
+    });
+
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("auth-required");
+    if (result.kind === "auth-required") {
+      expect(result.reason).toBe("expired");
+    }
+    expect(refreshTokens).not.toHaveBeenCalled();
+    expect(transport.calls).toHaveLength(1);
+  });
+
+  it("falls through to auth-required when the refresh callback throws", async () => {
+    const credentials = createInMemoryStore();
+    await credentials.write(sampleTokens);
+    const transport = createStubTransport([{ status: 401, body: { error: "expired" } }]);
+    const refreshTokens = async () => {
+      throw new Error("boom");
+    };
+    const client = createHostedClient({
+      baseUrl: BASE_URL,
+      credentials,
+      transport,
+      refreshTokens,
+    });
+
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("auth-required");
+    if (result.kind === "auth-required") {
+      expect(result.reason).toBe("expired");
+    }
+    expect(transport.calls).toHaveLength(1);
+  });
+
+  it("falls through to auth-required when credentials.write throws after refresh", async () => {
+    const credentials = createInMemoryStore();
+    await credentials.write(sampleTokens);
+    const throwingCredentials: CredentialStore = {
+      read: credentials.read.bind(credentials),
+      write: async () => {
+        throw new Error("disk full");
+      },
+      clear: credentials.clear.bind(credentials),
+    };
+    const transport = createStubTransport([{ status: 401, body: { error: "expired" } }]);
+    const refreshTokens = async () => ({ kind: "ok" as const, tokens: freshTokens });
+    const client = createHostedClient({
+      baseUrl: BASE_URL,
+      credentials: throwingCredentials,
+      transport,
+      refreshTokens,
+    });
+
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("auth-required");
+    if (result.kind === "auth-required") {
+      expect(result.reason).toBe("expired");
+    }
+    expect(transport.calls).toHaveLength(1);
+  });
 });

--- a/apps/cli/src/hosted-client.test.ts
+++ b/apps/cli/src/hosted-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createInMemoryStore, type CredentialStore, type Tokens } from "./credentials";
 import {
   createHostedClient,
@@ -11,7 +11,7 @@ const BASE_URL = "https://brief.test";
 const sampleTokens: Tokens = {
   accessToken: "access-abc",
   refreshToken: "refresh-xyz",
-  expiresAt: Date.now() + 3_600_000,
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
   userId: "user_01",
   email: "user@example.com",
 };
@@ -314,5 +314,130 @@ describe("HostedClient.logout", () => {
     await setup([{ throw: new Error("ECONNREFUSED") }]);
     const result = await client.logout();
     expect(result.kind).toBe("transient");
+  });
+});
+
+describe("HostedClient refresh-on-401", () => {
+  const freshTokens: Tokens = {
+    accessToken: "access-new",
+    refreshToken: "refresh-new",
+    expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    userId: "user_01",
+    email: "user@example.com",
+  };
+
+  it("redeems the refresh token on 401-expired and retries the original request once", async () => {
+    const credentials = createInMemoryStore();
+    await credentials.write(sampleTokens);
+    const transport = createStubTransport([
+      { status: 401, body: { error: "expired" } },
+      { status: 200, body: validIntakeResponse },
+    ]);
+    const refreshTokens = async () => ({ kind: "ok" as const, tokens: freshTokens });
+    const client = createHostedClient({
+      baseUrl: BASE_URL,
+      credentials,
+      transport,
+      refreshTokens,
+    });
+
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("ok");
+    expect(transport.calls).toHaveLength(2);
+    expect(transport.calls[0]?.init?.headers).toBeDefined();
+    const retryAuth = new Headers(transport.calls[1]?.init?.headers).get("authorization");
+    expect(retryAuth).toBe("Bearer access-new");
+    expect(await credentials.read()).toEqual(freshTokens);
+  });
+
+  it("falls through to auth-required when the refresh token itself is rejected", async () => {
+    const credentials = createInMemoryStore();
+    await credentials.write(sampleTokens);
+    const transport = createStubTransport([{ status: 401, body: { error: "expired" } }]);
+    const refreshTokens = async () =>
+      ({ kind: "expired" as const, message: "Refresh token rejected: invalid_grant" });
+    const client = createHostedClient({
+      baseUrl: BASE_URL,
+      credentials,
+      transport,
+      refreshTokens,
+    });
+
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("auth-required");
+    if (result.kind === "auth-required") {
+      expect(result.reason).toBe("expired");
+    }
+    // Credentials are left intact; the caller can decide to clear them.
+    expect(await credentials.read()).toEqual(sampleTokens);
+  });
+
+  it("falls through to auth-required on a transient refresh failure (no infinite-retry loop)", async () => {
+    const credentials = createInMemoryStore();
+    await credentials.write(sampleTokens);
+    const transport = createStubTransport([{ status: 401, body: { error: "expired" } }]);
+    const refreshTokens = async () =>
+      ({ kind: "transient" as const, cause: "ECONNREFUSED", message: "WorkOS unreachable" });
+    const client = createHostedClient({
+      baseUrl: BASE_URL,
+      credentials,
+      transport,
+      refreshTokens,
+    });
+
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("auth-required");
+    expect(transport.calls).toHaveLength(1);
+  });
+
+  it("does not attempt refresh on 401-invalid/revoked/missing reasons", async () => {
+    const credentials = createInMemoryStore();
+    await credentials.write(sampleTokens);
+    const transport = createStubTransport([{ status: 401, body: { error: "invalid" } }]);
+    const refreshTokens = vi.fn();
+    const client = createHostedClient({
+      baseUrl: BASE_URL,
+      credentials,
+      transport,
+      refreshTokens,
+    });
+
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("auth-required");
+    if (result.kind === "auth-required") {
+      expect(result.reason).toBe("invalid");
+    }
+    expect(refreshTokens).not.toHaveBeenCalled();
+  });
+
+  it("does not retry on 401 when no refreshTokens callback is supplied (backwards-compatible)", async () => {
+    const credentials = createInMemoryStore();
+    await credentials.write(sampleTokens);
+    const transport = createStubTransport([{ status: 401, body: { error: "expired" } }]);
+    const client = createHostedClient({ baseUrl: BASE_URL, credentials, transport });
+
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("auth-required");
+    expect(transport.calls).toHaveLength(1);
+  });
+
+  it("retries whoami the same way submit does", async () => {
+    const credentials = createInMemoryStore();
+    await credentials.write(sampleTokens);
+    const transport = createStubTransport([
+      { status: 401, body: { error: "expired" } },
+      { status: 200, body: { email: "user@example.com", userId: "user_01" } },
+    ]);
+    const refreshTokens = async () => ({ kind: "ok" as const, tokens: freshTokens });
+    const client = createHostedClient({
+      baseUrl: BASE_URL,
+      credentials,
+      transport,
+      refreshTokens,
+    });
+
+    const result = await client.whoami();
+    expect(result.kind).toBe("ok");
+    expect(transport.calls).toHaveLength(2);
   });
 });

--- a/apps/cli/src/hosted-client.test.ts
+++ b/apps/cli/src/hosted-client.test.ts
@@ -486,6 +486,30 @@ describe("HostedClient refresh-on-401", () => {
     expect(transport.calls).toHaveLength(1);
   });
 
+  it("propagates transient errors from the retried send after a successful refresh", async () => {
+    const credentials = createInMemoryStore();
+    await credentials.write(sampleTokens);
+    // First call returns 401-expired. Refresh succeeds and writes fresh
+    // tokens. The retry hits a transport throw — that must surface as
+    // transient (not auth-required), since the user IS authenticated.
+    const transport = createStubTransport([
+      { status: 401, body: { error: "expired" } },
+      { throw: new Error("ECONNRESET") },
+    ]);
+    const refreshTokens = async () => ({ kind: "ok" as const, tokens: freshTokens });
+    const client = createHostedClient({
+      baseUrl: BASE_URL,
+      credentials,
+      transport,
+      refreshTokens,
+    });
+
+    const result = await client.submit(validSubmission);
+    expect(result.kind).toBe("transient");
+    expect(await credentials.read()).toEqual(freshTokens);
+    expect(transport.calls).toHaveLength(2);
+  });
+
   it("falls through to auth-required when credentials.write throws after refresh", async () => {
     const credentials = createInMemoryStore();
     await credentials.write(sampleTokens);

--- a/apps/cli/src/hosted-client.ts
+++ b/apps/cli/src/hosted-client.ts
@@ -7,7 +7,19 @@ import {
   type VideoMetadata,
   type WhoamiResponse,
 } from "@brief/core";
-import type { CredentialStore } from "./credentials";
+import type { CredentialStore, Tokens } from "./credentials";
+
+/**
+ * Outcome of asking the auth provider to redeem a refresh token. Matches
+ * `RefreshResult` from `./auth` — duplicated here so the hosted client doesn't
+ * pull in WorkOS-specific code.
+ */
+export type RefreshTokensResult =
+  | { kind: "ok"; tokens: Tokens }
+  | { kind: "expired"; message: string }
+  | { kind: "transient"; cause: string; message: string };
+
+export type RefreshTokensFn = (refreshToken: string) => Promise<RefreshTokensResult>;
 
 export interface Transport {
   fetch(input: string | URL, init?: RequestInit): Promise<Response>;
@@ -66,6 +78,13 @@ export interface HostedClientOptions {
   transport?: Transport;
   /** Per-request timeout for fetch calls. Defaults to 60s to accommodate server-side LLM generation. */
   requestTimeoutMs?: number;
+  /**
+   * Optional refresh-token redeemer. When supplied, a 401 with reason `expired`
+   * triggers exactly one refresh + retry. If refresh itself returns `expired`
+   * or `transient`, or no callback is supplied, the original 401 surfaces as
+   * `auth-required` to the caller.
+   */
+  refreshTokens?: RefreshTokensFn;
 }
 
 const DEFAULT_RATE_LIMIT_RETRY_SEC = 60;
@@ -88,20 +107,39 @@ export function createHostedClient(opts: HostedClientOptions): HostedClient {
   const base = opts.baseUrl.replace(/\/$/, "");
   const requestTimeoutMs = opts.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
 
+  async function send(path: string, init: RequestInit, accessToken: string): Promise<Response> {
+    const headers = new Headers(init.headers ?? {});
+    headers.set("authorization", `Bearer ${accessToken}`);
+    return transport.fetch(`${base}${path}`, {
+      ...init,
+      headers,
+      signal: init.signal ?? AbortSignal.timeout(requestTimeoutMs),
+    });
+  }
+
   async function authorized(
     path: string,
     init: RequestInit,
   ): Promise<{ kind: "no-creds" } | { kind: "response"; res: Response } | { kind: "throw"; err: unknown }> {
     const tokens = await opts.credentials.read();
     if (!tokens) return { kind: "no-creds" };
-    const headers = new Headers(init.headers ?? {});
-    headers.set("authorization", `Bearer ${tokens.accessToken}`);
     try {
-      const res = await transport.fetch(`${base}${path}`, {
-        ...init,
-        headers,
-        signal: init.signal ?? AbortSignal.timeout(requestTimeoutMs),
-      });
+      let res = await send(path, init, tokens.accessToken);
+
+      // Reactive refresh: on a 401 caused by an expired access token, redeem
+      // the refresh token, persist the new tokens, and retry the request once.
+      // Any failure of the refresh path falls through with the original 401.
+      if (res.status === 401 && opts.refreshTokens) {
+        const reason = await authRequiredReasonFromResponse(res);
+        if (reason === "expired") {
+          const refreshed = await opts.refreshTokens(tokens.refreshToken);
+          if (refreshed.kind === "ok") {
+            await opts.credentials.write(refreshed.tokens);
+            res = await send(path, init, refreshed.tokens.accessToken);
+          }
+        }
+      }
+
       return { kind: "response", res };
     } catch (err) {
       return { kind: "throw", err };

--- a/apps/cli/src/hosted-client.ts
+++ b/apps/cli/src/hosted-client.ts
@@ -31,17 +31,33 @@ export const defaultTransport: Transport = {
 
 export type AuthRequiredReason = "missing" | "expired" | "invalid" | "revoked";
 
-async function authRequiredReasonFromResponse(res: Response): Promise<AuthRequiredReason> {
+/**
+ * Server 401 bodies carry an `error` string the verifier emits explicitly. We
+ * fall back to `expired` for ambiguous/unparseable bodies because that's the
+ * least-disruptive thing to tell the caller. Reactive refresh, however, MUST
+ * gate on `serverSaidExpired` (an explicit `error: "expired"`) — otherwise a
+ * malformed body would cause spurious refresh-token redemption attempts.
+ */
+interface AuthRequiredOutcome {
+  reason: AuthRequiredReason;
+  serverSaidExpired: boolean;
+}
+
+async function authRequiredOutcomeFromResponse(res: Response): Promise<AuthRequiredOutcome> {
   try {
     const body = (await res.clone().json()) as { error?: string };
-    if (body.error === "expired") return "expired";
-    if (body.error === "invalid") return "invalid";
-    if (body.error === "malformed") return "invalid";
-    if (body.error === "revoked") return "revoked";
+    if (body.error === "expired") return { reason: "expired", serverSaidExpired: true };
+    if (body.error === "invalid") return { reason: "invalid", serverSaidExpired: false };
+    if (body.error === "malformed") return { reason: "invalid", serverSaidExpired: false };
+    if (body.error === "revoked") return { reason: "revoked", serverSaidExpired: false };
   } catch {
     // fall through to default
   }
-  return "expired";
+  return { reason: "expired", serverSaidExpired: false };
+}
+
+async function authRequiredReasonFromResponse(res: Response): Promise<AuthRequiredReason> {
+  return (await authRequiredOutcomeFromResponse(res)).reason;
 }
 
 export type BriefResult =
@@ -126,16 +142,27 @@ export function createHostedClient(opts: HostedClientOptions): HostedClient {
     try {
       let res = await send(path, init, tokens.accessToken);
 
-      // Reactive refresh: on a 401 caused by an expired access token, redeem
-      // the refresh token, persist the new tokens, and retry the request once.
-      // Any failure of the refresh path falls through with the original 401.
+      // Reactive refresh: on a 401 the server explicitly tagged `expired`,
+      // redeem the refresh token, persist the new tokens, and retry the
+      // request once. We gate on the explicit server signal — not the
+      // fallback — so ambiguous 401 bodies don't trigger spurious refreshes.
+      //
+      // Any exception thrown by the refresh path (refresh callback,
+      // credentials.write, or the retry fetch) is swallowed so the original
+      // 401 falls through as `auth-required` instead of being converted into
+      // a transient failure.
       if (res.status === 401 && opts.refreshTokens) {
-        const reason = await authRequiredReasonFromResponse(res);
-        if (reason === "expired") {
-          const refreshed = await opts.refreshTokens(tokens.refreshToken);
-          if (refreshed.kind === "ok") {
-            await opts.credentials.write(refreshed.tokens);
-            res = await send(path, init, refreshed.tokens.accessToken);
+        const outcome = await authRequiredOutcomeFromResponse(res);
+        if (outcome.serverSaidExpired) {
+          try {
+            const refreshed = await opts.refreshTokens(tokens.refreshToken);
+            if (refreshed.kind === "ok") {
+              await opts.credentials.write(refreshed.tokens);
+              res = await send(path, init, refreshed.tokens.accessToken);
+            }
+          } catch {
+            // Preserve the original 401 so the caller treats this as
+            // auth-required, not transient.
           }
         }
       }

--- a/apps/cli/src/hosted-client.ts
+++ b/apps/cli/src/hosted-client.ts
@@ -147,22 +147,27 @@ export function createHostedClient(opts: HostedClientOptions): HostedClient {
       // request once. We gate on the explicit server signal — not the
       // fallback — so ambiguous 401 bodies don't trigger spurious refreshes.
       //
-      // Any exception thrown by the refresh path (refresh callback,
-      // credentials.write, or the retry fetch) is swallowed so the original
-      // 401 falls through as `auth-required` instead of being converted into
-      // a transient failure.
+      // Exceptions from the refresh callback or `credentials.write` are
+      // swallowed so the original 401 surfaces as `auth-required`. The retry
+      // `send`, however, runs after fresh tokens are already persisted: a
+      // throw from it is a genuine transport failure, not an auth problem,
+      // and must escape to the outer catch so callers see `transient`.
       if (res.status === 401 && opts.refreshTokens) {
         const outcome = await authRequiredOutcomeFromResponse(res);
         if (outcome.serverSaidExpired) {
+          let retryAccessToken: string | null = null;
           try {
             const refreshed = await opts.refreshTokens(tokens.refreshToken);
             if (refreshed.kind === "ok") {
               await opts.credentials.write(refreshed.tokens);
-              res = await send(path, init, refreshed.tokens.accessToken);
+              retryAccessToken = refreshed.tokens.accessToken;
             }
           } catch {
             // Preserve the original 401 so the caller treats this as
             // auth-required, not transient.
+          }
+          if (retryAccessToken !== null) {
+            res = await send(path, init, retryAccessToken);
           }
         }
       }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,9 +1,9 @@
 import { parseArgs } from "node:util";
 import { fetchMetadata, fetchTranscript, type SourceName } from "@brief/core";
-import { createAuthFlow } from "./auth";
+import { createAuthFlow, type AuthFlow } from "./auth";
 import { createFilesystemStore } from "./credentials";
 import { EXIT_ARG_ERROR, EXIT_TRANSIENT } from "./exit-codes";
-import { createHostedClient } from "./hosted-client";
+import { createHostedClient, type RefreshTokensFn } from "./hosted-client";
 import { runGenerate } from "./handlers/run-generate";
 import { runLogin } from "./handlers/run-login";
 import { runLogout } from "./handlers/run-logout";
@@ -95,6 +95,34 @@ function getApiBase(): string {
   return process.env.BRIEF_API_URL ?? DEFAULT_API_BASE;
 }
 
+/**
+ * Builds a refresh-token redeemer that lazily resolves the WorkOS client ID
+ * the first time a refresh is actually needed. Most CLI calls succeed without
+ * touching this path, so the env-or-server-config lookup is deferred until a
+ * 401-expired triggers it.
+ */
+function makeRefreshTokens(): RefreshTokensFn {
+  let cachedFlow: AuthFlow | null = null;
+  return async (refreshToken: string) => {
+    if (!cachedFlow) {
+      let clientId = process.env.WORKOS_CLIENT_ID;
+      if (!clientId) {
+        const config = await fetchServerConfig({ baseUrl: getApiBase() });
+        if (config.kind !== "ok") {
+          return {
+            kind: "transient",
+            cause: config.message,
+            message: `Could not resolve WorkOS client ID for token refresh: ${config.message}`,
+          };
+        }
+        clientId = config.config.workosClientId;
+      }
+      cachedFlow = createAuthFlow({ clientId });
+    }
+    return cachedFlow.refresh(refreshToken);
+  };
+}
+
 interface ParsedCommon {
   input: string;
   json: boolean;
@@ -173,7 +201,11 @@ async function dispatchLogin(): Promise<number> {
 
 async function dispatchLogout(): Promise<number> {
   const credentials = createFilesystemStore();
-  const hostedClient = createHostedClient({ baseUrl: getApiBase(), credentials });
+  const hostedClient = createHostedClient({
+    baseUrl: getApiBase(),
+    credentials,
+    refreshTokens: makeRefreshTokens(),
+  });
   return writeResult(await runLogout({ hostedClient, credentials }));
 }
 
@@ -187,7 +219,11 @@ async function dispatchWhoami(argv: string[]): Promise<number> {
     return EXIT_ARG_ERROR;
   }
   const credentials = createFilesystemStore();
-  const hostedClient = createHostedClient({ baseUrl: getApiBase(), credentials });
+  const hostedClient = createHostedClient({
+    baseUrl: getApiBase(),
+    credentials,
+    refreshTokens: makeRefreshTokens(),
+  });
   return writeResult(await runWhoami({ hostedClient }, { json }));
 }
 
@@ -240,7 +276,11 @@ async function dispatchGenerate(argv: string[]): Promise<number> {
   }
 
   const credentials = createFilesystemStore();
-  const hostedClient = createHostedClient({ baseUrl: getApiBase(), credentials });
+  const hostedClient = createHostedClient({
+    baseUrl: getApiBase(),
+    credentials,
+    refreshTokens: makeRefreshTokens(),
+  });
 
   const generateOpts: Parameters<typeof runGenerate>[1] = {
     input: common.input,


### PR DESCRIPTION
## Summary
- On a 401 response with `reason: expired`, the CLI now redeems the stored refresh token at WorkOS's `/user_management/authenticate` endpoint, persists the rotated tokens, and retries the original request once. Single retry only — never loops.
- `expiresAt` in the persisted credential file is now seconds since the Unix epoch (matching the JWT `exp` axis) instead of milliseconds. Legacy ms-encoded credentials are detected on read and invalidated cleanly so the user re-logins.
- 12 new unit tests cover the refresh path: happy retry, expired refresh-token, transient failure no-loop, retry skipped on non-expired 401 reasons, no-callback backwards-compat, and `whoami` going through the same code path as `submit`.

Closes #100
Closes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add refresh-token redemption to renew API tokens and retry a single failed request when credentials expire.
  * CLI now lazily wires a refresh mechanism so hosted requests can refresh tokens on-demand.

* **Bug Fixes**
  * Reject legacy millisecond-based stored credentials to avoid centuries-future expirations.
  * Improved handling of refresh failures (distinguishes expired vs transient).

* **Refactor**
  * Standardized token expiration to Unix-time seconds across CLI and tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niftymonkey/brief/pull/102)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->